### PR TITLE
37 thesis statuses

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,5 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require_tree .

--- a/app/assets/javascripts/mark_downloaded.js
+++ b/app/assets/javascripts/mark_downloaded.js
@@ -1,0 +1,27 @@
+function markDownloaded() {
+  function alertFail(target) {
+    target.append("<div class='alert alert-banner error'>We're sorry; this thesis could not be marked as downloaded.</div>");
+  }
+
+  $(document).ready(function() {
+    $("form").on("ajax:success", function (event) {
+      // Find actionable data.
+      var saved = event.detail[0].saved;
+      var thesis_id = event.detail[0].id.toString();
+      var target = $("div[data-id=thesis_" + thesis_id + "]");
+
+      // Communicate status to users.
+      if ( saved ) {
+        target.attr('class', 'panel panel-success');
+        target.find('form').replaceWith("<div>&#10004; Marked as downloaded</div>");
+        target.find('span.text-info').attr('class', 'text-success').text('downloaded');
+      } else {
+        alertFail(target.children('.panel-body'));
+      }
+
+    }).on("ajax:error", function (data) {
+      var target = $("form input:focus").parents('div.panel-body');
+      alertFail(target);
+    });
+  });
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 
 @import "_variables.scss";
 @import "libraries-global.scss";
+@import "thing.scss";

--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -1,0 +1,20 @@
+.text-info {
+  color: $informational;
+}
+.text-success {
+  color: $success;
+}
+.text-warning {
+  color: $warning;
+}
+.text-danger {
+  color: $error;
+}
+
+.button_to {
+  @extend .field-wrap;
+
+  input {
+    @extend .button-secondary;
+  }
+}

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -29,6 +29,27 @@ class ThesisController < ApplicationController
     @theses = Thesis.order('grad_date ASC').page(params[:page]).per(25)
   end
 
+  def mark_downloaded
+    @thesis = Thesis.find(params[:id])
+    if not @thesis.status == 'active'
+      raise ActionController::BadRequest.new
+    end
+
+    @thesis.status = 'downloaded'
+
+    respond_to do |format|
+      if @thesis.save
+        format.js
+        format.html { redirect_to process_path }
+        render json: { id: params[:id], saved: true }
+      else
+        format.js
+        format.html { redirect_to process_path }
+        render json: { id: params[:id], saved: false }
+      end
+    end
+  end
+
   private
 
   def require_user

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -18,7 +18,10 @@ class ThesisDashboard < Administrate::BaseDashboard
     abstract: Field::Text,
     grad_date: Field::DateTime,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    status: Field::Select.with_options(
+      collection: Thesis::STATUS_OPTIONS,
+    ),
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -47,6 +50,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     departments
     degrees
     advisors
+    status
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -61,6 +65,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     title
     abstract
     grad_date
+    status
   ].freeze
 
   # Overwrite this method to customize how theses are displayed

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -19,6 +19,8 @@ class Ability
       end
 
       # Define :process role here
+      # They should be able to view submissions and mark theses as done
+      # Should they be able to mark theses as withdrawn, or is that admin only?
     end
   end
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -10,6 +10,7 @@
 #  updated_at :datetime         not null
 #  user_id    :integer
 #  right_id   :integer
+#  status     :string           default("active")
 #
 
 class Thesis < ApplicationRecord
@@ -31,6 +32,9 @@ class Thesis < ApplicationRecord
 
   validates :departments, presence: true
   validates :degrees, presence: true
+
+  STATUS_OPTIONS = ['active', 'withdrawn', 'downloaded']
+  validates_inclusion_of :status, :in => STATUS_OPTIONS
 
   # temporarily disabling advisor validation to allow web form work to
   # proceed with the simpler elements before tackling this more complex
@@ -62,5 +66,15 @@ class Thesis < ApplicationRecord
   def split_graduation_date
     self.graduation_year = grad_date.strftime('%Y')
     self.graduation_month = grad_date.strftime('%B')
+  end
+
+  def css_alert_type
+    if self.status == 'active'
+      'info'
+    elsif self.status == 'withdrawn'
+      'danger'
+    elsif self.status == 'downloaded'
+      'success'
+    end
   end
 end

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -1,7 +1,7 @@
 <h3>Thesis Submissions Queue</h3>
 
 <% @theses.each do |thesis| %>
-  <div class="panel panel-info"> <%# color-code by status? %>
+  <div class="panel panel-<%= thesis.css_alert_type %>" data-id="thesis_<%= thesis.id %>">
     <div class="panel-heading">
       <div class="layout-3q1q layout-band">
         <div class="col3q">
@@ -13,14 +13,27 @@
       </div>
     </div>
     <div class="panel-body">
