### PR TITLE
ETS-88 Fix generated dashboard UI for viewing transfers

### DIFF
--- a/app/dashboards/transfer_dashboard.rb
+++ b/app/dashboards/transfer_dashboard.rb
@@ -10,10 +10,13 @@ class TransferDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
     department: Field::BelongsTo,
-    files_attachments: Field::HasMany.with_options(class_name: "ActiveStorage::Attachment"),
-    files_blobs: Field::HasMany.with_options(class_name: "ActiveStorage::Blob"),
+    files_attachments: AttachmentField,
     id: Field::Number,
-    grad_date: Field::Date,
+    grad_date: Field::DateTime.with_options(
+      format: "%Y %B"
+    ),
+    graduation_month: Field::Number,
+    graduation_year: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,8 +29,9 @@ class TransferDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
   user
   department
+  grad_date
+  created_at
   files_attachments
-  files_blobs
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -36,7 +40,6 @@ class TransferDashboard < Administrate::BaseDashboard
   user
   department
   files_attachments
-  files_blobs
   id
   grad_date
   created_at
@@ -49,8 +52,6 @@ class TransferDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
   user
   department
-  files_attachments
-  files_blobs
   grad_date
   ].freeze
 

--- a/app/fields/attachment_field.rb
+++ b/app/fields/attachment_field.rb
@@ -1,0 +1,7 @@
+require "administrate/field/base"
+
+class AttachmentField < Administrate::Field::Base
+  def attachments
+    data
+  end
+end

--- a/app/views/fields/attachment_field/_index.html.erb
+++ b/app/views/fields/attachment_field/_index.html.erb
@@ -1,0 +1,5 @@
+<% if field.attachments.count > 1 %>
+  <%= field.attachments.count %> attachments
+<% elsif field.attachments.count == 1 %>
+  1 attachment
+<% end %>

--- a/app/views/fields/attachment_field/_show.html.erb
+++ b/app/views/fields/attachment_field/_show.html.erb
@@ -1,0 +1,3 @@
+<% field.attachments.each do |attachment| %>
+  <%= link_to(attachment.filename, url_for(attachment)) %>
+<% end %>

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -280,4 +280,52 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     degree.reload
     assert_equal 'Master of Fine Arts', degree.name
   end
+
+  test 'thesis admins can access transfer panel' do 
+    mock_auth(users(:thesis_admin))
+    get "/admin/transfers"
+    assert_response :success
+  end
+
+  test 'users with admin rights can access transfer panel' do
+    mock_auth(users(:admin))
+    get "/admin/transfers"
+    assert_response :success
+  end
+
+  test 'non-admin users cannot access transfer dashboard' do
+    mock_auth(users(:basic))
+    get "/admin/transfers"
+    assert_response :redirect
+    mock_auth(users(:processor))
+    get "/admin/transfers"
+    assert_response :redirect
+    mock_auth(users(:transfer_submitter))
+    get "/admin/transfers"
+    assert_response :redirect
+  end
+
+  test 'transfer dashboard renders for admin users' do
+    mock_auth(users(:admin))
+    get "/admin/transfers"
+    assert_response :success
+  end
+
+  test 'transfer dashboard renders for thesis admins' do
+    mock_auth(users(:thesis_admin))
+    get "/admin/transfers"
+    assert_response :success
+  end
+
+  test 'thesis admins can view transfer details through dashboard' do
+    mock_auth(users(:thesis_admin))
+    get "/admin/transfers/#{transfers(:valid).id}"
+    assert_response :success
+  end
+
+  test 'users with admin rights can view transfer details through dashboard' do
+    mock_auth(users(:admin))
+    get "/admin/transfers/#{transfers(:valid).id}"
+    assert_response :success
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

* The UI generated by the administrate gem for viewing transfers is broken
due to missing templates for file attachments and blobs.
* The gem doesn't support ActiveStorage, so we need to define custom
fields as described here: https://github.com/thoughtbot/administrate/blob/master/docs/adding_custom_field_types.md

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETS-88
* https://mitlibraries.atlassian.net/browse/ETS-65

#### How this addresses that need:

* Defines custom fields for attachments.
* Removes blob as an attribute in all transfer templates to reduce
redundancy.
* Removes attachments and blobs as form attributes, since that doesn't
appear to work anyway.
* Changes grad date format in show page to %Y %B.
* Renders grad date and transfer date in index page.

#### Side effects of this change:

I chose not to define a custom field for blobs, as I couldn't think of a
scenario in which we would want separate fields for blobs and attachments
in the UI. However, this might change if we want to allow users to create
and edit full transfers through the admin dashboard.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
