### PR TITLE
Remove all but the most trivial validation on graduation_year

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -63,11 +63,13 @@ class Thesis < ApplicationRecord
     end
   }
 
-  # Ensures submitted year string is reasonably sane
+  # Ensures submitted graduation year is a four-digit integer, not less than
+  # the year of the Institute's founding.
+  # We expect that graduation_year will be a String (in which case to_s is a
+  # no-op), but if it's an Integer this will also work.
   def valid_year?
-    oldest_year = Time.zone.now.year - 5
-    latest_year = Time.zone.now.year + 5
-    return if (oldest_year..latest_year).cover?(graduation_year.to_i)
+    return if (/^\d{4}$/.match(graduation_year.to_s) &&
+               graduation_year.to_i >= 1861)
     errors.add(:graduation_year, 'Invalid graduation year')
   end
 

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -45,6 +45,33 @@ class ThesisTest < ActiveSupport::TestCase
     assert(thesis.invalid?)
   end
 
+  test 'grad year should be vaguely reasonable' do
+    thesis = theses(:one)
+    thesis.graduation_year = '1861'
+    assert thesis.valid?
+
+    thesis.graduation_year = '2018'
+    assert thesis.valid?
+
+    thesis.graduation_year = 1861
+    assert thesis.valid?
+
+    thesis.graduation_year = 2018
+    assert thesis.valid?
+
+    thesis.graduation_year = '1860'
+    assert thesis.invalid?
+
+    thesis.graduation_year = '10'
+    assert thesis.invalid?
+
+    thesis.graduation_year = '10000'
+    assert thesis.invalid?
+
+    thesis.graduation_year = 'honeybadgers'
+    assert thesis.invalid?
+  end
+
   test 'invalid without user' do
     thesis = theses(:one)
     thesis.user = nil


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
(see PR title)

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
Add a new thesis with a graduation year that is more than 5 years away from the current year (but still a 4-digit number after 1860). It should work on the PR build but not on staging.

Note that this introduces technical debt in that we will stop being able to add theses via the thesis ingest system starting in 7982 years.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-84

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
