### PR TITLE
Use permalinks, not expiring service URLs

### DIFF
--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -52,7 +52,7 @@
           Files:  <% if thesis.files.attached? %>
                     <% thesis.files.each do |file| %>
                       <br />
-                       <%= link_to(file.filename, file.service_url) %>
+                       <%= link_to(file.filename, url_for(file)) %>
                     <% end %>
                   <% else %>
                     No files attached


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
`file.service_url` expires; we should use a nonexpiring link to thesis content. I'm pretty sure this is the Rails-approved, All We Need To Do thing.

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Compare file URL structures on staging and the PR build - they look different.

Save a staging build and PR build URL for >5 minutes and then go back to them - PR build one should still work, staging will have expired.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-55

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
