### PR TITLE
Updates mentions of terms for February 2021

### DIFF
--- a/app/views/receipt_mailer/receipt_email.html.erb
+++ b/app/views/receipt_mailer/receipt_email.html.erb
@@ -6,7 +6,7 @@ your <%= @thesis.graduation_month %> <%=
 @thesis.graduation_year %> thesis "<%= @thesis.title %>" to the MIT Libraries.
 </p>
 
-<p>If you submitted a May or September 2020 thesis, please note that only the
+<p>If you submitted a February 2021 thesis, please note that only the
 ProQuest form, title page, and abstract should have been submitted here. The
 actual thesis should go directly to your department. For degree periods prior to
 May 2020, we accept all electronic copies via this form.</p>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -6,7 +6,7 @@
     <h3 class="title title-page">Preserve and share your scholarship</h3>
 
     <div class="well">
-      <h4>May or September 2020 degree list candidates</h4>
+      <h4>February 2021 degree list candidates</h4>
 
       <ul>
         <li>Your thesis must be submitted electronically to your department or

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <div class="well">
-      <h4>May or September 2020 degree list candidates</h4>
+      <h4>February 2021 degree list candidates</h4>
 
       <ul>
         <li>Please submit the PDF of your thesis directly to your department. 
@@ -116,7 +116,7 @@
                       'aria-describedby': 'thesis_files_ids-hint' },
         label: 'Files to upload',
         required: true,
-        hint: 'Please provide an exact PDF duplicate of your paper thesis (except May or September 2020 - see instructions at top of page).',
+        hint: 'Please provide an exact PDF duplicate of your paper thesis (except May or September 2020, or February 2021 - see instructions at top of page).',
         hint_html: { id: 'thesis_files_ids-hint' }  %>
 
     <div class='field-wrap'>

--- a/test/fixtures/receipt_mailer/receipt_email
+++ b/test/fixtures/receipt_mailer/receipt_email
@@ -15,7 +15,7 @@ either your ProQuest form, title page, and abstract or the electronic version of
 your September 2017 thesis "MyString" to the MIT Libraries.
 </p>
 
-<p>If you submitted a May or September 2020 thesis, please note that only the
+<p>If you submitted a February 2021 thesis, please note that only the
 ProQuest form, title page, and abstract should have been submitted here. The
 actual thesis should go directly to your department. For degree periods prior to
 May 2020, we accept all electronic copies via this form.</p>


### PR DESCRIPTION
# This is a PR against `main`, not `1.x`

The "real" PR is #579 .

This updates our references to recent terms to include "February 2021" - in some cases replacing "May or September 2020", and in some cases adding it to the list. A bit more details are in the commit message.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
