### PR TITLE
Ti 131 update landing page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'sass-rails'
 gem 'sentry-raven'
 gem 'simple_form'
 gem 'skylight'
-gem 'therubyracer', platforms: :ruby
 gem 'uglifier'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.0)
     kaminari-core (1.2.0)
-    libv8 (3.16.14.19)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -220,7 +219,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    ref (2.0.0)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -285,9 +283,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -342,7 +337,6 @@ DEPENDENCIES
   simplecov-lcov
   skylight
   sqlite3
-  therubyracer
   uglifier
   web-console
 

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -4,6 +4,28 @@
 
   <div class="col3q">
     <h3 class="title title-page">Preserve and share your scholarship</h3>
+
+    <div class="well">
+      <h4>May 2020 degree list candidates</h4>
+
+      <ul>
+        <li>Your thesis must be submitted electronically to your department or 
+        program. For this degree period Libraries will not accept PDFs directly
+        from the author.</li>
+
+        <li>For doctoral theses only: after submitting your thesis to your
+        department, please use this site to submit your 
+        <a href="https://libraries.mit.edu/wp-content/uploads/2019/08/umi-proquest-form.pdf">ProQuest 
+        form</a>
+        and a copy of your title and abstract pages.</li>
+      </ul>
+
+      <h4>Departments</h4>
+
+      Please do not submit via this site. Email mit-theses@mit.edu<mit-theses@mit.edu> with any questions.
+
+    </div>
+
     <p>
       Adding your thesis or dissertation to MIT's DSpace thesis collection is a great way to preserve the record of your scholarship at MIT. Theses in DSpace are visible to anyone in the world, and will be preserved digitally for long term use and access.
     </p>
@@ -14,10 +36,6 @@
 
     <p>
       Information about your thesis will be indexed by search engines like Google after your thesis is loaded into DSpace. All theses in DSpace can be accessed via a persistent URL (also called a handle) which will not change.
-    </p>
-
-    <p>
-      <strong>Paper copies of your thesis are still required and should be submitted to your academic department as usual.</strong> See <a href="https://libraries.mit.edu/archives/thesis-specs/index.html">Thesis Specifications</a> for more information.
     </p>
 
     <p>


### PR DESCRIPTION
## Status
**READY**

#### What does this PR do?

Updates the front page wording to reflect May 2020 theses workflow changes.

Removes `therubyracer` gem which is no longer needed.

#### How can a reviewer manually see the effects of these changes?

View the main index page in the PR. It's all wording changes (other than removing therubyracer which can be tested by "is this PR build working at all".

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TI-131

#### Screenshots (if appropriate)

#### Todo:
- [ ] Tests
- [ ] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
YES (removes therubyracer)
