### PR TITLE
Highlight currently active button on processing queue page

### DIFF
--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -1,0 +1,11 @@
+module ThesisHelper
+  def highlight_class(status)
+    if params[:status].nil? && status == 'active'
+      'button-primary'
+    elsif params[:status] == status
+      'button-primary'
+    else
+      'button-secondary'
+    end
+  end
+end

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -2,10 +2,10 @@
 
 <div class="wrap-filters">
   View:
-  <%= link_to "Active", process_path(status: 'active'), { class: 'btn button-small button-secondary'} %>
-  <%= link_to "Downloaded", process_path(status: 'downloaded'), { class: 'btn button-small button-secondary'} %>
-  <%= link_to "Withdrawn", process_path(status: 'withdrawn'), { class: 'btn button-small button-secondary'} %>
-  <%= link_to "All", process_path(status: 'any'), { class: 'btn button-small button-secondary'} %>
+  <%= link_to "Active", process_path(status: 'active'), { class: "btn button-small #{highlight_class('active')}"} %>
+  <%= link_to "Downloaded", process_path(status: 'downloaded'), { class: "btn button-small #{highlight_class('downloaded')}"} %>
+  <%= link_to "Withdrawn", process_path(status: 'withdrawn'), { class: "btn button-small #{highlight_class('withdrawn')}"} %>
+  <%= link_to "All", process_path(status: 'any'), { class: "btn button-small #{highlight_class('any')}"} %>
 </div>
 
 <% @theses.each do |thesis| %>

--- a/test/helpers/test_helper.rb
+++ b/test/helpers/test_helper.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+include ThesisHelper
+
+class ThesisHelperTest < ActionView::TestCase
+  test 'highlight class if no status' do
+    params[:status] = nil
+
+    assert_equal 'button-primary', highlight_class('active')
+    assert_equal 'button-secondary', highlight_class('downloaded')
+    assert_equal 'button-secondary', highlight_class('withdrawn')
+    assert_equal 'button-secondary', highlight_class('any')
+  end
+
+  test 'highlight class when status is active' do
+    params[:status] = 'active'
+
+    assert_equal 'button-primary', highlight_class('active')
+    assert_equal 'button-secondary', highlight_class('downloaded')
+    assert_equal 'button-secondary', highlight_class('withdrawn')
+    assert_equal 'button-secondary', highlight_class('any')
+  end
+
+  test 'highlight class when status is downloaded' do
+    params[:status] = 'downloaded'
+
+    assert_equal 'button-secondary', highlight_class('active')
+    assert_equal 'button-primary', highlight_class('downloaded')
+    assert_equal 'button-secondary', highlight_class('withdrawn')
+    assert_equal 'button-secondary', highlight_class('any')
+  end
+
+  test 'highlight class when status is withdrawn' do
+    params[:status] = 'withdrawn'
+
+    assert_equal 'button-secondary', highlight_class('active')
+    assert_equal 'button-secondary', highlight_class('downloaded')
+    assert_equal 'button-primary', highlight_class('withdrawn')
+    assert_equal 'button-secondary', highlight_class('any')
+  end
+
+  test 'highlight class when status is any' do
+    params[:status] = 'any'
+
+    assert_equal 'button-secondary', highlight_class('active')
+    assert_equal 'button-secondary', highlight_class('downloaded')
+    assert_equal 'button-secondary', highlight_class('withdrawn')
+    assert_equal 'button-primary', highlight_class('any')
+  end
+
+  test 'highlight class when status is bogus' do
+    params[:status] = 'bogus'
+
+    assert_equal 'button-secondary', highlight_class('active')
+    assert_equal 'button-secondary', highlight_class('downloaded')
+    assert_equal 'button-secondary', highlight_class('withdrawn')
+    assert_equal 'button-secondary', highlight_class('any')
+  end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
(title says it all)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Look at `/process` or `/process?status=whatever` on the PR build. Sometimes a button is blue! It is the right button.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-50

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
