### PR TITLE
46 set user roles

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -14,7 +14,10 @@ class UserDashboard < Administrate::BaseDashboard
     email: Field::String,
     admin: Field::Boolean,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime
+    updated_at: Field::DateTime,
+    role: Field::Select.with_options(
+      collection: User::ROLES
+    )
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -23,10 +26,10 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    theses
     id
-    uid
     email
+    role
+    theses
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -48,6 +51,7 @@ class UserDashboard < Administrate::BaseDashboard
     theses
     email
     admin
+    role
   ].freeze
 
   # Overwrite this method to customize how users are displayed

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -183,6 +183,15 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test 'sysadmins can edit roles through user dashboard' do
+    mock_auth(users(:sysadmin))
+    user = users(:processor)
+    patch admin_user_path(user),
+      params: { user: { role: 'thesis_admin' } }
+    user.reload
+    assert_equal 'thesis_admin', user.role
+  end
+
   test 'accessing rights panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/rights'


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Allows user roles to be set through the admin dashboard.

This is permissible to all thesis admins, since the prior description of thesis admins is that they should be able to use the admin dashboards. However, I wonder if it would be appropriate to restrict this to sysadmins only? You're the one who's had the direct stakeholder conversations - tell me what you think.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Go to /admin on PR build, look at a user, yay there is a dropdown for editing their roles

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-46

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
