### PR TITLE
Trigger submit after successful upload

### DIFF
--- a/app/assets/javascripts/direct_uploads.js
+++ b/app/assets/javascripts/direct_uploads.js
@@ -44,3 +44,9 @@ addEventListener("direct-upload:end", event => {
   const element = document.getElementById(`direct-upload-${id}`)
   element.classList.add("direct-upload--complete")
 })
+
+addEventListener("direct-uploads:end", event => {
+  console.log("direct-uploads:end")
+  // Workaround for https://github.com/rails/rails/issues/31860
+  event.target.submit()
+})


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

This is a workaround for some odd behavior where Firefox doesn't submit the form properly if you enter an error state, fix it, then submit again.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-92

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
