### PR TITLE
Adds models for holds and hold_sources

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -15,8 +15,13 @@
 #  updated_at       :datetime         not null
 #
 class Hold < ApplicationRecord
-	belongs_to :thesis
-	belongs_to :hold_source
+  belongs_to :thesis
+  belongs_to :hold_source
 
-	enum status: [ :active, :expired, :released ]
+  enum status: [ :active, :expired, :released ]
+
+  validates :date_requested, presence: true
+  validates :date_start, presence: true
+  validates :date_end, presence: true
+  validates :status, presence: true
 end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: holds
+#
+#  id               :integer          not null, primary key
+#  thesis_id        :integer          not null
+#  date_requested   :date             not null
+#  date_start       :date             not null
+#  date_end         :date             not null
+#  hold_source_id   :integer          not null
+#  case_number      :string
+#  status           :integer          not null
+#  processing_notes :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+class Hold < ApplicationRecord
+	belongs_to :thesis
+	belongs_to :hold_source
+
+	enum status: [ :active, :expired, :released ]
+end

--- a/app/models/hold_source.rb
+++ b/app/models/hold_source.rb
@@ -8,5 +8,7 @@
 #  updated_at :datetime         not null
 #
 class HoldSource < ApplicationRecord
-	has_many :holds
+  has_many :holds
+
+  validates :source, presence: true
 end

--- a/app/models/hold_source.rb
+++ b/app/models/hold_source.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: hold_sources
+#
+#  id         :integer          not null, primary key
+#  source     :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class HoldSource < ApplicationRecord
+	has_many :holds
+end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -23,6 +23,9 @@ class Thesis < ApplicationRecord
   has_many :department_theses
   has_many :departments, through: :department_theses
 
+  has_many :holds
+  has_many :hold_sources, through: :holds
+
   has_many_attached :files
 
   attr_accessor :graduation_year, :graduation_month

--- a/db/migrate/20210111000000_create_holds.rb
+++ b/db/migrate/20210111000000_create_holds.rb
@@ -1,0 +1,22 @@
+class CreateHolds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :hold_sources do |t|
+      t.text :source, null: false
+
+      t.timestamps
+    end
+
+    create_table :holds do |t|
+      t.belongs_to :thesis, null: false, foreign_key: true
+      t.date :date_requested, null: false
+      t.date :date_start, null: false
+      t.date :date_end, null: false
+      t.belongs_to :hold_source, null: false, foreign_key: true
+      t.string :case_number, null: true
+      t.integer :status, null: false
+      t.text :processing_notes, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_104412) do
+ActiveRecord::Schema.define(version: 2021_01_11_000000) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -74,6 +74,27 @@ ActiveRecord::Schema.define(version: 2020_12_16_104412) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "hold_sources", force: :cascade do |t|
+    t.text "source", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "holds", force: :cascade do |t|
+    t.integer "thesis_id", null: false
+    t.date "date_requested", null: false
+    t.date "date_start", null: false
+    t.date "date_end", null: false
+    t.integer "hold_source_id", null: false
+    t.string "case_number"
+    t.integer "status", null: false
+    t.text "processing_notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["hold_source_id"], name: "index_holds_on_hold_source_id"
+    t.index ["thesis_id"], name: "index_holds_on_thesis_id"
+  end
+
   create_table "rights", force: :cascade do |t|
     t.text "statement", null: false
     t.datetime "created_at", null: false
@@ -128,6 +149,8 @@ ActiveRecord::Schema.define(version: 2020_12_16_104412) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "holds", "hold_sources"
+  add_foreign_key "holds", "theses"
   add_foreign_key "submitters", "departments"
   add_foreign_key "submitters", "users"
   add_foreign_key "transfers", "departments"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,4 +16,9 @@ Right.find_or_create_by(statement: 'Other')
 Degree.find_or_create_by(name: 'Bachelor of Science')
 Degree.find_or_create_by(name: 'Master of Business Analytics')
 
+# Create Hold Sources
+HoldSource.find_or_create_by(source: 'TLO')
+HoldSource.find_or_create_by(source: 'Vice Chancellor')
+HoldSource.find_or_create_by(source: 'VPR')
+
 Rails.logger.info('Seeding DB Complete')

--- a/test/fixtures/hold_sources.yml
+++ b/test/fixtures/hold_sources.yml
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: hold_sources
+#
+#  id         :integer          not null, primary key
+#  source     :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+tlo:
+  source: 'technology licensing office'
+
+vc:
+  source: 'vice chancellor'
+
+vpr:
+  source: 'vice president for research'

--- a/test/fixtures/holds.yml
+++ b/test/fixtures/holds.yml
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: holds
+#
+#  id               :integer          not null, primary key
+#  thesis_id        :integer          not null
+#  date_requested   :date             not null
+#  date_start       :date             not null
+#  date_end         :date             not null
+#  hold_source_id   :integer          not null
+#  case_number      :string
+#  status           :integer          not null
+#  processing_notes :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+valid:
+  thesis: with_hold
+  date_requested: 2017-09-01
+  date_start: 2017-09-01
+  date_end: 2067-12-31
+  hold_source: tlo
+  case_number: null
+  status: active
+  processing_notes: null

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -75,6 +75,17 @@ with_note:
   status: 'active'  # The default, but specified for testing purposes.
   note: 'Absolutely for sure rocket science'
 
