### PR TITLE
41 additional roles

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -9,8 +9,21 @@ module Admin
     before_action :authenticate_user!
     before_action :authenticate_admin
 
+    # People with sysadmin privileges can do anything here. People with thesis
+    # admin privileges can create and edit but not destroy theses.
     def authenticate_admin
-      return if current_user && current_user.admin?
+      admin_actions = %w[show update index create]
+      if current_user
+        if [
+            can?(:administrate, Admin) &&
+              admin_actions.include?(params[:action]),
+            current_user.role == 'sysadmin',
+            current_user.admin?
+          ].any?
+
+          return
+        end
+      end
       redirect_to '/', alert: 'Not authorized.'
     end
 

--- a/app/dashboards/department_dashboard.rb
+++ b/app/dashboards/department_dashboard.rb
@@ -21,9 +21,9 @@ class DepartmentDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
+    name
     theses
     id
-    name
     created_at
   ].freeze
 

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -7,6 +7,10 @@ class ThesisDashboard < Administrate::BaseDashboard
   # Each different type represents an Administrate::Field object,
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
+  #
+  # The dashboard must know about grad_date, since it is a column on the model
+  # schema, but also about graduation_year and graduation_month, since Thesis
+  # performs before_create validation on these objects.
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
     right: Field::BelongsTo,
@@ -17,6 +21,8 @@ class ThesisDashboard < Administrate::BaseDashboard
     title: Field::String,
     abstract: Field::Text,
     grad_date: Field::DateTime,
+    graduation_month: Field::Number,
+    graduation_year: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     status: Field::Select.with_options(
@@ -56,6 +62,9 @@ class ThesisDashboard < Administrate::BaseDashboard
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
+  #
+  # Make sure you display graduation_year and graduation_month on the form or
+  # you will be unable to create Theses!
   FORM_ATTRIBUTES = %i[
     user
     right
@@ -64,8 +73,9 @@ class ThesisDashboard < Administrate::BaseDashboard
     advisors
     title
     abstract
-    grad_date
     status
+    graduation_year
+    graduation_month
   ].freeze
 
   # Overwrite this method to customize how theses are displayed

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,20 +7,47 @@ class Ability
     # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 
     if user.present?
-      # Any user can create a new Thesis
-      can :create, Thesis
-
-      # Only the Thesis owner can view their Thesis
-      can :read, Thesis, user_id: user.id
-
+      @user = user
       # Admin users can do everything for all models
       if user.admin?
         can :manage, :all
       end
 
-      # Define :process role here
-      # They should be able to view submissions and mark theses as done
-      # Should they be able to mark theses as withdrawn, or is that admin only?
+      # This line matches users' roles with the functions defined below,
+      # giving them privileges accordingly.
+      send(@user.role.to_sym)
     end
+  end
+
+  # The default; any logged-in user. The use case here is students uploading
+  # their theses.
+  def basic
+    # Any user can create a new Thesis.
+    can :create, Thesis
+
+    # Only the Thesis owner can view their Thesis.
+    can :read, Thesis, user_id: @user.id
+  end
+
+  # Library staff who process the thesis queue. They should be able to use the
+  # submissions processing queue page and whatever functionality it exposes,
+  # but not the admin dashboards.
+  def processor
+    basic
+    can :mark_downloaded, Thesis
+    can :process_theses, Thesis
+  end
+
+  # Library staff who can use the admin dashboards (which includes operations
+  # on departments and advisors), but who don't have system administration
+  # powers.
+  def thesis_admin
+    processor
+    can [:create, :update], Thesis
+    can :administrate, Admin
+  end
+
+  def sysadmin
+    can :manage, :all
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@
 #  admin      :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  role       :string           default("basic")
 #
 
 class User < ApplicationRecord
@@ -20,6 +21,9 @@ class User < ApplicationRecord
   validates :uid, presence: true
   validates :email, presence: true
   has_many :theses
+
+  ROLES = %w[basic processor thesis_admin sysadmin]
+  validates_inclusion_of :role, :in => ROLES
 
   # `uid` is a unique ID that comes back from OmniAuth (which gets it from
   # the remote authentication provider). It is used to lookup or create a new

--- a/db/migrate/20180125202718_add_role_to_users.rb
+++ b/db/migrate/20180125202718_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :role, :string, default: 'basic'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180124144953) do
+ActiveRecord::Schema.define(version: 20180125202718) do
 
   create_table "advisors", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20180124144953) do
     t.boolean "admin", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role", default: "basic"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["uid"], name: "index_users_on_uid", unique: true
   end

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -147,12 +147,35 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
-  test 'non-admin users cannot see submissions processing page' do
-    sign_in users(:yo)
-    assert_not users(:yo).admin?
+  test 'basic users cannot see submissions processing page' do
+    sign_in users(:basic)
     assert_raises(CanCan::AccessDenied) do
       get '/process'
     end
