### PR TITLE
Remove minitest reporters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,5 +42,4 @@ end
 group :test do
   gem 'climate_control'
   gem 'coveralls', require: false
-  gem 'minitest-reporters'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,6 @@ GEM
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
-    ansi (1.5.0)
     arel (8.0.0)
     ast (2.4.0)
     autoprefixer-rails (8.0.0)
@@ -135,11 +134,6 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    minitest-reporters (1.1.19)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     momentjs-rails (2.17.1)
       railties (>= 3.1)
     multi_json (1.13.1)
@@ -286,7 +280,6 @@ DEPENDENCIES
   kaminari
   listen
   lograge
-  minitest-reporters
   omniauth-saml
   pg (= 0.21)
   puma

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,6 @@ SimpleCov.start('rails')
 
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'minitest/reporters'
-
-Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

There seems to be an ongoing debate between the reporters, rails and
minitest to determine who is at fault for things being messed up. I’m
just removing reporters for now and using the default reporter. We can
revisit this in the future if anyone really cares.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES (sort of... just a removal of one but you do need to bundle)