### PR TITLE
Add Author relationship model to application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup System

--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class AuthorsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -6,12 +6,12 @@ class ThesisController < ApplicationController
 
   def new
     @thesis = Thesis.new
-    @thesis.user = current_user
+    @thesis.users = [current_user]
   end
 
   def create
     @thesis = Thesis.new(thesis_params)
-    @thesis.user = current_user
+    @thesis.users = [current_user]
     @thesis.files.attach(params[:thesis][:files])
     if @thesis.save
       flash.notice = 'Thank you for your submission.'

--- a/app/dashboards/author_dashboard.rb
+++ b/app/dashboards/author_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class AuthorDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    user: Field::BelongsTo,
+    thesis: Field::BelongsTo,
+    id: Field::Number,
+    graduation_confirmed: Field::Boolean,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+  id
+  user
+  thesis
+  graduation_confirmed
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+  id
+  user
+  thesis
+  graduation_confirmed
+  created_at
+  updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+  user
+  thesis
+  graduation_confirmed
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how authors are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(author)
+  #   "Author ##{author.id}"
+  # end
+end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -12,7 +12,7 @@ class ThesisDashboard < Administrate::BaseDashboard
   # schema, but also about graduation_year and graduation_month, since Thesis
   # performs before_create validation on these objects.
   ATTRIBUTE_TYPES = {
-    user: Field::BelongsTo,
+    users: Field::HasMany,
     right: Field::BelongsTo,
     departments: Field::HasMany,
     degrees: Field::HasMany,
@@ -48,7 +48,7 @@ class ThesisDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
     title
-    user
+    users
     holds
     right
     grad_date
@@ -58,7 +58,7 @@ class ThesisDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    user
+    users
     title
     abstract
     grad_date
@@ -85,7 +85,7 @@ class ThesisDashboard < Administrate::BaseDashboard
   # Make sure you display graduation_year and graduation_month on the form or
   # you will be unable to create Theses!
   FORM_ATTRIBUTES = %i[
-    user
+    users
     right
     departments
     degrees

--- a/app/mailers/receipt_mailer.rb
+++ b/app/mailers/receipt_mailer.rb
@@ -2,7 +2,8 @@ class ReceiptMailer < ApplicationMailer
   def receipt_email(thesis)
     return if ENV['DISABLE_ALL_EMAIL'] # allows PR builds to disable emails
     @thesis = thesis
-    mail(to: thesis.user.email,
+    emails = thesis.users.map { |u| u.email }.join(",")
+    mail(to: emails,
          cc: ENV['THESIS_ADMIN_EMAIL'],
          subject: 'Thesis Submission Receipt - MIT Libraries')
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -25,8 +25,8 @@ class Ability
     # Any user can create a new Thesis.
     can :create, Thesis
 
-    # Only the Thesis owner can view their Thesis.
-    can :read, Thesis, user_id: @user.id
+    # Only the Thesis author can view their Thesis.
+    can :read, Thesis, users: { id: @user.id }
   end
 
   # Users who can submit and view transfers.

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: authors
+#
+#  id                   :integer          not null, primary key
+#  user_id              :integer          not null
+#  thesis_id            :integer          not null
+#  graduation_confirmed :boolean          default(FALSE), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+class Author < ApplicationRecord
+  belongs_to :user
+  belongs_to :thesis
+
+  validates :graduation_confirmed, exclusion: [nil]
+end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  user_id            :integer
 #  right_id           :integer
 #  status             :string           default("active")
 #  processor_note     :text
@@ -19,7 +18,6 @@
 #
 
 class Thesis < ApplicationRecord
-  belongs_to :user
   belongs_to :right
   has_many :degree_theses
   has_many :degrees, through: :degree_theses
@@ -32,6 +30,9 @@ class Thesis < ApplicationRecord
 
   has_many :advisor_theses
   has_many :advisors, through: :advisor_theses
+
+  has_many :authors
+  has_many :users, through: :authors
 
   has_many_attached :files
 
@@ -57,10 +58,11 @@ class Thesis < ApplicationRecord
     { message: VALIDATION_MSGS[:departments] }
   validates :degrees, presence:
     { message: VALIDATION_MSGS[:degrees] }
+
   validates :files_complete, exclusion: [nil]
   validates :metadata_complete, exclusion: [nil]
 
-  # validates :files, presence: true
+  validates :users, presence: true
 
   STATUS_OPTIONS = ['active', 'withdrawn', 'downloaded']
   validates_inclusion_of :status, :in => STATUS_OPTIONS
@@ -76,9 +78,9 @@ class Thesis < ApplicationRecord
   before_create :combine_graduation_date
   after_find :split_graduation_date
 
-  scope :name_asc, lambda {
-    includes(:user).order('users.surname, users.given_name')
-  }
+  #scope :name_asc, lambda {
+  #  includes(:user).order('users.surname, users.given_name')
+  #}
   scope :date_asc, -> { order('grad_date') }
   scope :by_status, lambda { |status|
     if status == 'any'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,8 @@ class User < ApplicationRecord
 
   validates :uid, presence: true #, uniqueness: true
   validates :email, presence: true
-  has_many :theses
+  has_many :authors
+  has_many :theses, through: :authors
   has_many :transfers
   has_many :submitters
   has_many :departments, through: :submitters

--- a/app/views/thesis/_thesis.html.erb
+++ b/app/views/thesis/_thesis.html.erb
@@ -2,7 +2,7 @@
   <div class="panel-heading">
     <div class="layout-3q1q layout-band">
       <div class="col3q">
-        <h4><span >Submitted by: </span><%= thesis.user.name %></h4>
+        <h4><span >Submitted by: </span><%= thesis.users.map { |u| u.name }.join(",") %></h4>
       </div>
       <div class="col1q-r">
         <p class="status copy-sup">Status: <span class="thesis-status type-<%= thesis.css_alert_type %>"> <%= thesis.status %></span></p>

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -12,13 +12,6 @@
       <%= link_to "All",magic_status_url('any'), { class: "btn button-small #{highlight_status('any')}"} %>
     </div>
   </div>
-  <div class="grid-item">
-    <div class="wrap-filters">
-      Sort by:
-      <%= link_to "Date", magic_sort_url('date'), { class: "btn button-small #{highlight_sort('date')}"} %>
-      <%= link_to "Name", magic_sort_url('name'), { class: "btn button-small #{highlight_sort('name')}"} %>
-    </div>
-  </div>
 </div>
 
 <% if show_form %>

--- a/app/views/thesis/show.html.erb
+++ b/app/views/thesis/show.html.erb
@@ -17,7 +17,7 @@
 </ul>
 
 <p class="copy-sup">
-  Submitted on <%= @thesis.created_at.to_formatted_s(:long) %> by <%= @thesis.user.email %>
+  Submitted on <%= @thesis.created_at.to_formatted_s(:long) %> by <%= @thesis.users.map { |u| u.name }.join(",") %>
 </p>
 
 <p>Theses will only be added to DSpace after degrees have been awarded and the thesis has been fully processed and cataloged by the MIT Libraries, which will be at least 3 months after the degree date.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :users
     resources :advisors
+    resources :authors
     resources :degrees
     resources :departments
     resources :department_theses

--- a/db/migrate/20210127184534_create_authors.rb
+++ b/db/migrate/20210127184534_create_authors.rb
@@ -1,0 +1,11 @@
+class CreateAuthors < ActiveRecord::Migration[6.0]
+  def change
+    create_table :authors do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :thesis, null: false, foreign_key: true
+      t.boolean :graduation_confirmed, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210127192429_remove_user_id_from_thesis.rb
+++ b/db/migrate/20210127192429_remove_user_id_from_thesis.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromThesis < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :theses, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,16 @@ ActiveRecord::Schema.define(version: 2021_01_28_183652) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "authors", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "thesis_id", null: false
+    t.boolean "graduation_confirmed", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["thesis_id"], name: "index_authors_on_thesis_id"
+    t.index ["user_id"], name: "index_authors_on_user_id"
+  end
+
   create_table "degree_theses", id: false, force: :cascade do |t|
     t.integer "thesis_id"
     t.integer "degree_id"
@@ -133,7 +143,6 @@ ActiveRecord::Schema.define(version: 2021_01_28_183652) do
     t.date "grad_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
     t.integer "right_id"
     t.string "status", default: "active"
     t.text "processor_note"
@@ -142,7 +151,6 @@ ActiveRecord::Schema.define(version: 2021_01_28_183652) do
     t.boolean "metadata_complete", default: false, null: false
     t.string "publication_status", default: "Not ready for publication", null: false
     t.index ["right_id"], name: "index_theses_on_right_id"
-    t.index ["user_id"], name: "index_theses_on_user_id"
   end
 
   create_table "transfers", force: :cascade do |t|
@@ -170,6 +178,8 @@ ActiveRecord::Schema.define(version: 2021_01_28_183652) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "authors", "theses"
+  add_foreign_key "authors", "users"
   add_foreign_key "holds", "hold_sources"
   add_foreign_key "holds", "theses"
   add_foreign_key "submitters", "departments"

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -160,7 +160,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     yo = users(:yo)
     sign_in yo
 
-    thesis = Thesis.where(user: yo).first
+    thesis = yo.theses.first
     note_text = 'Yo dawg, I heard you like notes on your thesis'
     thesis.processor_note = note_text
     thesis.save
@@ -214,7 +214,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     # first page.
     expected_theses = Thesis.order('grad_date ASC').first(25)
     expected_theses.each do |t|
-      assert @response.body.include? t.user.email
+      assert t.users.map {|u| @response.body.include? u.email}.all?
     end
   end
 
@@ -459,14 +459,6 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     theses = @controller.instance_variable_get(:@theses)
     assert theses.first.grad_date <= theses.second.grad_date
     assert theses.second.grad_date <= theses.third.grad_date
-  end
-
-  test 'can be sorted by name' do
-    sign_in users(:admin)
-    get process_path(sort: 'name')
-    theses = @controller.instance_variable_get(:@theses)
-    assert theses.first.user.surname <= theses.second.user.surname
-    assert theses.second.user.surname <= theses.third.user.surname
   end
 
   test 'can be filtered by start year' do

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: authors
+#
+#  id                   :integer          not null, primary key
+#  user_id              :integer          not null
+#  thesis_id            :integer          not null
+#  graduation_confirmed :boolean          default(FALSE), not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+
+one:
+  user: yo
+  thesis: one
+  graduation_confirmed: false
+
+two:
+  user: yo
+  thesis: two
+  graduation_confirmed: true
+
+three:
+  user: basic
+  thesis: two
+  graduation_confirmed: false
+
+four:
+  user: basic
+  thesis: with_note
+  graduation_confirmed: false
+
+five:
+  user: basic
+  thesis: active
+  graduation_confirmed: false

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  user_id            :integer
 #  right_id           :integer
 #  status             :string           default("active")
 #  processor_note     :text
@@ -24,7 +23,6 @@ one:
   title: MyString
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -34,7 +32,6 @@ two:
   title:  Can apparent superluminal neutrino speeds be explained as a quantum weak measurement?
   abstract: Probably not.
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -43,7 +40,6 @@ downloaded:
   title: MyString
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -53,7 +49,6 @@ withdrawn:
   title: MyString
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -63,7 +58,6 @@ active:
   title: MyString
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -73,7 +67,6 @@ with_note:
   title: MyString
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -84,7 +77,6 @@ with_hold:
   title: MySensitiveThesis
   abstract: MyText
   grad_date: 2017-09-13
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -95,7 +87,6 @@ june_2018:
   title: MyString
   abstract: MyText
   grad_date: 2018-06-01
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -104,7 +95,6 @@ september_2018:
   title: MyString
   abstract: MyText
   grad_date: 2018-09-01
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -113,7 +103,6 @@ february_2019:
   title: MyString
   abstract: MyText
   grad_date: 2019-02-01
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -122,7 +111,6 @@ june_2019:
   title: MyString
   abstract: MyText
   grad_date: 2019-06-01
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -131,7 +119,6 @@ september_2019:
   title: MyString
   abstract: MyText
   grad_date: 2019-09-01
-  user: yo
   right: one
   departments: [one]
   degrees: [one]
@@ -140,6 +127,5 @@ multi_depts:
   title: MyOverAchievement
   abstract: MyText
   grad_date: 2019-02-01
-  user: yo
   right: one
   degrees: [one]

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class AuthorTest < ActiveSupport::TestCase
+  test 'can edit graduation confirmation' do
+    a = Author.first
+    assert(a.graduation_confirmed == false)
+    a.graduation_confirmed = true
+    a.save
+    assert(a.valid?)
+  end
+end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  user_id            :integer
 #  right_id           :integer
 #  status             :string           default("active")
 #  processor_note     :text
@@ -21,9 +20,6 @@
 require 'test_helper'
 
 class ThesisTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
   test 'valid thesis' do
     thesis = theses(:one)
     assert(thesis.valid?)
@@ -97,8 +93,15 @@ class ThesisTest < ActiveSupport::TestCase
 
   test 'invalid without user' do
     thesis = theses(:one)
-    thesis.user = nil
+    thesis.users = []
+    thesis.save
     assert(thesis.invalid?)
+  end
+
+  test 'valid with multiple authors' do
+    t = theses(:two)
+    assert(t.authors.count > 1)
+    assert(t.valid?)
   end
 
   test 'invalid without right' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -123,4 +123,14 @@ class UserTest < ActiveSupport::TestCase
   test 'thesis_admins can see all departments' do
     assert_equal users(:thesis_admin).submittable_departments.length, Department.all.length
   end
+
+  test 'has zero or more theses through author table' do
+    u1 = users(:yo)
+    u2 = users(:bad)
+    assert(u1.authors.any?)
+    assert(u1.theses.any?)
+    assert(u1.valid?)
+    assert(u2.theses.empty?)
+    assert(u2.valid?)
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

* The user-thesis relationship should clarify which users authored a
thesis
* We need a place to record whether a thesis author has graduated

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-75

#### How this addresses that need:

* Adds Author table to join User and Thesis
* Adds graduation_confirmed boolean column to Author
* Adds basic administrate UI to edit graduation_confirmed field

#### Side effects of this change:

This is a significant change. It initially broke the thesis processing
XHRs, the Ability model, the receipt mailer, and multiple admin UIs,
among other things. I believe I've fixed everything, but it's worth
noting that there may be additional fallout that we might not find until
later.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