+with_hold:
+  title: MySensitiveThesis
+  abstract: MyText
+  grad_date: 2017-09-13
+  user: yo
+  right: one
+  departments: [one]
+  degrees: [one]
+  status: 'active'
+  note: 'Something sensitive'
+
 june_2018:
   title: MyString
   abstract: MyText

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -68,13 +68,14 @@ class ThesisHelperTest < ActionView::TestCase
     # two
     # active
     # with_note
+    # with_hold
     # june_2018
     # september_2018
     # february_2019
     # june_2019
     # september_2019
 
-    expected = { "Sep 2017"=>4, "Jun 2018"=>1, "Sep 2018"=>1,
+    expected = { "Sep 2017"=>5, "Jun 2018"=>1, "Sep 2018"=>1,
                  "Feb 2019"=>1, "Jun 2019"=>1, "Sep 2019"=>1}
     assert_equal expected, grouped_theses
   end
@@ -107,7 +108,7 @@ class ThesisHelperTest < ActionView::TestCase
 
     # Expects the theses as noted in the 3 tests above to exist.
 
-    expected = { "Sep 2017"=>6, "Jun 2018"=>1, "Sep 2018"=>1,
+    expected = { "Sep 2017"=>7, "Jun 2018"=>1, "Sep 2018"=>1,
                  "Feb 2019"=>1, "Jun 2019"=>1, "Sep 2019"=>1}
     assert_equal expected, grouped_theses
   end

--- a/test/models/hold_source_test.rb
+++ b/test/models/hold_source_test.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: hold_sources
+#
+#  id         :integer          not null, primary key
+#  source     :text             not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'test_helper'
+
+class HoldSourceTest < ActiveSupport::TestCase
+  test 'valid hold source' do
+    holdsource = hold_sources(:tlo)
+    assert(holdsource.valid?)
+  end
+end

--- a/test/models/hold_source_test.rb
+++ b/test/models/hold_source_test.rb
@@ -14,4 +14,10 @@ class HoldSourceTest < ActiveSupport::TestCase
     holdsource = hold_sources(:tlo)
     assert(holdsource.valid?)
   end
+
+  test 'source is required' do
+    holdsource = hold_sources(:tlo)
+    holdsource.source = nil
+    assert(holdsource.invalid?)
+  end
 end

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -22,6 +22,39 @@ class HoldTest < ActiveSupport::TestCase
     assert(hold.valid?)
   end
 
+  test 'valid date_requested' do
+    hold = holds(:valid)
+    assert(hold.valid?)
+    hold.date_requested = nil
+    assert(hold.invalid?)
+    hold.date_requested = 'foo'
+    assert(hold.invalid?)
+    hold.date_requested = '2021-14-40'
+    assert(hold.invalid?)
+  end
+
+  test 'valid date_start' do
+    hold = holds(:valid)
+    assert(hold.valid?)
+    hold.date_start = nil
+    assert(hold.invalid?)
+    hold.date_start = 'foo'
+    assert(hold.invalid?)
+    hold.date_start = '2021-14-40'
+    assert(hold.invalid?)
+  end
+
+  test 'valid date_end' do
+    hold = holds(:valid)
+    assert(hold.valid?)
+    hold.date_end = nil
+    assert(hold.invalid?)
+    hold.date_end = 'foo'
+    assert(hold.invalid?)
+    hold.date_end = '2021-14-40'
+    assert(hold.invalid?)
+  end
+
   test 'only valid status values' do
     hold = holds(:valid)
     hold.status = "active"
@@ -33,9 +66,7 @@ class HoldTest < ActiveSupport::TestCase
     assert_raises ArgumentError do
       hold.status = "garbage"
     end
-    assert_raises ActiveRecord::NotNullViolation do
-      hold.status = nil
-      hold.save
-    end
+    hold.status = nil
+    assert(hold.invalid?)
   end
 end

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: holds
+#
+#  id               :integer          not null, primary key
+#  thesis_id        :integer          not null
+#  date_requested   :date             not null
+#  date_start       :date             not null
+#  date_end         :date             not null
+#  hold_source_id   :integer          not null
+#  case_number      :string
+#  status           :integer          not null
+#  processing_notes :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+require 'test_helper'
+
+class HoldTest < ActiveSupport::TestCase
+  test 'valid hold' do
+    hold = holds(:valid)
+    assert(hold.valid?)
+  end
+
+  test 'only valid status values' do
+    hold = holds(:valid)
+    hold.status = "active"
+    assert(hold.valid?)
+    hold.status = "expired"
+    assert(hold.valid?)
+    hold.status = "released"
+    assert(hold.valid?)
+    assert_raises ArgumentError do
+      hold.status = "garbage"
+    end
+    assert_raises ActiveRecord::NotNullViolation do
+      hold.status = nil
+      hold.save
+    end
+  end
+end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -184,4 +184,18 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.graduation_month = 'December'
     assert thesis.invalid?
   end
+
+  test 'a thesis may have a hold' do
+    thesis = theses(:with_hold)
+    assert thesis.holds.count == 1
+
+    thesis = theses(:one)
+    assert thesis.holds.count == 0
+  end
+
+  test 'thesis holds have readable attributes' do
+    thesis = theses(:with_hold)
+    assert thesis.holds.first.hold_source.source == 'technology licensing office'
+    assert thesis.holds.first.status = 'active'
+  end
 end


### PR DESCRIPTION
This adds models for Holds and Hold_Sources, along with basic tests.

The details of these models are derived from the 1.2 data model that can be found linked to the Jira ticket in this PR.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
