### PR TITLE
Adds Advisor model, dashboard, and tests

### DIFF
--- a/app/controllers/admin/advisors_controller.rb
+++ b/app/controllers/admin/advisors_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class AdvisorsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/advisor_dashboard.rb
+++ b/app/dashboards/advisor_dashboard.rb
@@ -1,0 +1,65 @@
+require "administrate/base_dashboard"
+
+class AdvisorDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    theses: Field::HasMany,
+    id: Field::Number,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+  name
+  theses
+  id
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+  theses
+  id
+  name
+  created_at
+  updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+  theses
+  name
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how advisors are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(advisor)
+    "Advisor #{advisor.name}"
+  end
+end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -38,6 +38,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     processor_note: Field::Text,
     metadata_complete: Field::Boolean,
     holds: Field::HasMany,
+    advisors: Field::HasMany,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -66,6 +67,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     updated_at
     departments
     degrees
+    advisors
     holds
     status
     publication_status
@@ -87,6 +89,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     right
     departments
     degrees
+    advisors
     title
     abstract
     status

--- a/app/models/advisor.rb
+++ b/app/models/advisor.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: advisors
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Advisor < ApplicationRecord
+  has_many :advisor_theses
+  has_many :theses, through: :advisor_theses
+
+  validates :name, presence: true
+end

--- a/app/models/advisor_thesis.rb
+++ b/app/models/advisor_thesis.rb
@@ -1,0 +1,11 @@
+# == Schema Information
+#
+# Table name: advisor_theses
+#
+#  thesis_id  :integer
+#  advisor_id :integer
+#
+class AdvisorThesis < ApplicationRecord
+  belongs_to :thesis
+  belongs_to :advisor
+end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -2,16 +2,20 @@
 #
 # Table name: theses
 #
-#  id         :integer          not null, primary key
-#  title      :string           not null
-#  abstract   :text             not null
-#  grad_date  :date             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :integer
-#  right_id   :integer
-#  status     :string           default("active")
-#  note       :text
+#  id                 :integer          not null, primary key
+#  title              :string
+#  abstract           :text
+#  grad_date          :date             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :integer
+#  right_id           :integer
+#  status             :string           default("active")
+#  processor_note     :text
+#  author_note        :text
+#  files_complete     :boolean          default(FALSE), not null
+#  metadata_complete  :boolean          default(FALSE), not null
+#  publication_status :string           default("Not ready for publication"), not null
 #
 
 class Thesis < ApplicationRecord
@@ -25,6 +29,9 @@ class Thesis < ApplicationRecord
 
   has_many :holds
   has_many :hold_sources, through: :holds
+
+  has_many :advisor_theses
+  has_many :advisors, through: :advisor_theses
 
   has_many_attached :files
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   # For details see http://guides.rubyonrails.org/routing.html
   namespace :admin do
     resources :users
+    resources :advisors
     resources :degrees
     resources :departments
     resources :holds

--- a/db/migrate/20210125212125_create_advisors_again.rb
+++ b/db/migrate/20210125212125_create_advisors_again.rb
@@ -1,0 +1,14 @@
+class CreateAdvisorsAgain < ActiveRecord::Migration[6.0]
+  def change
+    create_table :advisors do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    create_table :advisor_theses, id: false do |t|
+      t.belongs_to :thesis, index: true
+      t.belongs_to :advisor, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_20_213811) do
+ActiveRecord::Schema.define(version: 2021_01_25_212125) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -31,6 +31,19 @@ ActiveRecord::Schema.define(version: 2021_01_20_213811) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "advisor_theses", id: false, force: :cascade do |t|
+    t.integer "thesis_id"
+    t.integer "advisor_id"
+    t.index ["advisor_id"], name: "index_advisor_theses_on_advisor_id"
+    t.index ["thesis_id"], name: "index_advisor_theses_on_thesis_id"
+  end
+
+  create_table "advisors", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "degree_theses", id: false, force: :cascade do |t|

--- a/test/fixtures/advisors.yml
+++ b/test/fixtures/advisors.yml
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: advisors
+#
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+first:
+  name: Addy McAdvisor
+
+second:
+  name: Viola McAdvisor

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -2,16 +2,20 @@
 #
 # Table name: theses
 #
-#  id         :integer          not null, primary key
-#  title      :string           not null
-#  abstract   :text             not null
-#  grad_date  :date             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :integer
-#  right_id   :integer
-#  status     :string           default("active")
-#  note       :text
+#  id                 :integer          not null, primary key
+#  title              :string
+#  abstract           :text
+#  grad_date          :date             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :integer
+#  right_id           :integer
+#  status             :string           default("active")
+#  processor_note     :text
+#  author_note        :text
+#  files_complete     :boolean          default(FALSE), not null
+#  metadata_complete  :boolean          default(FALSE), not null
+#  publication_status :string           default("Not ready for publication"), not null
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -24,6 +28,7 @@ one:
   right: one
   departments: [one]
   degrees: [one]
+  advisors: [first]
 
 two:
   title:  Can apparent superluminal neutrino speeds be explained as a quantum weak measurement?

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -114,6 +114,7 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
                           right_id: Right.first.id,
                           department_ids: [ Department.first.id ],
                           degree_ids: [ Degree.first.id ],
+                          advisor_ids: [ Advisor.first.id ],
                           title: 'yoyos are cool',
                           abstract: 'We discovered it with science',
                           graduation_month: 'June',

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -149,6 +149,18 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert !Thesis.exists?(thesis_id)
   end
 
+  test 'can assign advisors to theses via thesis panel' do
+    needle = advisors(:second)
+    mock_auth(users(:thesis_admin))
+    thesis = Thesis.first
+    assert_equal thesis.advisors.count, 0
+    patch admin_thesis_path(thesis),
+      params: { thesis: { advisor_ids: [needle.id] } }
+    thesis.reload
+    assert_equal thesis.advisors.count, 1
+    assert_equal needle.name, thesis.advisors.first.name
+  end
+
   test 'accessing users panel works with admin rights' do
     mock_auth(users(:admin))
     get '/admin/users'
@@ -328,6 +340,52 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     mock_auth(users(:admin))
     get "/admin/transfers/#{transfers(:valid).id}"
     assert_response :success
+  end
+
+  # Advisors
+  test 'accessing advisors panel does not work with basic rights' do
+    mock_auth(users(:basic))
+    get '/admin/advisors'
+    assert_response :redirect
+    mock_auth(users(:processor))
+    get '/admin/advisors'
+    assert_response :redirect
+  end
+
+  test 'accessing advisors panel as an admin user works' do
+    mock_auth(users(:admin))
+    get '/admin/advisors'
+    assert_response :success
+    assert_equal('/admin/advisors', path)
+  end
+
+  test 'accessing advisors panel as a thesis_admin user works' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/advisors'
+    assert_response :success
+    assert_equal('/admin/advisors', path)
+  end
+
+  test 'can edit advisors through admin dashboard' do
+    needle = 'Another Advisor'
+    mock_auth(users(:thesis_admin))
+    advisor = Advisor.first
+    assert_not_equal needle, advisor.name
+    patch admin_advisor_path(advisor),
+      params: { advisor: { name: needle } }
+    advisor.reload
+    assert_equal needle, advisor.name
+  end
+
+  test 'can assign theses to advisors via advisor form' do
+    needle = theses(:two)
+    mock_auth(users(:thesis_admin))
+    advisor = Advisor.first
+    assert_not_equal needle.title, advisor.theses.first.title
+    patch admin_advisor_path(advisor),
+      params: { advisor: { thesis_ids: [needle.id] } }
+    advisor.reload
+    assert_equal needle.title, advisor.theses.first.title
   end
 
   # Holds

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -2,16 +2,20 @@
 #
 # Table name: theses
 #
-#  id         :integer          not null, primary key
-#  title      :string           not null
-#  abstract   :text             not null
-#  grad_date  :date             not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :integer
-#  right_id   :integer
-#  status     :string           default("active")
-#  note       :text
+#  id                 :integer          not null, primary key
+#  title              :string
+#  abstract           :text
+#  grad_date          :date             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :integer
+#  right_id           :integer
+#  status             :string           default("active")
+#  processor_note     :text
+#  author_note        :text
+#  files_complete     :boolean          default(FALSE), not null
+#  metadata_complete  :boolean          default(FALSE), not null
+#  publication_status :string           default("Not ready for publication"), not null
 #
 
 require 'test_helper'
@@ -34,6 +38,25 @@ class ThesisTest < ActiveSupport::TestCase
   test 'valid without abstract' do
     thesis = theses(:one)
     thesis.abstract = nil
+    assert thesis.valid?
+  end
+
+  test 'valid without advisor' do
+    thesis = theses(:two)
+    assert_equal 0, thesis.advisors.count
+    assert thesis.valid?
+  end
+
+  test 'valid with one advisor' do
+    thesis = theses(:one)
+    assert_equal 1, thesis.advisors.count
+    assert thesis.valid?
+  end
+
+  test 'can have multiple advisors' do
+    thesis = theses(:one)
+    thesis.advisors = [advisors(:first),advisors(:second)]
+    assert_equal 2, thesis.advisors.count
     assert thesis.valid?
   end
 


### PR DESCRIPTION
This adds the Advisor model called for in the latest data model - via a two-way link table to Thesis records. There is also a new admin dashboard for this model.

There is not currently a dashboard for the actual Advisor_Thesis link table. If that is specifically needed as well, I can add it. The relationship can be managed via either Thesis or Advisor records (and I've added tests to confirm this behavior).

#### Ticket

https://mitlibraries.atlassian.net/browse/ETS-95

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
