### PR TITLE
Fully remove sysadmin role and clarify Admin flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,24 @@ are configured to allow for the domain this app runs at.
 
 ## User Roles
 
-There are a few user roles that can be assigned by admins (one of the user roles!). The abilities of each role are defined in the [ability model](https://github.com/MITLibraries/thing/blob/master/app/models/ability.rb).
+There are a few user roles that provide different levels of permissions. The
+abilities of each role are defined in the [ability model](https://github.com/MITLibraries/thing/blob/master/app/models/ability.rb).
 
-`Basic` is the default user role and is assigned when a user self creates and account. Self creation is the only supported way to create an account. If we have a new staff member, they first need to login to self create an account with the basic role and then admin staff can assign them appropriate roles.
+`Basic` is the default user role and is assigned when a user self creates an
+account. Self creation is the only supported way to create an account. If we
+have a new staff member, they first need to login to self create an account
+with the basic role and then admin staff can assign them appropriate roles.
 
 `Thesis Processor` is used for any users that process theses.
 
-`Thesis Admin` can do everything a Thesis Processor can do but can also create and update any thesis (not just their own like a basic user).
+`Thesis Admin` can do everything a `Thesis Processor` can do but can also create
+and update any thesis (not just their own like a `Basic` user).
 
-`Admin` can do anything, including deleting or changing anything and assigning roles to other users. Assigning roles is done in the web UI.
+The `Admin` flag can be assigned to a user with any role. `Admin` users can do
+anything, including deleting or changing theses, modifying user roles, and
+deleting users.
+
+Assigning roles and the `Admin` flag is done in the web UI.
 
 ## Sending Receipt Email in Production
 

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -9,8 +9,7 @@ module Admin
     before_action :authenticate_user!
     before_action :authenticate_admin
 
-    # People with sysadmin privileges can do anything here. People with thesis
-    # admin privileges can create and edit but not destroy theses.
+    # Ensure that current user has admin privileges.
     def authenticate_admin
       admin_actions = %w[show update index create edit]
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,8 +43,7 @@ class Ability
   end
 
   # Library staff who can use the admin dashboards (which includes operations
-  # on departments), but who don't have system administration
-  # powers.
+  # on departments).
   def thesis_admin
     processor
     can %i[create update], Thesis

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   validates :email, presence: true
   has_many :theses
 
-  ROLES = %w[basic processor thesis_admin sysadmin]
+  ROLES = %w[basic processor thesis_admin]
   validates_inclusion_of :role, :in => ROLES
 
   # `uid` is a unique ID that comes back from OmniAuth (which gets it from

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -58,10 +58,3 @@ thesis_admin:
   role: 'thesis_admin'
   given_name: 'Thesis A.'
   surname: 'Robot'
-
-sysadmin:
-  uid: 'sysadmin_id'
-  email: 'sysadmin@example.com'
-  role: 'sysadmin'
-  given_name: 'Sysadmin'
-  surname: 'Robot'


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?
Removes remnants of sysadmin role, originally added here: https://github.com/MITLibraries/thing/pull/42

Also clarifies that the `Admin` flag is not a distinct role, but an additional level of permissions that can be added to any role.

#### Helpful background context (if appropriate)
The sysadmin role was deemed redundant and removed here: https://github.com/MITLibraries/thing/pull/267

We don't use it, but it's mentioned in a couple places. This PR removes those mentions.

#### How can a reviewer manually see the effects of these changes?
Confirm that the sysadmin role no longer exists in the admin UI.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-115
- https://mitlibraries.atlassian.net/browse/TI-125

#### Screenshots (if appropriate)

#### Todo:
- [x] Tests
- [x] Documentation
- [ ] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
