### PR TITLE
Adds admin dashboards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'administrate'
 gem 'devise'
 gem 'omniauth-mit-oauth2'
 gem 'omniauth-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,10 +40,23 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    administrate (0.8.1)
+      actionpack (>= 4.2, < 5.2)
+      actionview (>= 4.2, < 5.2)
+      activerecord (>= 4.2, < 5.2)
+      autoprefixer-rails (>= 6.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sass-rails (~> 5.0)
+      selectize-rails (~> 0.6)
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     arel (8.0.0)
+    autoprefixer-rails (7.1.2.3)
+      execjs
     bcrypt (3.1.11)
     bindex (0.5.0)
     builder (3.2.3)
@@ -64,6 +77,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.4)
       tins (~> 1.6)
+    datetime_picker_rails (0.0.7)
+      momentjs-rails (>= 2.8.1)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -80,8 +95,24 @@ GEM
       activesupport (>= 4.2.0)
     hashie (3.5.5)
     i18n (0.8.6)
+    jquery-rails (4.3.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.1.0)
     jwt (1.5.6)
+    kaminari (1.0.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
+      activerecord
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -97,6 +128,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.2.0)
     minitest (5.10.2)
+    momentjs-rails (2.17.1)
+      railties (>= 3.1)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -164,6 +197,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selectize-rails (0.12.4)
     selenium-webdriver (3.4.3)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -215,6 +249,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  administrate
   annotate
   byebug
   capybara

--- a/app/controllers/admin/advisors_controller.rb
+++ b/app/controllers/admin/advisors_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class AdvisorsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Advisor.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Advisor.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,23 @@
+# All Administrate controllers inherit from this `Admin::ApplicationController`,
+# making it the ideal place to put authentication logic or other
+# before_actions.
+#
+# If you want to add pagination or other controller-level concerns,
+# you're free to overwrite the RESTful controller actions.
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_user!
+    before_action :authenticate_admin
+
+    def authenticate_admin
+      return if current_user && current_user.admin?
+      redirect_to '/', alert: 'Not authorized.'
+    end
+
+    # Override this value to specify the number of elements to display at a time
+    # on index pages. Defaults to 20.
+    # def records_per_page
+    #   params[:per_page] || 20
+    # end
+  end
+end

--- a/app/controllers/admin/degrees_controller.rb
+++ b/app/controllers/admin/degrees_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class DegreesController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Degree.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Degree.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class DepartmentsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Department.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Department.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/rights_controller.rb
+++ b/app/controllers/admin/rights_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class RightsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Right.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Right.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/theses_controller.rb
+++ b/app/controllers/admin/theses_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class ThesesController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Thesis.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Thesis.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class UsersController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = User.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   User.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/advisor_dashboard.rb
+++ b/app/dashboards/advisor_dashboard.rb
@@ -1,0 +1,54 @@
+require "administrate/base_dashboard"
+
+class AdvisorDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :theses,
+    :name,
+  ].freeze
+
+  # Overwrite this method to customize how advisors are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(advisor)
+    advisor.name
+  end
+end

--- a/app/dashboards/degree_dashboard.rb
+++ b/app/dashboards/degree_dashboard.rb
@@ -1,0 +1,54 @@
+require "administrate/base_dashboard"
+
+class DegreeDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :theses,
+    :name,
+  ].freeze
+
+  # Overwrite this method to customize how degrees are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(degree)
+    degree.name
+  end
+end

--- a/app/dashboards/department_dashboard.rb
+++ b/app/dashboards/department_dashboard.rb
@@ -1,0 +1,54 @@
+require "administrate/base_dashboard"
+
+class DepartmentDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :theses,
+    :id,
+    :name,
+    :created_at,
+    :updated_at,
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :theses,
+    :name,
+  ].freeze
+
+  # Overwrite this method to customize how departments are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(department)
+    department.name
+  end
+end

