### PR TITLE
add link to processing from admin and file downloads from show

### DIFF
--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -24,6 +24,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     graduation_year: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    files: FileField,
     status: Field::Select.with_options(
       collection: Thesis::STATUS_OPTIONS,
     ),
@@ -57,6 +58,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     degrees
     status
     note
+    files
   ].freeze
 
   # FORM_ATTRIBUTES

--- a/app/fields/file_field.rb
+++ b/app/fields/file_field.rb
@@ -1,0 +1,7 @@
+require 'administrate/field/base'
+
+class FileField < Administrate::Field::Base
+  def files
+    data.record.files
+  end
+end

--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -1,0 +1,21 @@
+<%#
+# Navigation
+
+This partial is used to display the navigation in Administrate.
+By default, the navigation contains navigation links
+for all resources in the admin dashboard,
+as defined by the routes in the `admin/` namespace
+%>
+
+<nav class="navigation" role="navigation">
+
+  <%= link_to('Process Theses', process_path, class: "navigation__link") %>
+
+  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+    <%= link_to(
+      display_resource_name(resource),
+      [namespace, resource.path],
+      class: "navigation__link navigation__link--#{nav_link_state(resource)}"
+    ) %>
+  <% end %>
+</nav>

--- a/app/views/fields/file_field/_show.html.erb
+++ b/app/views/fields/file_field/_show.html.erb
@@ -1,0 +1,3 @@
+<% field.files.each do |file| %>
+  <%= link_to(file.filename, url_for(file)) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :thesis, only: [:new, :create, :show]
-  get 'process', to: 'thesis#process_theses'
+  get 'process', to: 'thesis#process_theses', as: 'process'
   get 'process/:status', to: 'thesis#process_theses'
   post 'done/:id', to: 'thesis#mark_downloaded',
                    id: /[0-9]+/,

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -87,6 +87,12 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_response :redirect
   end
 
+  test 'thesis admins can view an admin theses show page' do
+    mock_auth(users(:thesis_admin))
+    get admin_thesis_path(theses(:one))
+    assert_response :success
+  end
+
   test 'thesis admins can update theses through admin panel' do
     mock_auth(users(:thesis_admin))
 


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

- adds link to process theses in admin navigation
- adds link to download files from admin thesis show pages

#### How can a reviewer manually see the effects of these changes?
- in the admin interface, the top link in the navigation should always be to the processing page
- in the admin thesis view page, links to download files should now exist if the thesis has files attached

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-63
- and another one but Jira is down so I am not sure the number

#### Todo:
- [ ] Tests
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
