### PR TITLE
Adds a note field to the Transfer model

### DIFF
--- a/app/models/submitter.rb
+++ b/app/models/submitter.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: submitters
+#
+#  id            :integer          not null, primary key
+#  user_id       :integer          not null
+#  department_id :integer          not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 class Submitter < ApplicationRecord
   belongs_to :user
   belongs_to :department

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -8,6 +8,7 @@
 #  grad_date     :date             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  note          :text
 #
 class Transfer < ApplicationRecord
   belongs_to :user

--- a/db/migrate/20201216104412_add_note_to_transfers.rb
+++ b/db/migrate/20201216104412_add_note_to_transfers.rb
@@ -1,0 +1,5 @@
+class AddNoteToTransfers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :transfers, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_213534) do
+ActiveRecord::Schema.define(version: 2020_12_16_104412) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_213534) do
     t.date "grad_date", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "note"
     t.index ["department_id"], name: "index_transfers_on_department_id"
     t.index ["user_id"], name: "index_transfers_on_user_id"
   end

--- a/test/fixtures/submitters.yml
+++ b/test/fixtures/submitters.yml
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: submitters
+#
+#  id            :integer          not null, primary key
+#  user_id       :integer          not null
+#  department_id :integer          not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:

--- a/test/fixtures/transfers.yml
+++ b/test/fixtures/transfers.yml
@@ -8,10 +8,12 @@
 #  grad_date     :date             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  note          :text
 #
 valid:
   department: one
   grad_date: 2020-05-01
+  note: 'Let me tell you a thing or two about these files. For one, they are all artisanally crafted by very skilled pigeons. Well, except for the one that we found under a cupboard in the back of the lab. No one knows why it exists - but every time we process the data without it, the laptop starts smoking. Seriously.'
   user: transfer_submitter
 
 alsovalid:

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -8,6 +8,7 @@
 #  grad_date     :date             not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
+#  note          :text
 #
 require 'test_helper'
 
@@ -46,6 +47,12 @@ class TransferTest < ActiveSupport::TestCase
     @transfer.graduation_month = nil
     @transfer.graduation_year = nil
     assert @transfer.invalid?
+  end
+
+  test 'valid even without a note' do
+    assert @transfer.valid?
+    @transfer.note = nil
+    assert @transfer.valid?
   end
 
   test 'grad year should be vaguely reasonable' do


### PR DESCRIPTION
## Why are these changes being introduced:

* The latest data model calls for a note field to be available - but not
  required - for Transfer records.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETS-78

## How does this address that need:

* This adds a note field to the Transfer model, and updates one of the
  fixtures to contain a long (over 255 characters) note. It also
  includes relevant tests to make sure that a Transfer is considered
  valid without one.
* The models have also been annotated using `bundle exec annotate
  --models`

## Document any side effects to this change:

* Generating the annotations has added them for the Submitter model,
  which previously did not have any.

## Requires Database Migrations?
YES

## Includes new or updated dependencies?
NO
