### PR TITLE
SAML config now supports multiple signing cert

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -55,6 +55,7 @@ Devise.setup do |config|
                     idp_cert_fingerprint: idp_metadata[:idp_cert_fingerprint],
                     idp_sso_target_url: ENV['IDP_SSO_URL'],
                     idp_cert: idp_metadata[:idp_cert],
+                    idp_cert_multi: idp_metadata[:idp_cert_multi],
                     certificate: Base64.strict_decode64(ENV['SP_CERTIFICATE']),
                     private_key: Base64.strict_decode64(ENV['SP_PRIVATE_KEY']),
                     issuer: ENV['SP_ENTITY_ID'],
@@ -68,7 +69,7 @@ Devise.setup do |config|
                                 want_assertions_encrypted: true,
                                 metadata_signed: true,
                                 embed_sign: false,
-                                digest_method: XMLSecurity::Document::SHA1,
-                                signature_method: XMLSecurity::Document::RSA_SHA1 }
+                                digest_method: XMLSecurity::Document::RSA_SHA256,
+                                signature_method: XMLSecurity::Document::RSA_SHA256 }
   end
 end


### PR DESCRIPTION
**Why are these changes being introduced:**

* IST recently changed the IdP metadata to include multiple signing
  certs for the main IdP. SAML exposes single and multiple certs via
  distinct metadata elements rather than just providing single certs as
  an array of 1.

**Relevant ticket(s):**

* https://mitlibraries.atlassian.net/browse/ETS-79

How does this address that need:

* This looks for either single or multiple certs and passes it all to
  our SP
* Also updates the signing algorithm to RSA_256

**Testing suggestions:** 

The best way to test this is to deploy `main` to heroku staging with the settings for IdP metadata matching our official docs ( https://touchstone.mit.edu/metadata/MIT-metadata.xml ) and separately with the slim version ( https://touchstone.mit.edu/metadata/idp.mit.edu-metadata.xml ). That should show a failure for the official and success for the slim version.

However, if you deploy this branch to staging, both versions of the IdP metadata should work.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO


#### Includes new or updated dependencies?

NO
