### PR TITLE
Moves skip verify_authenticity_token to appropriate controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  skip_before_action :verify_authenticity_token
 
   def new_session_path(_scope)
     root_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+    skip_before_action :verify_authenticity_token
+
     def saml
       @user = User.from_omniauth(request.env['omniauth.auth'])
       sign_in_and_redirect @user, event: :authentication


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Moves skip verify_authenticity_token to appropriate controller rather than setting it globally. 

#### How can a reviewer manually see the effects of these changes?

It is fairly complicated, but if you setup a shib IdP on testshib.org you can remove this changed line to see it block the authentication process. The skip is therefore necessary, but having it globally makes other form submissions insecure which was clearly not the intent.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-33

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO