### PR TITLE
Adds fields to active_storage_attachment

### DIFF
--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -26,7 +26,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     graduation_year: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    files: FileField,
+    files: AttachmentField,
     files_complete: Field::Boolean,
     status: Field::Select.with_options(
       collection: Thesis::STATUS_OPTIONS,

--- a/app/fields/file_field.rb
+++ b/app/fields/file_field.rb
@@ -1,7 +1,0 @@
-require 'administrate/field/base'
-
-class FileField < Administrate::Field::Base
-  def files
-    data.record.files
-  end
-end

--- a/app/models/active_storage_attachment_extension.rb
+++ b/app/models/active_storage_attachment_extension.rb
@@ -1,0 +1,13 @@
+# This is necessary for the enum (or for any model relationships we want to
+# define). We can access the fields we want to extend directly with just the
+# database migration, but this allows for the enum which should be convenient
+# over time to ensure our data only contains states we are expecting.
+
+module ActiveStorageAttachmentExtension
+  extend ActiveSupport::Concern
+
+  included do
+    enum purpose: [:thesis_pdf, :thesis_source, :thesis_supplementary_file,
+                   :proquest_form, :signature_page]
+  end
+end

--- a/app/views/fields/attachment_field/_show.html.erb
+++ b/app/views/fields/attachment_field/_show.html.erb
@@ -1,3 +1,8 @@
 <% field.attachments.each do |attachment| %>
-  <%= link_to(attachment.filename, url_for(attachment)) %>
+  <ul>
+    <li>Link: <%= link_to(attachment.filename, url_for(attachment)) %></li>
+    <li>Purpose: <%= attachment.purpose %></li>
+    <li>Description: <%= attachment.description %></li>
+  </ul>
+  <hr />
 <% end %>

--- a/app/views/fields/file_field/_show.html.erb
+++ b/app/views/fields/file_field/_show.html.erb
@@ -1,3 +1,0 @@
-<% field.files.each do |file| %>
-  <%= link_to(file.filename, url_for(file)) %>
-<% end %>

--- a/app/views/thesis/_thesis.html.erb
+++ b/app/views/thesis/_thesis.html.erb
@@ -38,7 +38,12 @@
           <div class="files-list">
             <% if thesis.files.attached? %>
               <% thesis.files.each do |file| %>
-                 <%= link_to(file.filename, url_for(file)) %>
+                <ul>
+                  <li>Link: <%= link_to(file.filename, url_for(file)) %></li>
+                  <li>Purpose: <%= file.purpose %></li>
+                  <li>Description: <%= file.description %></li>
+                </ul>
+                <hr />
               <% end %>
             <% else %>
               No files attached

--- a/config/initializers/active_storage_attachment_extension.rb
+++ b/config/initializers/active_storage_attachment_extension.rb
@@ -1,0 +1,4 @@
+# Ensures this module is included any time ActiveStorage class reloads
+Rails.configuration.to_prepare do
+  ActiveStorage::Attachment.include ActiveStorageAttachmentExtension
+end

--- a/db/migrate/20210125145505_extend_active_storage_for_thesis_types.rb
+++ b/db/migrate/20210125145505_extend_active_storage_for_thesis_types.rb
@@ -1,0 +1,6 @@
+class ExtendActiveStorageForThesisTypes < ActiveRecord::Migration[6.0]
+  def change
+    add_column :active_storage_attachments, :description, :text, null: true
+    add_column :active_storage_attachments, :purpose, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2021_01_25_212125) do
     t.integer "record_id", null: false
     t.integer "blob_id", null: false
     t.datetime "created_at", null: false
+    t.text "description"
+    t.integer "purpose"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end

--- a/test/integration/files_test.rb
+++ b/test/integration/files_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class FilesIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+    @transfer_params = {
+      department_id: departments(:one).id,
+      graduation_year: (Time.current.year + 1).to_s,
+      graduation_month: 'September',
+      files: fixture_file_upload('test/fixtures/files/a_pdf.pdf', 'application/pdf')
+    }
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'files default purpose and description to nil' do
+    mock_auth(users(:transfer_submitter))
+    orig_count = Transfer.count
+    post transfer_index_path, params: { transfer: @transfer_params }
+    transfer = Transfer.last
+    assert_nil transfer.files.first.purpose
+    assert_nil transfer.files.first.description
+  end
+
+  test 'files can have a purpose' do
+    mock_auth(users(:transfer_submitter))
+    orig_count = Transfer.count
+    post transfer_index_path, params: { transfer: @transfer_params }
+    transfer = Transfer.last
+
+    f1 = transfer.files.first
+    f1.purpose = 0
+    f1.save
+    refute_nil transfer.files.first.purpose
+    assert_equal transfer.files.first.purpose, "thesis_pdf"
+  end
+
+  test 'files can have a description' do
+    mock_auth(users(:transfer_submitter))
+    orig_count = Transfer.count
+    post transfer_index_path, params: { transfer: @transfer_params }
+    transfer = Transfer.last
+
+    f1 = transfer.files.first
+    f1.description = "Hallo!"
+    f1.save
+    refute_nil transfer.files.first.description
+    assert_equal transfer.files.first.description, "Hallo!"
+  end
+end


### PR DESCRIPTION
#### Why are these changes being introduced:

* Our workflows require the ability to track the reason a file is being
  submitted (primary thesis file, supplementary files, signature page,
  etc)

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-30
* https://mitlibraries.atlassian.net/browse/ETD-145

#### How does this address that need:

* By extending the active_storage_attachment class and adding two fields
  to the associated database table, we can easily provide the info our
  app needs
* The extra module we load into the class is only necessary to allow an
  enum, but it has a nice side effect of allowing us to include the
  module with our models to be more visible to developers that there is
  something non-default in our active_storage_attachment class.

#### Document any side effects to this change:

By extending the active_storage_attachment class, it is possible future
changes to ActiveStorage may be in conflict with our changes. This feels
quite unlikely, but as it's possible it feels worth noting.

We are using the terminology "purpose" for the "type" of file. The
reason being that a file "type" is commonly used to describe things like
"it's a PDF" or "it's a zip file". As we _also_ care about that meaning
of "type" in this application and already store that by default in
ActiveStorage it felt useful longer term to choose another label to
represent the "purpose" of the file being submitted.

#### How to see this change

The current UI does not have a way to set these new fields. It does have a rudimentary way to _view_ these fields in both Transfer and Thesis views. This is not intended as the final UI, but just a way to show the data _someplace_.

Locally, or on the PR build, you can manually populate these fields in the `rails console` doing something like:

```
t = Transfer.last
f = t.files.first
f.description = "hallo!"
f.purpose = 0
f.save

pp f (or view in the Transfer administrate panel)

#<ActiveStorage::Attachment:0x00007ff175f3e300
 id: 83,
 name: "files",
 record_type: "Transfer",
 record_id: 6,
 blob_id: 102,
 created_at: Tue, 26 Jan 2021 14:51:39 UTC +00:00,
 description: "hallo!",
 purpose: "thesis_pdf">
```

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES


#### Includes new or updated dependencies?

NO
