### PR TITLE
Redirect if request host doesn't match configured preferred host

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ and use rails standard verbose logging.
 `JS_EXCEPTION_LOGGER_KEY` - set this to the value of the rollbar public post key
 to enable capturing javascript exceptions.
 
+`PREFERRED_DOMAIN` - set this to the domain you would like to to use. Any other
+requests that come to the app will redirect to the root of this domain. This is
+useful to prevent access to herokuapp.com domains as well as any legacy domains
+you'd like to handle.
+
 `RAILS_LOG_TO_STDOUT` - log to standard out instead of a file. Heroku enables
 this automatically. It is often nice in development as well.
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  before_action :ensure_domain
 
   def new_session_path(_scope)
     root_path
@@ -11,5 +12,15 @@ class ApplicationController < ActionController::Base
     else
       new_thesis_path
     end
+  end
+
+  private
+
+  # redirects herokuapp domains and old domains to preferred domains
+  def ensure_domain
+    return unless ENV['PREFERRED_DOMAIN']
+    return if request.host == ENV['PREFERRED_DOMAIN']
+    Rails.logger.info("Handling Domain Redirect: #{request.host}")
+    redirect_to "https://#{ENV['PREFERRED_DOMAIN']}", status: :moved_permanently
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,5 +33,9 @@ Rails.application.routes.draw do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
 
+  # handle old vireo starting URLs
+  get 'vireo', to: redirect('/')
+  get 'vireo/:whatever', to: redirect('/')
+
   root to: 'static#index'
 end

--- a/test/integration/redirect_domains_test.rb
+++ b/test/integration/redirect_domains_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class RedirectDomainsTest < ActionDispatch::IntegrationTest
+  test 'no PREFERRED_DOMAIN' do
+    get '/'
+    assert_response :success
+    assert_equal('/', @request.path)
+  end
+
+  test 'PREFERRED_DOMAIN domain matches request host' do
+    ClimateControl.modify(PREFERRED_DOMAIN: 'example.org') do
+      get 'http://example.org/'
+      assert_response :success
+      assert_equal('example.org', request.host)
+      assert_equal('/', @request.path)
+    end
+  end
+
+  test 'PREFERRED_DOMAIN does not match request host' do
+    ClimateControl.modify(PREFERRED_DOMAIN: 'example.com') do
+      get 'http://example.org/'
+      assert_response :redirect
+      assert_equal('example.org', request.host)
+      follow_redirect!
+      assert_equal('example.com', request.host)
+      assert_equal('/', @request.path)
+    end
+  end
+
+  test 'vireo/start url handling' do
+    get '/vireo/start'
+    assert_equal('/vireo/start', @request.path)
+    follow_redirect!
+    assert_equal('/', @request.path)
+  end
+
+  test 'vireo/admin url handling' do
+    get '/vireo/admin'
+    assert_equal('/vireo/admin', @request.path)
+    follow_redirect!
+    assert_equal('/', @request.path)
+  end
+
+  test 'vireo url handling' do
+    get '/vireo'
+    assert_equal('/vireo', @request.path)
+    follow_redirect!
+    assert_equal('/', @request.path)
+  end
+end


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Redirects from heroku or old domains to preferred domain if one is configured.

This is not yet ready for review, I wanted to see it on heroku before writing tests.

The PR build is configured to have a `PREFERRED_DOMAIN` of `yolo.mitlib.net`. You can see the various aspects of this working by:

- accessing the PR build by it's heroku name and being redirect to https://yolo.mitlib.net
- accessing https://yolo.mitlib.net/vireo/start and being redirected to root
- accessing https://yolo.mitlib.net/vireo/admin and being redirected to root


#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-91

#### Todo:
- [x] Tests
- [x] Documentation

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO