### PR TITLE
Bugfix dept degree

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -82,7 +82,7 @@ class ThesisController < ApplicationController
   def thesis_params
     params.require(:thesis).permit(:title, :abstract, :graduation_month,
                                    :graduation_year, :right_id,
-                                   department_ids: [], degree_ids: [])
+                                   :department_ids, :degree_ids)
   end
 
   def handle_thesis_ajax(handler)

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -21,8 +21,8 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
            thesis: {
              title: title,
              abstract: 'Frook.',
-             department_ids: [departments(:one).id.to_s],
-             degree_ids: [degrees(:one).id.to_s],
+             department_ids: departments(:one).id.to_s,
+             degree_ids: degrees(:one).id.to_s,
              right_id: rights(:one).id.to_s,
              graduation_year: (Time.current.year + 1).to_s,
              graduation_month: 'September',
@@ -46,7 +46,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
              title: title,
              abstract: 'Frook.',
              # The missing department ids here should cause the form to fail.
-             degree_ids: [degrees(:one).id.to_s],
+             degree_ids: degrees(:one).id.to_s,
              right_id: rights(:one).id.to_s,
              graduation_year: (Time.current.year + 1).to_s,
              graduation_month: 'December',

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class ThesisIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'posting valid thesis' do
+    mock_auth(users(:basic))
+    orig_count = Thesis.count
+    post thesis_index_path,
+         params: { thesis:
+           { right_id: Right.first.id,
+             department_ids: [Department.first.id],
+             degree_ids: [Degree.first.id],
+             title: 'yoyos are cool',
+             abstract: 'We discovered it with science',
+             graduation_month: 'June',
+             graduation_year: Time.zone.today.year,
+             files: fixture_file_upload('test/fixtures/files/a_pdf.pdf',
+                                        'application/pdf') } }
+    assert_equal orig_count + 1, Thesis.count
+    assert_equal 'yoyos are cool', Thesis.last.title
+    assert_equal 'We discovered it with science', Thesis.last.abstract
+  end
+end

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -15,8 +15,8 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
     post thesis_index_path,
          params: { thesis:
            { right_id: Right.first.id,
-             department_ids: [Department.first.id],
-             degree_ids: [Degree.first.id],
+             department_ids: Department.first.id,
+             degree_ids: Degree.first.id,
              title: 'yoyos are cool',
              abstract: 'We discovered it with science',
              graduation_month: 'June',


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

There are two commits. The first adds a test for the _before_ behavior that was never tested in an Integration test.

The second, updates the behavior to reflect the change made in the UI which removed the multi select options for dept/degree. The controller was still expecting an array of values for those UI elements and thus was broken. The commit changes the controller expectation to be single values for each and updates tests in a couple locations to match that new behavior. The change to the UI that caused this bug landed last week. Ooops (on me).

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
