### PR TITLE
ETS-40 Add transfer submitter role

### DIFF
--- a/app/controllers/admin/transfers_controller.rb
+++ b/app/controllers/admin/transfers_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class TransfersController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -1,0 +1,28 @@
+class TransferController < ApplicationController
+  before_action :require_user
+  before_action :authenticate_user!
+  load_and_authorize_resource
+  protect_from_forgery with: :exception
+
+  def new
+    @transfer = Transfer.new
+    @transfer.user = current_user
+  end
+
+  def show
+    @transfer = Transfer.find(params[:id])
+  end
+
+  private
+
+  def require_user
+    return if current_user
+    # Do NOT use ENV['FAKE_AUTH_ENABLED'] directly! Use the config. It performs
+    # an additional check to make sure we are not on the production server.
+    if Rails.configuration.fake_auth_enabled
+      redirect_to user_developer_omniauth_authorize_path
+    else
+      redirect_to user_saml_omniauth_authorize_path
+    end
+  end
+end

--- a/app/dashboards/transfer_dashboard.rb
+++ b/app/dashboards/transfer_dashboard.rb
@@ -1,0 +1,75 @@
+require "administrate/base_dashboard"
+
+class TransferDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    user: Field::BelongsTo,
+    department: Field::BelongsTo,
+    files_attachments: Field::HasMany.with_options(class_name: "ActiveStorage::Attachment"),
+    files_blobs: Field::HasMany.with_options(class_name: "ActiveStorage::Blob"),
+    id: Field::Number,
+    grad_date: Field::Date,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+  user
+  department
+  files_attachments
+  files_blobs
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+  user
+  department
+  files_attachments
+  files_blobs
+  id
+  grad_date
+  created_at
+  updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+  user
+  department
+  files_attachments
+  files_blobs
+  grad_date
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how transfers are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(transfer)
+  #   "Transfer ##{transfer.id}"
+  # end
+end

--- a/app/helpers/transfer_helper.rb
+++ b/app/helpers/transfer_helper.rb
@@ -1,0 +1,2 @@
+module TransferHelper
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -29,6 +29,13 @@ class Ability
     can :read, Thesis, user_id: @user.id
   end
 
+  # Users who can submit and view transfers.
+  def transfer_submitter
+    basic
+    can :create, Transfer
+    can :read, Transfer, user_id: @user.id
+  end
+
   # Library staff who process the thesis queue. They should be able to use the
   # submissions processing queue page and whatever functionality it exposes,
   # but not the admin dashboards.
@@ -40,6 +47,7 @@ class Ability
     can :process_theses, Thesis
     can :stats, Thesis
     can :read, Thesis
+    can :read, Transfer
   end
 
   # Library staff who can use the admin dashboards (which includes operations
@@ -47,6 +55,8 @@ class Ability
   def thesis_admin
     processor
     can %i[create update], Thesis
+    can :create, Transfer
+    can :read, Transfer
     can :administrate, Admin
   end
 end

--- a/app/views/transfer/new.html.erb
+++ b/app/views/transfer/new.html.erb
@@ -1,0 +1,1 @@
+<%= content_for(:title, "Thesis Transfer Submission | MIT Libraries") %>

--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -1,0 +1,1 @@
+<%= content_for(:title, "Thesis Transfer Submission | MIT Libraries") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     resources :departments
     resources :rights
     resources :theses
+    resources :transfers
 
     root to: "theses#index"
   end
@@ -27,6 +28,8 @@ Rails.application.routes.draw do
   devise_for :users, :controllers => {
     :omniauth_callbacks => 'users/omniauth_callbacks'
   }
+
+  resources :transfer, only: [:new, :create, :show]
 
   devise_scope :user do
     get 'sign_in', to: 'devise/sessions#new', as: :user_session

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -4,7 +4,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~ the submission system ~~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'new prompts for login' do
     get '/thesis/new'
-    assert_response :redirect
+    assert_redirected_to '/users/auth/saml'
   end
 
   test 'new when logged in' do

