### PR TITLE
Remove files uploaded in integration tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,5 +40,14 @@ end
 module ActionDispatch
   class IntegrationTest
     include Devise::Test::IntegrationHelpers
+
+    def remove_uploaded_files
+      FileUtils.rm_rf(Rails.root.join('tmp', 'storage'))
+    end
+
+    def after_teardown
+      super
+      remove_uploaded_files
+    end
   end
 end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Deletes files that were uploaded in integration tests.

#### How can a reviewer manually see the effects of these changes?

Locally, check railsroot/tmp/storage before running tests. If you have run tests on a previous branch after we implemented file upload testing you should see a bunch of files.

After running this branch, you should not see anything there. Yay.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-54

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO