### PR TITLE
ETS-71 Add submitter model

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -12,6 +12,8 @@ class Department < ApplicationRecord
   has_many :department_theses
   has_many :theses, through: :department_theses
   has_many :transfers
+  has_many :submitters
+  has_many :users, through: :submitters
 
   validates :name, presence: true
 end

--- a/app/models/submitter.rb
+++ b/app/models/submitter.rb
@@ -1,0 +1,4 @@
+class Submitter < ApplicationRecord
+  belongs_to :user
+  belongs_to :department
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ApplicationRecord
   validates :email, presence: true
   has_many :theses
   has_many :transfers
+  has_many :submitters
+  has_many :departments, through: :submitters
 
   ROLES = %w[basic processor thesis_admin]
   validates_inclusion_of :role, :in => ROLES

--- a/db/migrate/20201209213534_create_submitters.rb
+++ b/db/migrate/20201209213534_create_submitters.rb
@@ -1,0 +1,10 @@
+class CreateSubmitters < ActiveRecord::Migration[6.0]
+  def change
+    create_table :submitters do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :department, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_03_120000) do
+ActiveRecord::Schema.define(version: 2020_12_09_213534) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,15 @@ ActiveRecord::Schema.define(version: 2020_12_03_120000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "submitters", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "department_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["department_id"], name: "index_submitters_on_department_id"
+    t.index ["user_id"], name: "index_submitters_on_user_id"
+  end
+
   create_table "theses", force: :cascade do |t|
     t.string "title", null: false
     t.text "abstract", null: false
@@ -118,6 +127,8 @@ ActiveRecord::Schema.define(version: 2020_12_03_120000) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "submitters", "departments"
+  add_foreign_key "submitters", "users"
   add_foreign_key "transfers", "departments"
   add_foreign_key "transfers", "users"
 end

--- a/test/fixtures/departments.yml
+++ b/test/fixtures/departments.yml
@@ -15,3 +15,6 @@ one:
 
 two:
   name: Computational Musicology
+
+three:
+  name: Theoretical Metallurgy

--- a/test/fixtures/submitters.yml
+++ b/test/fixtures/submitters.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: yo
+  department: one
+
+two:
+  user: yo
+  department: two
+
+three:
+  user: admin
+  department: two

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -34,7 +34,7 @@ class DepartmentTest < ActiveSupport::TestCase
     assert(department.valid?)
   end
 
-  test 'can have or or more transfers' do
+  test 'can have one or more transfers' do
     d = Department.last
     assert(d.name == 'Underwater Basketweaving')
     tcount = d.transfers.count
@@ -61,5 +61,23 @@ class DepartmentTest < ActiveSupport::TestCase
     assert(d.name == 'Underwater Basketweaving')
     ttest = d.transfers.first
     assert(ttest.grad_date.to_s == '2020-05-01')
+  end
+
+  test 'can have zero or more users' do
+    department_one = departments(:one)
+    department_two = departments(:two)
+    department_three = departments(:three)
+    assert(department_one.users.count == 1)
+    assert(department_two.users.count == 2)
+    assert(department_three.users.count == 0)
+  end
+
+  test 'can have zero or more submitters' do
+    department_one = departments(:one)
+    department_two = departments(:two)
+    department_three = departments(:three)
+    assert(department_one.submitters.count == 1)
+    assert(department_two.submitters.count == 2)
+    assert(department_three.submitters.count == 0)
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -106,4 +106,13 @@ class UserTest < ActiveSupport::TestCase
     ttest = u.transfers.first
     assert(ttest.grad_date.to_s == '2020-05-01')
   end
+
+  test 'can have zero or more departments as submitter' do
+    yo = users(:yo)
+    admin = users(:admin)
+    bad = users(:bad)
+    assert(yo.departments.count == 2)
+    assert(admin.departments.count == 1)
+    assert(bad.departments.count == 0)
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need a Submitter model to know which Users can submit Transfers
for various Departments.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETS-71

#### How this addresses that need:

Adds Submitter model to join Transfers and Departments.

#### Side effects of this change:

New database migration.

#### Includes new or updated dependencies?
NO
