### PR TITLE
23 desuckify security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development do
 end
 
 group :test do
+  gem 'climate_control'
   gem 'coveralls', require: false
   gem 'minitest-reporters'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
       xpath (~> 2.0)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    climate_control (0.2.0)
     concurrent-ruby (1.0.5)
     coveralls (0.8.21)
       json (>= 1.8, < 3)
@@ -276,6 +277,7 @@ DEPENDENCIES
   annotate
   byebug
   capybara
+  climate_control
   coveralls
   devise
   listen
@@ -300,4 +302,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -32,7 +32,24 @@ this automatically. It is often nice in development as well.
 
 ## Authentication for Development ONLY
 
-`FAKE_AUTH_ENABLED` - set to `true`. WARNING: DO NOT DO THIS IN PRODUCTION! BAD!
+There's a fake auth system you can use on review apps. It bypasses the actual auth system and just logs you in with a fake developer account.
+
+### To enable on review apps
+* Set `FAKE_AUTH_ENABLED` to `true`
+
+### To enable on localhost
+In `.env`:
+* Set `FAKE_AUTH_ENABLED=true`
+
+### To enable on staging or production
+Don't.
+
+Also, you shouldn't be able to. Even if you set `FAKE_AUTH_ENABLED`, the `HEROKU_APP_NAME` check will fail.
+
+### To use in the codebase
+Use `Rails.configuration.fake_auth_enabled`, NOT `ENV['FAKE_AUTH_ENABLED']`.
+
+Using the latter bypasses the app name check, which can let us inadvertently turn on fake auth in production. `nope`
 
 ## Authentication for production
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,53 @@
+{
+  "name": "thing",
+  "scripts": {},
+  "env": {
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "LANG": {
+      "required": true
+    },
+    "PAPERTRAIL_API_TOKEN": {
+      "required": true
+    },
+    "PRIVATE_KEY": {
+      "required": true
+    },
+    "RACK_ENV": {
+      "required": true
+    },
+    "RAILS_ENV": {
+      "required": true
+    },
+    "RAILS_LOG_TO_STDOUT": {
+      "required": true
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "required": true
+    },
+    "SECRET_KEY_BASE": {
+      "required": true
+    },
+    "SKYLIGHT_AUTHENTICATION": {
+      "required": true
+    },
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
+    }
+  },
+  "addons": [
+    "papertrail",
+    "heroku-postgresql"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -22,7 +22,9 @@ class ThesisController < ApplicationController
 
   def require_user
     return if current_user
-    if ENV['FAKE_AUTH_ENABLED'] == 'true'
+    # Do NOT use ENV['FAKE_AUTH_ENABLED'] directly! Use the config. It performs
+    # an additional check to make sure we are not on the production server.
+    if Rails.configuration.fake_auth_enabled
       redirect_to user_developer_omniauth_authorize_path
     else
       redirect_to user_saml_omniauth_authorize_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,9 +6,11 @@ module Users
       flash[:notice] = "Welcome #{@user.email}!"
     end
 
-    # Do _NOT_ set FAKE_AUTH_ENABLED in staging or production. Ever. Bad Idea.
+    # Make sure to use Rails.configuration.fake_auth_enabled and not
+    # ENV['FAKE_AUTH_ENABLED'] here. The config performs an additional check
+    # to make sure we're not on the production server.
     def developer
-      raise 'Invalid Authentication' unless ENV['FAKE_AUTH_ENABLED'] == 'true'
+      raise 'Invalid Authentication' unless Rails.configuration.fake_auth_enabled
       @user = User.from_omniauth(request.env['omniauth.auth'])
       @user.admin = true
       @user.uid = @user.email

--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -1,0 +1,26 @@
+module FakeAuthConfig
+  # Used in an initializer to determine if the application is configured and
+  # allowed to use fake authentication.
+  def fake_auth_status
+    return true if fake_auth_enabled? && app_name_pattern_match?
+    false
+  end
+
+  private
+
+  def fake_auth_enabled?
+    ENV['FAKE_AUTH_ENABLED'] == 'true'
+  end
+
+  # Checks to make sure the application is not the staging or production
+  # instance via a heroku ENV.
+  # In development env we always return `true` to avoid having to set a fake app
+  # name to match the pr build name patterns.
+  # In test env we require setting a fake app name to allow for testing of the
+  # pattern.
+  def app_name_pattern_match?
+    return true if Rails.env.development?
+    review_app_pattern = /^library-thesis-dropbox-staging-pr-[\d]+$/
+    review_app_pattern.match(ENV['HEROKU_APP_NAME']).present?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@
 #
 
 class User < ApplicationRecord
-  if ENV['FAKE_AUTH_ENABLED'] == 'true'
+  if Rails.configuration.fake_auth_enabled  # Use config, not ENV. See README.
     devise :omniauthable, omniauth_providers: [:developer]
   else
     devise :omniauthable, omniauth_providers: [:saml]

--- a/app/views/layouts/_site_header.html.erb
+++ b/app/views/layouts/_site_header.html.erb
@@ -27,7 +27,7 @@
             <%= link_to("Admin", admin_root_path) %>
           <% end %>
         <% else %>
-          <% if ENV['FAKE_AUTH_ENABLED'] == 'true' %>
+          <% if Rails.configuration.fake_auth_enabled %>
             <%= link_to("Sign in", user_developer_omniauth_authorize_path, id: "sign_in", class: 'action-auth') %>
           <% else %>
             <%= link_to("Sign in", user_saml_omniauth_authorize_path, id: "sign_in", class: 'action-auth') %>

--- a/config/initializers/0_fake_auth_configuration.rb
+++ b/config/initializers/0_fake_auth_configuration.rb
@@ -1,0 +1,5 @@
+# This configuration needs to load before the devise initializer so this value
+# is available when needed.
+
+include FakeAuthConfig
+Rails.application.config.fake_auth_enabled = FakeAuthConfig.fake_auth_status

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -32,7 +32,7 @@ Devise.setup do |config|
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
 
-  if ENV['FAKE_AUTH_ENABLED'] == 'true'
+  if Rails.configuration.fake_auth_enabled
     config.omniauth :developer
   else
     # Omniauth Config

--- a/test/models/fake_auth_test.rb
+++ b/test/models/fake_auth_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class FakeAuthTest < ActiveSupport::TestCase
+  include FakeAuthConfig
+
+  test 'fakeauth disabled' do
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'false',
+      HEROKU_APP_NAME: 'library-thesis-dropbox-staging-pr-123'
+    ) do
+      assert_equal(false, fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled pr pattern app name' do
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'true',
+      HEROKU_APP_NAME: 'library-thesis-dropbox-staging-pr-123'
+    ) do
+      assert_equal(true, fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled no heroku app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true' do
+      assert_equal(false, fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled production app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
+                          HEROKU_APP_NAME: 'library-thesis-dropbox' do
+      assert_equal(false, fake_auth_status)
+    end
+  end
+
+  test 'fakeauth enabled staging app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
+                          HEROKU_APP_NAME: 'library-thesis-dropbox-staging' do
+      assert_equal(false, fake_auth_status)
+    end
+  end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
We need to ensure that we don't accidentally enable fake auth in production. This checks on the Heroku app name as well as the `FAKE_AUTH_ENABLED` env variable.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-23

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES (for some reason dotenv wasn't already there)

  