### PR TITLE
Include May as a valid graduation month

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -58,7 +58,7 @@ class Thesis < ApplicationRecord
   STATUS_OPTIONS = ['active', 'withdrawn', 'downloaded']
   validates_inclusion_of :status, :in => STATUS_OPTIONS
 
-  VALID_MONTHS = ['February', 'June', 'September']
+  VALID_MONTHS = ['February', 'May', 'June', 'September']
 
   before_create :combine_graduation_date
   after_find :split_graduation_date
@@ -98,7 +98,7 @@ class Thesis < ApplicationRecord
   def valid_month?
     return if VALID_MONTHS.include?(graduation_month)
     errors.add(:graduation_month,
-      'Invalid graduation month; must be June, September, or February')
+      'Invalid graduation month; must be May, June, September, or February')
   end
 
   # Combine the UI supplied month and year into a datetime object

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -143,7 +143,7 @@ class ThesisTest < ActiveSupport::TestCase
     assert_not(thesis.valid?)
   end
 
-  test 'only June, September, and February are valid months' do
+  test 'only May, June, September, and February are valid months' do
     thesis = theses(:one)
     thesis.grad_date = nil
     thesis.graduation_year = 2018
@@ -161,7 +161,7 @@ class ThesisTest < ActiveSupport::TestCase
     assert thesis.invalid?
 
     thesis.graduation_month = 'May'
-    assert thesis.invalid?
+    assert thesis.valid?
 
     thesis.graduation_month = 'June'
     assert thesis.valid?


### PR DESCRIPTION
## Status
READY

#### What does this PR do?
Adds May to the `VALID_MONTHS` array of possible graduation months.

#### Helpful background context (if appropriate)
Beginning in 2020, commencement activities will begin one week earlier. This will place graduation day on May 29, 2020. However, some future graduation days will be in June (e.g., 2023).

#### How can a reviewer manually see the effects of these changes?
Begin a test ingest in the CI deploy associated with this PR. The 'Month' drop-down menu should include the options February, May, June, September.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-130

#### Todo:
- [x] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
