### PR TITLE
Let users filter thesis processing page by status

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -26,7 +26,20 @@ class ThesisController < ApplicationController
   # Do not name this simply 'process' or you will shadow a built-in controller
   # function and then you will be sad.
   def process_theses
-    @theses = Thesis.order('grad_date ASC').page(params[:page]).per(25)
+    status = params[:status]
+
+    if status.present?
+      # We could also test that Thesis::STATUS_OPTIONS.include? status,
+      # but we aren't, because:
+      # 1) if some URL hacker enters status=purple, they'll get 200 OK, not
+      #    500;
+      # 2) also they deserve the blank page they get.
+      queryset = Thesis.where(status: status)
+    else
+      queryset = Thesis.all
+    end
+
+    @theses = queryset.order('grad_date ASC').page(params[:page]).per(25)
   end
 
   def mark_downloaded

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -1,5 +1,13 @@
 <h3>Thesis Submissions Queue</h3>
 
+<div class="wrap-filters">
+  View:
+  <%= link_to "All", process_path, { class: 'btn button-small button-secondary'} %>
+  <%= link_to "Active", process_path(status: 'active'), { class: 'btn button-small button-secondary'} %>
+  <%= link_to "Downloaded", process_path(status: 'downloaded'), { class: 'btn button-small button-secondary'} %>
+  <%= link_to "Withdrawn", process_path(status: 'withdrawn'), { class: 'btn button-small button-secondary'} %>
+</div>
+
 <% @theses.each do |thesis| %>
   <div class="panel panel-<%= thesis.css_alert_type %>" data-id="thesis_<%= thesis.id %>">
     <div class="panel-heading">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :thesis, only: [:new, :create, :show]
   get 'process', to: 'thesis#process_theses'
+  get 'process/:status', to: 'thesis#process_theses'
   post 'done/:id', to: 'thesis#mark_downloaded',
                    id: /[0-9]+/,
                    as: 'mark_downloaded'


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Adds filter-by-status options to the thesis processing queue; tests them.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Go to `/process` on the PR build. Observe the view-by buttons. Click them.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-38

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