+  end
+
+  test 'processor users can see submissions processing page' do
+    sign_in users(:processor)
+    get '/process'
+    assert_response :success
+  end
+
+  test 'thesis admin users can see submissions processing page' do
+    sign_in users(:thesis_admin)
+    get '/process'
+    assert_response :success
+  end
+
+  test 'sysadmin users can see submissions processing page' do
+    sign_in users(:sysadmin)
+    get '/process'
+    assert_response :success
+  end
+
+  test 'admin users can see submissions processing page' do
+    sign_in users(:admin)
+    get '/process'
+    assert_response :success
   end
 
   test 'submissions include submitter email' do

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -8,6 +8,7 @@
 #  admin      :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  role       :string           default("basic")
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -28,3 +29,23 @@ admin:
 bad:
   uid: 'bad_id'
   email: 'bad@example.com'
+
+basic:
+  uid: 'basic_id'
+  email: 'basic@example.com'
+  role: 'basic'
+
+processor:
+  uid: 'processor_id'
+  email: 'processor@example.com'
+  role: 'processor'
+
+thesis_admin:
+  uid: 'thesis_admin_id'
+  email: 'thesis_admin@example.com'
+  role: 'thesis_admin'
+
+sysadmin:
+  uid: 'sysadmin_id'
+  email: 'sysadmin@example.com'
+  role: 'sysadmin'

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -17,12 +17,34 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_equal('/', path)
   end
 
-  test 'accessing admin panel without admin rights redirects to root' do
-    mock_auth(users(:yo))
+  test 'accessing admin panel as a basic user redirects to root' do
+    mock_auth(users(:basic))
     get '/admin'
     assert_response :redirect
     follow_redirect!
     assert_equal('/', path)
+  end
+
+  test 'accessing admin panel as a processor user redirects to root' do
+    mock_auth(users(:processor))
+    get '/admin'
+    assert_response :redirect
+    follow_redirect!
+    assert_equal('/', path)
+  end
+
+  test 'accessing admin panel as a thesis admin works' do
+    mock_auth(users(:thesis_admin))
+    get '/admin'
+    assert_response :success
+    assert_equal('/admin', path)
+  end
+
+  test 'accessing admin panel as a sysadmin works' do
+    mock_auth(users(:sysadmin))
+    get '/admin'
+    assert_response :success
+    assert_equal('/admin', path)
   end
 
   test 'accessing admin panel with admin rights works' do
@@ -32,45 +54,301 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_equal('/admin', path)
   end
 
-  test 'accessing theses panel' do
+  test 'accessing theses panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/theses'
     assert_response :success
     assert_equal('/admin/theses', path)
   end
 
-  test 'accessing users panel' do
+  test 'accessing theses panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/theses'
+    assert_response :success
+    assert_equal('/admin/theses', path)
+  end
+
+  test 'accessing theses panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/theses'
+    assert_response :success
+    assert_equal('/admin/theses', path)
+  end
+
+  test 'accessing theses panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/theses'
+    assert_response :redirect
+  end
+
+  test 'accessing theses panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/theses'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can update theses through admin panel' do
+    mock_auth(users(:thesis_admin))
+
+    thesis = Thesis.first
+    new_title = 'yoyos are cool'
+    assert_not_equal thesis.title, new_title
+
+    patch admin_thesis_path(thesis),
+      params: { thesis: { title: new_title } }
+
+    thesis.reload
+    assert_response :redirect
+    assert_equal path, admin_thesis_path(thesis)
+    assert_equal new_title, thesis.title
+  end
+
+  test 'thesis admins can create theses through admin panel' do
+    mock_auth(users(:thesis_admin))
+
+    orig_count = Thesis.count
+
+    # Important! Enter the grad month and year, not the grad date. The Thesis
+    # model does some before-creation logic to combine the month and year into
+    # the grad_date attribute on the model instance.
+    post admin_theses_path,
+      params: { thesis: { user_id: User.first.id,
+                          right_id: Right.first.id,
+                          department_ids: [ Department.first.id ],
+                          degree_ids: [ Degree.first.id ],
+                          advisor_ids: [ Advisor.first.id ],
+                          title: 'yoyos are cool',
+                          abstract: 'We discovered it with science',
+                          graduation_month: 'May',
+                          graduation_year: Date.today.year } }
+
+    assert_equal orig_count + 1, Thesis.count
+    assert_equal 'yoyos are cool', Thesis.last.title
+    assert_equal 'We discovered it with science', Thesis.last.abstract
+  end
+
+  test 'thesis admins cannot destroy theses through admin panel' do
+    mock_auth(users(:thesis_admin))
+
+    thesis = Thesis.first
+    # Cache this, because the thesis will stop existing if the delete goes
+    # through.
+    thesis_id = thesis.id
+
+    delete admin_thesis_path(thesis)
+    assert Thesis.exists?(thesis_id)
+  end
+
+  test 'sysadmins can destroy theses through admin panel' do
+    mock_auth(users(:sysadmin))
+
+    thesis = Thesis.first
+    # Cache this, because the thesis will stop existing if the delete goes
+    # through.
+    thesis_id = thesis.id
+
+    delete admin_thesis_path(thesis)
+    assert !Thesis.exists?(thesis_id)
+  end
+
+  test 'accessing users panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/users'
     assert_response :success
     assert_equal('/admin/users', path)
   end
 
