### PR TITLE
Restrict valid months to February, June, September

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -41,6 +41,8 @@ class Thesis < ApplicationRecord
   STATUS_OPTIONS = ['active', 'withdrawn', 'downloaded']
   validates_inclusion_of :status, :in => STATUS_OPTIONS
 
+  VALID_MONTHS = ['February', 'June', 'September']
+
   before_create :combine_graduation_date
   after_find :split_graduation_date
 
@@ -74,8 +76,9 @@ class Thesis < ApplicationRecord
   end
 
   def valid_month?
-    return if Date::MONTHNAMES.compact.include?(graduation_month)
-    errors.add(:graduation_month, 'Invalid graduation month')
+    return if VALID_MONTHS.include?(graduation_month)
+    errors.add(:graduation_month,
+      'Invalid graduation month; must be June, September, or February')
   end
 
   # Combine the UI supplied month and year into a datetime object

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -31,7 +31,7 @@
       <div class='group-inline'>
 
       <%= f.input :graduation_month, label: 'Month', as: :select,
-                           collection: Date::MONTHNAMES.compact,
+                           collection: Thesis::VALID_MONTHS,
                            wrapper_html: { class: 'field-wrap' },
                            input_html: { class: 'field field-select' } %>
 

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -25,7 +25,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
              degree_ids: [degrees(:one).id.to_s],
              right_id: rights(:one).id.to_s,
              graduation_year: (Time.current.year + 1).to_s,
-             graduation_month: 'December',
+             graduation_month: 'September',
              files: fixture_file_upload('files/a_pdf.pdf', 'application/pdf')
            }
          }
@@ -467,17 +467,19 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:admin)
     get process_path(start_year: '2019')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert_not view_theses.exists? theses(:may_2018).id
-    assert_not view_theses.exists? theses(:august_2018).id
-    assert view_theses.exists? theses(:may_2019).id
-    assert view_theses.exists? theses(:august_2019).id
+    assert_not view_theses.exists? theses(:june_2018).id
+    assert_not view_theses.exists? theses(:september_2018).id
+    assert view_theses.exists? theses(:june_2019).id
+    assert view_theses.exists? theses(:september_2019).id
   end
 
   test 'start year filter is inclusive' do
     sign_in users(:admin)
     get process_path(start_year: '2019')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:january_2019).id
+    assert view_theses.exists? theses(:february_2019).id
+    assert view_theses.exists? theses(:june_2019).id
+    assert view_theses.exists? theses(:september_2019).id
   end
 
   test 'filtering by start year does not flash errors' do
@@ -489,19 +491,19 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'can be filtered by start year and month' do
     sign_in users(:admin)
-    get process_path(start_year: '2019', start_month: '6')
+    get process_path(start_year: '2019', start_month: '7')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert_not view_theses.exists? theses(:may_2018).id
-    assert_not view_theses.exists? theses(:august_2018).id
-    assert_not view_theses.exists? theses(:may_2019).id
-    assert view_theses.exists? theses(:august_2019).id
+    assert_not view_theses.exists? theses(:june_2018).id
+    assert_not view_theses.exists? theses(:september_2018).id
+    assert_not view_theses.exists? theses(:june_2019).id
+    assert view_theses.exists? theses(:september_2019).id
   end
 
   test 'start year and month filter is inclusive' do
     sign_in users(:admin)
-    get process_path(start_year: '2019', start_month: '5')
+    get process_path(start_year: '2019', start_month: '6')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:may_2019).id
+    assert view_theses.exists? theses(:june_2019).id
   end
 
   test 'filtering by start year and month does not flash errors' do
@@ -515,17 +517,18 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:admin)
     get process_path(end_year: '2018')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:may_2018).id
-    assert view_theses.exists? theses(:august_2018).id
-    assert_not view_theses.exists? theses(:may_2019).id
-    assert_not view_theses.exists? theses(:august_2019).id
+    assert view_theses.exists? theses(:june_2018).id
+    assert view_theses.exists? theses(:september_2018).id
+    assert_not view_theses.exists? theses(:june_2019).id
+    assert_not view_theses.exists? theses(:september_2019).id
   end
 
   test 'end year filter is inclusive' do
     sign_in users(:admin)
     get process_path(end_year: '2019')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:december_2019).id
+    assert view_theses.exists? theses(:june_2019).id
+    assert view_theses.exists? theses(:september_2019).id
   end
 
   test 'filtering by end year does not flash errors' do
@@ -537,19 +540,19 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'can be filtered by end year and month' do
     sign_in users(:admin)
-    get process_path(end_year: '2019', end_month: '6')
+    get process_path(end_year: '2019', end_month: '7')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:may_2018).id
-    assert view_theses.exists? theses(:august_2018).id
-    assert view_theses.exists? theses(:may_2019).id
-    assert_not view_theses.exists? theses(:august_2019).id
+    assert view_theses.exists? theses(:june_2018).id
+    assert view_theses.exists? theses(:september_2018).id
+    assert view_theses.exists? theses(:june_2019).id
+    assert_not view_theses.exists? theses(:september_2019).id
   end
 
   test 'end year and month filter is inclusive' do
     sign_in users(:admin)
