### PR TITLE
Seeds prs and rake without env

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,8 @@
 {
   "name": "thing",
-  "scripts": {},
+  "scripts": {
+    "postdeploy": "bundle exec rails db:seed"
+  },
   "env": {
     "AWS_ACCESS_KEY_ID": {
       "required": true

--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -9,7 +9,14 @@ module FakeAuthConfig
   private
 
   def fake_auth_enabled?
-    ENV['FAKE_AUTH_ENABLED'] == 'true'
+    # Default to fake auth in development unless FAKE_AUTH_ENABLED=false
+    # This allows rake tasks to run without loading ENV.
+    # This line is not testable because it checks for dev env explicitly.
+    if Rails.env.development? && ENV['FAKE_AUTH_ENABLED'].nil?
+      true
+    else
+      ENV['FAKE_AUTH_ENABLED'] == 'true'
+    end
   end
 
   # Checks to make sure the application is not the staging or production

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,19 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+Rails.logger.info('Seeding DB Starting')
+
+# Create Departments
+Department.find_or_create_by(name: 'Aeronautics and Astronautics')
+Department.find_or_create_by(name: 'Archaeology and Materials')
+
+# Create Rights
+Right.find_or_create_by(statement: 'MIT')
+Right.find_or_create_by(statement: 'Author Retains')
+Right.find_or_create_by(statement: 'Other')
+
+# Create Degrees
+Degree.find_or_create_by(name: 'Bachelor of Science')
+Degree.find_or_create_by(name: 'Master of Business Analytics')
+
+Rails.logger.info('Seeding DB Complete')


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

1) Allow rake tasks to run without loading ENV 

Because of our fake auth detection in the Devise initializer, it was
not possible to run things such as `rake db:migrate` without prefixing
with `heroku local:run` which would load the ENV. This fixes that by
assuming fake auth in development unless it is explicitly set to false.

https://mitlibraries.atlassian.net/browse/TI-44

2) Seeds DB only in PR builds

Staging and Production will not run this automatically but PR builds
should.

https://mitlibraries.atlassian.net/browse/TI-45

https://devcenter.heroku.com/articles/github-integration-review-apps#the
-postdeploy-script

#### How to check this

- On heroku PR build... sign in and marvel at the populated degrees, departments and rights.
- locally, run `bin/rails db:seed` without the `heroku local:run` prefix and it should run the seed (or anything else you want to run but that's kinda part of this pr so why not.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO