### PR TITLE
Front page is splash for anon users, thesis submission for logged-in

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,9 @@ Rails.application.routes.draw do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
 
+  authenticated do
+    root :to => 'thesis#new'
+  end
+
   root to: 'static#index'
 end

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -39,4 +39,10 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal(usercount + 1, User.count)
   end
+
+  test 'redirect to root path after login' do
+    mock_auth(users(:yo))
+    follow_redirect!
+    assert_equal '/', @request.path
+  end
 end

--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class RoutesTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'root path is splash controller for anonymous user' do
+    get root_path
+    assert @controller.instance_of? StaticController
+    assert_equal 'index', @controller.action_name
+  end
+
+  test 'root path is new thesis controller for logged-in user' do
+    mock_auth(users(:yo))
+    get root_path
+    assert @controller.instance_of? ThesisController
+    assert_equal 'new', @controller.action_name
+  end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Root path is a splash page to anonymous users (pending TI-25), thesis submission page for logged-in users.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Fire up the app. Lo, it is the splash page. Log in. Lo, it is now the thesis submission form.

This was originally intended as just TI-24, but adding the test for redirect-after-login behavior turned out to be logically entailed by that work, so this will also close TI-26.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-26
- https://mitlibraries.atlassian.net/browse/TI-24

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