-  test 'accessing rights panel' do
+  test 'accessing users panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/users'
+    assert_response :success
+    assert_equal('/admin/users', path)
+  end
+
+  test 'accessing users panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/users'
+    assert_response :success
+    assert_equal('/admin/users', path)
+  end
+
+  test 'accessing users panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/users'
+    assert_response :redirect
+  end
+
+  test 'accessing users panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/users'
+    assert_response :redirect
+  end
+
+  test 'accessing rights panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/rights'
     assert_response :success
     assert_equal('/admin/rights', path)
   end
 
-  test 'accessing departments panel' do
+  test 'accessing rights panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/rights'
+    assert_response :success
+    assert_equal('/admin/rights', path)
+  end
+
+  test 'accessing rights panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/rights'
+    assert_response :success
+    assert_equal('/admin/rights', path)
+  end
+
+  test 'accessing rights panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/rights'
+    assert_response :redirect
+  end
+
+  test 'accessing rights panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/rights'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can edit rights through admin dashboard' do
+    mock_auth(users(:thesis_admin))
+    right = Right.first
+    patch admin_right_path(right),
+      params: { right: { statement: 'GPL 4.0' } }
+    right.reload
+    assert_equal 'GPL 4.0', right.statement
+  end
+
+  test 'accessing departments panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/departments'
     assert_response :success
     assert_equal('/admin/departments', path)
   end
 
-  test 'accessing degrees panel' do
+  test 'accessing departments panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/departments'
+    assert_response :success
+    assert_equal('/admin/departments', path)
+  end
+
+  test 'accessing departments panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/departments'
+    assert_response :success
+    assert_equal('/admin/departments', path)
+  end
+
+  test 'accessing departments panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/departments'
+    assert_response :redirect
+  end
+
+  test 'accessing departments panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/departments'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can edit departments through admin dashboard' do
+    mock_auth(users(:thesis_admin))
+    department = Department.first
+    patch admin_department_path(department),
+      params: { department: { name: 'Course LII' } }
+    department.reload
+    assert_equal 'Course LII', department.name
+  end
+
+  test 'accessing degrees panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/degrees'
     assert_response :success
     assert_equal('/admin/degrees', path)
   end
 
-  test 'accessing advisors panel' do
+  test 'accessing degrees panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/degrees'
+    assert_response :success
+    assert_equal('/admin/degrees', path)
+  end
+
+  test 'accessing degrees panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/degrees'
+    assert_response :success
+    assert_equal('/admin/degrees', path)
+  end
+
+  test 'accessing degrees panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/degrees'
+    assert_response :redirect
+  end
+
+  test 'accessing degrees panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/degrees'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can edit degrees through admin dashboard' do
+    mock_auth(users(:thesis_admin))
+    degree = Degree.first
+    patch admin_degree_path(degree),
+      params: { degree: { name: 'Master of Fine Arts' } }
+    degree.reload
+    assert_equal 'Master of Fine Arts', degree.name
+  end
+
+  test 'accessing advisors panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/advisors'
     assert_response :success
     assert_equal('/admin/advisors', path)
+  end
+
+  test 'accessing advisors panel works with sysadmin rights' do
+    mock_auth(users(:sysadmin))
+    get '/admin/advisors'
+    assert_response :success
+    assert_equal('/admin/advisors', path)
+  end
+
+  test 'accessing advisors panel works with thesis_admin rights' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/advisors'
+    assert_response :success
+    assert_equal('/admin/advisors', path)
+  end
+
+  test 'accessing advisors panel does not work with processor rights' do
+    mock_auth(users(:processor))
+    get '/admin/advisors'
+    assert_response :redirect
+  end
+
+  test 'accessing advisors panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/advisors'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can edit advisors through admin dashboard' do
+    mock_auth(users(:thesis_admin))
+    advisor = Advisor.first
+    patch admin_advisor_path(advisor),
+      params: { advisor: { name: 'Fabio Zoltán de Academe' } }
+    advisor.reload
+    assert_equal 'Fabio Zoltán de Academe', advisor.name
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,6 +8,7 @@
 #  admin      :boolean          default(FALSE)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  role       :string           default("basic")
 #
 
 require 'test_helper'


### PR DESCRIPTION
## Status
**READY**

This is pending review/merge of #41 - I want to make sure there isn't a conflict between the database migrations.

#### What does this PR do?
Adds roles (processor, thesis administrator, sysadmin) per stakeholder discussion. 

#### Helpful background context (if appropriate)
Library staff who are processing the thesis queue should be able to download theses and mark them as downloaded, but not to access the admin panel. Thesis administrators should be able to edit theses (including marking them as withdrawn) but not delete them.

#### How can a reviewer manually see the effects of these changes?
Honestly I'm not sure how to do that - in theory you can create different accounts with fakeauth and assign them different roles and log in and see what happens, but in practice I can't log in with the same fakeauth account more than once (because it tries to create the user and fails due to nonuniqueness). I guess if you fix the fakeauth bug you could try that?

You can also read through the admin_dashboards test and see if you feel reassured.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-41

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
YES
#### Includes new or updated dependencies?
NO