--- a/app/dashboards/right_dashboard.rb
+++ b/app/dashboards/right_dashboard.rb
@@ -1,0 +1,51 @@
+require "administrate/base_dashboard"
+
+class RightDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    statement: Field::Text,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :theses,
+    :statement
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :id,
+    :statement,
+    :created_at,
+    :updated_at,
+    :theses
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :statement
+  ].freeze
+
+  # Overwrite this method to customize how rights are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(right)
+    right.statement
+  end
+end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -1,0 +1,72 @@
+require "administrate/base_dashboard"
+
+class ThesisDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    user: Field::BelongsTo,
+    right: Field::BelongsTo,
+    departments: Field::HasMany,
+    degrees: Field::HasMany,
+    advisors: Field::HasMany,
+    id: Field::Number,
+    title: Field::String,
+    abstract: Field::Text,
+    grad_date: Field::DateTime,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :title,
+    :user,
+    :right,
+    :grad_date
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :id,
+    :user,
+    :title,
+    :abstract,
+    :grad_date,
+    :right,
+    :created_at,
+    :updated_at,
+    :departments,
+    :degrees,
+    :advisors
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :user,
+    :right,
+    :departments,
+    :degrees,
+    :advisors,
+    :title,
+    :abstract,
+    :grad_date,
+  ].freeze
+
+  # Overwrite this method to customize how theses are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(thesis)
+    "Thesis: #{thesis.title}"
+  end
+end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,0 +1,59 @@
+require "administrate/base_dashboard"
+
+class UserDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    uid: Field::String,
+    email: Field::String,
+    admin: Field::Boolean,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :theses,
+    :id,
+    :uid,
+    :email
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :theses,
+    :id,
+    :uid,
+    :email,
+    :admin,
+    :created_at,
+    :updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [
+    :theses,
+    :email,
+    :admin
+  ].freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(user)
+    user.email
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,15 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :users
+    resources :advisors
+    resources :degrees
+    resources :departments
+    resources :rights
+    resources :theses
+
+    root to: "theses#index"
+  end
+
   devise_for :users, :controllers => {
     :omniauth_callbacks => 'users/omniauth_callbacks'
   }

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -23,3 +23,4 @@ yo:
 admin:
   uid: 'admin_id'
   email: 'admin@example.com'
+  admin: true

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class AuthenticationTest < ActionDispatch::IntegrationTest
+  test 'accessing admin panel unauthenticated redirects to root' do
+    get '/admin'
+    assert_response :redirect
+    follow_redirect!
+    assert_response :success
+    assert_equal('/', path)
+  end
+
+  test 'accessing admin panel without admin rights redirects to root' do
+    mock_auth(users(:yo))
+    get '/admin'
+    assert_response :redirect
+    follow_redirect!
+    assert_equal('/', path)
+  end
+
+  test 'accessing admin panel with admin rights works' do
+    mock_auth(users(:admin))
+    get '/admin'
+    assert_response :success
+    assert_equal('/admin', path)
+  end
+
+  test 'accessing theses panel' do
+    mock_auth(users(:admin))
+    get '/admin/theses'
+    assert_response :success
+    assert_equal('/admin/theses', path)
+  end
+
+  test 'accessing users panel' do
+    mock_auth(users(:admin))
+    get '/admin/users'
+    assert_response :success
+    assert_equal('/admin/users', path)
+  end
+
+  test 'accessing rights panel' do
+    mock_auth(users(:admin))
+    get '/admin/rights'
+    assert_response :success
+    assert_equal('/admin/rights', path)
+  end
+
+  test 'accessing departments panel' do
+    mock_auth(users(:admin))
+    get '/admin/departments'
+    assert_response :success
+    assert_equal('/admin/departments', path)
+  end
+
+  test 'accessing degrees panel' do
+    mock_auth(users(:admin))
+    get '/admin/degrees'
+    assert_response :success
+    assert_equal('/admin/degrees', path)
+  end
+
+  test 'accessing advisors panel' do
+    mock_auth(users(:admin))
+    get '/admin/advisors'
+    assert_response :success
+    assert_equal('/admin/advisors', path)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,12 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alpha order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    def mock_auth(user)
+      OmniAuth.config.mock_auth[:mit_oauth2] =
+        OmniAuth::AuthHash.new(provider: 'mit_oauth2',
+                               uid: user.uid,
+                               info: { email: user.email })
+      get '/users/auth/mit_oauth2/callback'
+    end
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

* adds admin dashboard via `administrate` gem
* only Users with `admin = true` can access the dashboards
* An admin ui at this early stage will let us confirm the data models
  are indeed what we intend them to be and move more rapidly to staff
  feedback (not yet though!).
* `administrate` seems flexible enough to use for semi-custom admin
  interfaces without the hassle of weird DSLs.
* Most of what we will need for admin UI works out of the box. At this
  time I believe adding the rest won't be awful. You can remind me when
  I am wrong.

#### Helpful background context (if appropriate)

These are not intended to be complete admin interfaces. Instead, these are proposed
starting points for our admin interfaces.

#### How can a reviewer manually see the effects of these changes?

Using credentials for MIT OpenID in your ENV (I know #9 is still open but for local dev you can use your own):

Confirm you have no admin rights:
```
heroku local:run rails console
u = User.find_by(email: 'youremail@mit.edu')
u.admin?
```

If you have admin, remove it for now.

```
u.admin = false
u.save
exit
```

If you have no account, no worries as one will be created with no admin rights in the next step if one doesn't exist.

```
heroku local
localhost:5000/users/auth/mit_oauth2
localhost:5000/admin
```

You should be on the "hi" page because we don't have flashes enabled or a template yet.

Back in the console, add your admin rights and then back on the site:
```
localhost:5000/admin
```

And you should have dashboard access and be able to CRUD all the models from the generated UI.

#### What are the relevant tickets?
- #14 
- #13 (it's not much yet, but it's there)

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES