### PR TITLE
Redirect back to filtered path when updating records

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -49,7 +49,7 @@ class ThesisController < ApplicationController
     else
       flash[:error] = "#{@thesis.title} was unable to be marked downloaded."
     end
-    redirect_to process_path
+    redirect_back(fallback_location: process_path)
   end
 
   def mark_withdrawn
@@ -64,7 +64,7 @@ class ThesisController < ApplicationController
     else
       flash[:error] = "#{@thesis.title} was unable to be marked withdrawn."
     end
-    redirect_to process_path
+    redirect_back(fallback_location: process_path)
   end
 
   def annotate
@@ -77,7 +77,7 @@ class ThesisController < ApplicationController
     else
       flash[:error] = "#{@thesis.title} note was unable to be updated."
     end
-    redirect_to process_path
+    redirect_back(fallback_location: process_path)
   end
 
   def stats


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

When working from the theses process list, marking a thesis complete, withdrawn or adding a note returned the processor to the process_path. However, that didn't take into account any filters or sorting they had done.

By using the redirect_back with a fallback to the process_path we should safely be able to return them to the same filtered list they started from while returning to the unfiltered list if the request doesn't have that information for some reason.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-116

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