-    get process_path(end_year: '2019', end_month: '5')
+    get process_path(end_year: '2019', end_month: '6')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert view_theses.exists? theses(:may_2019).id
+    assert view_theses.exists? theses(:june_2019).id
   end
 
   test 'filtering by end year and month does not flash errors' do
@@ -561,13 +564,13 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'can be filtered by both start and end dates' do
     sign_in users(:admin)
-    get process_path(start_year: '2018', start_month: '6',
+    get process_path(start_year: '2018', start_month: '7',
                      end_year: '2019', end_month: '6')
     view_theses = @controller.instance_variable_get(:@theses)
-    assert_not view_theses.exists? theses(:may_2018).id
-    assert view_theses.exists? theses(:august_2018).id
-    assert view_theses.exists? theses(:may_2019).id
-    assert_not view_theses.exists? theses(:august_2019).id
+    assert_not view_theses.exists? theses(:june_2018).id
+    assert view_theses.exists? theses(:september_2018).id
+    assert view_theses.exists? theses(:june_2019).id
+    assert_not view_theses.exists? theses(:september_2019).id
   end
 
   test 'rejects start month without year' do

--- a/test/fixtures/receipt_mailer/receipt_email
+++ b/test/fixtures/receipt_mailer/receipt_email
@@ -11,7 +11,7 @@
     <p>Hello,</p>
 
 <p>You are receiving this message to confirm the successful submission of the
-electronic version of your July 2017 thesis "MyString" to the MIT Libraries.
+electronic version of your September 2017 thesis "MyString" to the MIT Libraries.
 </p>
 
 <p>You do not need to reply to this message.</p>

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -19,7 +19,7 @@
 one:
   title: MyString
   abstract: MyText
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -28,7 +28,7 @@ one:
 two:
   title:  Can apparent superluminal neutrino speeds be explained as a quantum weak measurement?
   abstract: Probably not.
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -37,7 +37,7 @@ two:
 downloaded:
   title: MyString
   abstract: MyText
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -47,7 +47,7 @@ downloaded:
 withdrawn:
   title: MyString
   abstract: MyText
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -57,7 +57,7 @@ withdrawn:
 active:
   title: MyString
   abstract: MyText
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -67,7 +67,7 @@ active:
 with_note:
   title: MyString
   abstract: MyText
-  grad_date: 2017-07-13
+  grad_date: 2017-09-13
   user: yo
   right: one
   departments: [one]
@@ -75,55 +75,46 @@ with_note:
   status: 'active'  # The default, but specified for testing purposes.
   note: 'Absolutely for sure rocket science'
 
-may_2018:
+june_2018:
   title: MyString
   abstract: MyText
-  grad_date: 2018-05-01
+  grad_date: 2018-06-01
   user: yo
   right: one
   departments: [one]
   degrees: [one]
 
-august_2018:
+september_2018:
   title: MyString
   abstract: MyText
-  grad_date: 2018-08-01
+  grad_date: 2018-09-01
   user: yo
   right: one
   departments: [one]
   degrees: [one]
 
-january_2019:
+february_2019:
   title: MyString
   abstract: MyText
-  grad_date: 2019-01-01
+  grad_date: 2019-02-01
   user: yo
   right: one
   departments: [one]
   degrees: [one]
 
-may_2019:
+june_2019:
   title: MyString
   abstract: MyText
-  grad_date: 2019-05-01
+  grad_date: 2019-06-01
   user: yo
   right: one
   departments: [one]
   degrees: [one]
 
-august_2019:
+september_2019:
   title: MyString
   abstract: MyText
-  grad_date: 2019-08-01
-  user: yo
-  right: one
-  departments: [one]
-  degrees: [one]
-
-december_2019:
-  title: MyString
-  abstract: MyText
-  grad_date: 2019-12-31
+  grad_date: 2019-09-01
   user: yo
   right: one
   departments: [one]

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -124,7 +124,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
                           degree_ids: [ Degree.first.id ],
                           title: 'yoyos are cool',
                           abstract: 'We discovered it with science',
-                          graduation_month: 'May',
+                          graduation_month: 'June',
                           graduation_year: Date.today.year } }
 
     assert_equal orig_count + 1, Thesis.count

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -142,4 +142,46 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.save
     assert_not(thesis.valid?)
   end
+
+  test 'only June, September, and February are valid months' do
+    thesis = theses(:one)
+    thesis.grad_date = nil
+    thesis.graduation_year = 2018
+
+    thesis.graduation_month = 'January'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'February'
+    assert thesis.valid?
+
+    thesis.graduation_month = 'March'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'April'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'May'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'June'
+    assert thesis.valid?
+
+    thesis.graduation_month = 'July'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'August'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'September'
+    assert thesis.valid?
+
+    thesis.graduation_month = 'October'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'November'
+    assert thesis.invalid?
+
+    thesis.graduation_month = 'December'
+    assert thesis.invalid?
+  end
 end


### PR DESCRIPTION
This requires changing a lot of files because the test fixtures
had different months and therefore this validity check caused
numerous tests to fail, but it isn't actually a very big change.

## Status
**READY**

#### What does this PR do?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?
On submission form on PR build, you will see that only February, June, and September are available in the graduation month drop-down. If you try to create a thesis with a different graduation month (e.g. in the shell), it will fail.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-85

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
