### PR TITLE
Allow processors to view all Theses

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -39,6 +39,7 @@ class Ability
     can :annotate, Thesis
     can :process_theses, Thesis
     can :stats, Thesis
+    can :read, Thesis
   end
 
   # Library staff who can use the admin dashboards (which includes operations

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -86,6 +86,18 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'thesis_admin users can view another user thesis' do
+    sign_in users(:thesis_admin)
+    get "/thesis/#{theses(:one).id}"
+    assert_response :success
+  end
+
+  test 'processor users can view another user thesis' do
+    sign_in users(:processor)
+    get "/thesis/#{theses(:one).id}"
+    assert_response :success
+  end
+
   # Tests below this note are to protect us from our future selves.
   # Currently we have no routes for delete/update or controller actions to
   # handle this, but I'm adding these tests to remind us in the future that if


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Allows `thesis_admin` and `processor` roles to view all Thesis records.

#### Helpful background context (if appropriate)

This bug has been around a while, but was only noticeable to staff that are thesis_admins or processors but also _not_ general admins.

The presence of effectively two roles systems (the named roles and the "admin" role) is technical debt and a new ticket will be opened to address that. The new ticket is https://mitlibraries.atlassian.net/browse/TI-115, the original is https://mitlibraries.atlassian.net/browse/TI-110
#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-110

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