--- a/test/controllers/transfer_controller_test.rb
+++ b/test/controllers/transfer_controller_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class TransferControllerTest < ActionDispatch::IntegrationTest
+  test 'new redirects to login' do
+    get '/transfer/new'
+    assert_response :redirect
+    assert_redirected_to '/users/auth/saml'
+  end
+
+  test 'transfer submitters can submit a transfer' do
+    sign_in users(:transfer_submitter)
+    get '/transfer/new'
+    assert_response :success
+  end
+
+  test 'thesis admins can submit a transfer' do
+    sign_in users(:thesis_admin)
+    get '/transfer/new'
+    assert_response :success
+  end
+
+  test 'login redirect when anonymous user tries to submit or view a transfer' do
+    get '/transfer/new'
+    assert_redirected_to '/users/auth/saml'
+    get "/transfer/#{transfers(:valid).id}"
+    assert_redirected_to '/users/auth/saml'
+  end
+
+  test 'basic user cannot submit or view a transfer' do
+    sign_in users(:basic)
+    assert_raises CanCan::AccessDenied do
+      get "/transfer/new"
+    end
+    sign_in users(:basic)
+    assert_raises CanCan::AccessDenied do
+      get "/transfer/#{transfers(:valid).id}"
+    end
+  end
+
+  test 'processor cannot submit a transfer' do
+    sign_in users(:processor)
+    assert_raises CanCan::AccessDenied do
+      get "/transfer/new"
+    end
+  end
+
+  test 'transfer submitter can view their own transfer' do
+    sign_in users(:transfer_submitter)
+    get "/transfer/#{transfers(:valid).id}"
+    assert_response :success
+  end
+
+  test 'transfer submitter cannot view transfers they did not submit' do
+    sign_in users(:transfer_submitter)
+    assert_raises CanCan::AccessDenied do
+      get "/transfer/#{transfers(:alsovalid).id}"
+    end
+  end
+
+  test 'thesis admin can view any transfer' do
+    sign_in users(:thesis_admin)
+    get "/transfer/#{transfers(:valid).id}"
+    assert_response(:success)
+    get "/transfer/#{transfers(:alsovalid).id}"
+    assert_response(:success)
+  end
+
+  test 'processor can view any transfer' do
+    sign_in users(:processor)
+    get "/transfer/#{transfers(:valid).id}"
+    assert_response(:success)
+    get "/transfer/#{transfers(:alsovalid).id}"
+    assert_response(:success)
+  end
+end

--- a/test/fixtures/submitters.yml
+++ b/test/fixtures/submitters.yml
@@ -1,13 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: yo
+  user: transfer_submitter
   department: one
 
 two:
-  user: yo
+  user: transfer_submitter
   department: two
 
 three:
-  user: admin
+  user: thesis_admin
   department: two

--- a/test/fixtures/transfers.yml
+++ b/test/fixtures/transfers.yml
@@ -12,7 +12,12 @@
 valid:
   department: one
   grad_date: 2020-05-01
-  user: yo
+  user: transfer_submitter
+
+alsovalid:
+  department: one
+  grad_date: 2020-05-01
+  user: thesis_admin
 
 baduser:
   department: one

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -52,6 +52,13 @@ processor:
   given_name: 'Processor'
   surname: 'Robot'
 
+transfer_submitter:
+  uid: 'transfer_submitter_id'
+  email: 'transfer@example.com'
+  role: 'transfer_submitter'
+  given_name: 'Terry'
+  surname: 'Ransfer'
+
 thesis_admin:
   uid: 'thesis_admin_id'
   email: 'thesis_admin@example.com'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -101,18 +101,18 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'can access transfer from user' do
-    u = User.last
-    assert(u.name == 'Yobot, Yo (yo@example.com)')
+    u = users(:transfer_submitter)
+    assert(u.name == 'Ransfer, Terry (transfer@example.com)')
     ttest = u.transfers.first
     assert(ttest.grad_date.to_s == '2020-05-01')
   end
 
   test 'can have zero or more departments as submitter' do
-    yo = users(:yo)
-    admin = users(:admin)
+    transfer_submitter = users(:transfer_submitter)
+    thesis_admin = users(:thesis_admin)
     bad = users(:bad)
-    assert(yo.departments.count == 2)
-    assert(admin.departments.count == 1)
+    assert(transfer_submitter.departments.count == 2)
+    assert(thesis_admin.departments.count == 1)
     assert(bad.departments.count == 0)
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

The Ability model needs a submitter role to control who has
permission to deposit and manage transfers.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETS-40

#### How this addresses that need:

This adds the transfer submitter role, along with the preliminary
TransferController with create and show methods. (Additional logic
will be added to the controller as needed.)

The Ability model now includes the following additional permissions:
* thesis_admin can create transfers and view any transfer
* transfer_submitter can create transfers and view their own transfers
* processor can view any transfer

#### Side effects of this change:

* Generated the transfer dashboard and created a couple of stubbed
transfer views.
* Minor changes to our test fixtures to make the controller tests
clearer.
* Updated a thesis controller test assertion to redirect to the
login URL specifically, instead of redirecting anywhere.

#### Todo:
- [x] Tests
- [x] Documentation
- [x] Stakeholder approval

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
