### PR TITLE
ENV configurable log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ and use rails standard verbose logging.
 `JS_EXCEPTION_LOGGER_KEY` - set this to the value of the rollbar public post key
 to enable capturing javascript exceptions.
 
+`LOG_LEVEL` - we set sane defaults in development or production, but you can
+override easily with this ENV if you need to get more details.
+
 `PREFERRED_DOMAIN` - set this to the domain you would like to to use. Any other
 requests that come to the app will redirect to the root of this domain. This is
 useful to prevent access to herokuapp.com domains as well as any legacy domains

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # allow configurable log levels, default to debug
+  config.log_level = ENV['LOG_LEVEL'] || :debug
+
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,9 +49,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # allow configurable log levels, default to info
+  config.log_level = ENV['LOG_LEVEL'] || :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

sane defaults but override-able without changing code if we need to go
to debug in prod for some reason

#### How can a reviewer manually see the effects of these changes?

in prod, this change will not show debug events. In the PR build, if you add `LOG_LEVEL=debug` to the ENV config, it will show debug events.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-106

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
