### PR TITLE
Updates pr build pattern match to allow fake auth

### DIFF
--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -27,7 +27,7 @@ module FakeAuthConfig
   # pattern.
   def app_name_pattern_match?
     return true if Rails.env.development?
-    review_app_pattern = /^library-thesis-dropbox-s-pr-[\d]+$/
+    review_app_pattern = /^library-thesis-dropbox-s?-pr-[\d]+$/
     review_app_pattern.match(ENV['HEROKU_APP_NAME']).present?
   end
 end

--- a/test/models/fake_auth_test.rb
+++ b/test/models/fake_auth_test.rb
@@ -21,6 +21,15 @@ class FakeAuthTest < ActiveSupport::TestCase
     end
   end
 
+  test 'fakeauth enabled pr minus s pattern app name' do
+    ClimateControl.modify(
+      FAKE_AUTH_ENABLED: 'true',
+      HEROKU_APP_NAME: 'library-thesis-dropbox--pr-123'
+    ) do
+      assert_equal(true, fake_auth_status)
+    end
+  end
+
   test 'fakeauth enabled no heroku app name' do
     ClimateControl.modify FAKE_AUTH_ENABLED: 'true' do
       assert_equal(false, fake_auth_status)


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

The PR builds now have incremented over 99 which seems to have
triggered a pattern match problem as they removed an extra character
from the middle of the expected URL to allow for the extra character
in the number to fit in their url size.

This should keep us safe for another 900 builds or so.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
