### PR TITLE
Orders departments alphabetically on ingest form

### DIFF
--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -25,6 +25,7 @@
                            } %>
 
     <%= f.association :departments, label_method: :name, as: :select,
+                         collection: Department.order(:name),
                          validate: { presence: true },
                          include_hidden: false,
                          wrapper_html: { class: 'field-wrap select' },


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Updated display order of departments to be alphabetical. Stakeholders confirmed Degrees do not need the same ordering for some reason. (I suspect we'll need a way to more explicitly control ordering for that at some point as it appears random but they like it so it's clearly not).

#### How can a reviewer manually see the effects of these changes?

In the PR build, add some additional departments in a non-alpha order. They should be alpha on the ingest form dropdown select.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-96

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