-      <%= 'Department'.pluralize(thesis.departments.count) %>:
-        <%= thesis.departments.map{|d| d.name}.join(",") %><br />
-      <%= 'Degree'.pluralize(thesis.degrees.count) %>:
-        <%= thesis.degrees.map{|d| d.name}.join(",") %><br />
+      <div class="layout-3q1q layout-band">
+        <div class="col3q">
+          <%= "Department".pluralize(thesis.departments.count) %>:
+            <%= thesis.departments.map{|d| d.name}.join(",") %><br />
+          <%= "Degree".pluralize(thesis.degrees.count) %>:
+            <%= thesis.degrees.map{|d| d.name}.join(",") %><br />
+          </div>
+          <div class="col1q">
+            <% if thesis.status == "active" %>
+              <%= button_to "Mark as downloaded",
+                  { action: "mark_downloaded", id: thesis.id },
+                  remote: true %>
+            <% end %>
+          </div>
+        </div>
     </div>
     <div class="panel-footer">
-      <%= link_to 'View details', thesis_path(thesis.id) %>
+      <%= link_to "View details", thesis_path(thesis.id) %>
       --
+      Status: <span class="text-<%= thesis.css_alert_type %>">
+        <%= thesis.status %></span>
       <%# Other stuff should go here when e.g. people can mark as done or
           a download link exists. %>
     </div>
@@ -28,3 +41,5 @@
 <% end %>
 
 <%= paginate @theses %>
+
+<script>markDownloaded();</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
 
   resources :thesis, only: [:new, :create, :show]
   get 'process', to: 'thesis#process_theses'
+  post 'done/:id', to: 'thesis#mark_downloaded',
+                   id: /[0-9]+/,
+                   as: 'mark_downloaded'
 
   devise_for :users, :controllers => {
     :omniauth_callbacks => 'users/omniauth_callbacks'

--- a/db/migrate/20180124144953_add_status_to_theses.rb
+++ b/db/migrate/20180124144953_add_status_to_theses.rb
@@ -1,0 +1,5 @@
+class AddStatusToTheses < ActiveRecord::Migration[5.1]
+  def change
+    add_column :theses, :status, :string, default: 'active'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713123901) do
+ActiveRecord::Schema.define(version: 20180124144953) do
 
   create_table "advisors", force: :cascade do |t|
     t.string "name", null: false
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20170713123901) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.integer "right_id"
+    t.string "status", default: "active"
     t.index ["right_id"], name: "index_theses_on_right_id"
     t.index ["user_id"], name: "index_theses_on_user_id"
   end

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -10,6 +10,7 @@
 #  updated_at :datetime         not null
 #  user_id    :integer
 #  right_id   :integer
+#  status     :string           default("active")
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -33,3 +34,36 @@ two:
   departments: [one]
   degrees: [one]
   advisors: [one]
+
+downloaded:
+  title: MyString
+  abstract: MyText
+  grad_date: 2017-07-13
+  user: yo
+  right: one
+  departments: [one]
+  degrees: [one]
+  advisors: [one]
+  status: 'downloaded'
+
+withdrawn:
+  title: MyString
+  abstract: MyText
+  grad_date: 2017-07-13
+  user: yo
+  right: one
+  departments: [one]
+  degrees: [one]
+  advisors: [one]
+  status: 'withdrawn'
+
+active:
+  title: MyString
+  abstract: MyText
+  grad_date: 2017-07-13
+  user: yo
+  right: one
+  departments: [one]
+  degrees: [one]
+  advisors: [one]
+  status: 'active'  # The default, but specified for testing purposes.

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -10,6 +10,7 @@
 #  updated_at :datetime         not null
 #  user_id    :integer
 #  right_id   :integer
+#  status     :string           default("active")
 #
 
 require 'test_helper'
@@ -97,5 +98,33 @@ class ThesisTest < ActiveSupport::TestCase
     thesis = theses(:one)
     thesis.advisors = [advisors(:one), advisors(:two)]
     assert(thesis.valid?)
+  end
+
+  test 'can have active status' do
+    thesis = theses(:one)
+    thesis.status = 'active'
+    thesis.save
+    assert(thesis.valid?)
+  end
+
+  test 'can have withdrawn status' do
+    thesis = theses(:one)
+    thesis.status = 'withdrawn'
+    thesis.save
+    assert(thesis.valid?)
+  end
+
+  test 'can have downloaded status' do
+    thesis = theses(:one)
+    thesis.status = 'downloaded'
+    thesis.save
+    assert(thesis.valid?)
+  end
+
+  test 'cannot have other statuses' do
+    thesis = theses(:one)
+    thesis.status = 'nobel prize-winning'
+    thesis.save
+    assert_not(thesis.valid?)
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Adds processing statuses to theses.  Indicates processing status on submissions queue page. Lets users mark theses as downloaded.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Go to `/process` on the PR build. There are 'mark downloaded' buttons on active theses (but only on active theses). Click them. Fun!

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-37

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
YES

#### Includes new or updated dependencies?
NO
