### PR TITLE
ETD-182 Fix bug that prevents theses from being destroyed

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -31,7 +31,7 @@ class Thesis < ApplicationRecord
   has_many :advisor_theses
   has_many :advisors, through: :advisor_theses
 
-  has_many :authors
+  has_many :authors, dependent: :destroy
   has_many :users, through: :authors
 
   has_many_attached :files

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   validates :uid, presence: true #, uniqueness: true
   validates :email, presence: true
   has_many :authors
-  has_many :theses, through: :authors
+  has_many :theses, through: :authors, dependent: :restrict_with_error
   has_many :transfers
   has_many :submitters
   has_many :departments, through: :submitters

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -104,6 +104,34 @@ class ThesisTest < ActiveSupport::TestCase
     assert(t.valid?)
   end
 
+  test 'a thesis with associated authors and users can be deleted' do
+    t = theses(:one)
+    t.authors.any?
+    t.users.any?
+    assert_difference("Thesis.count", -1) { t.destroy }
+  end
+
+  test 'when a thesis is deleted, the associated author is also deleted' do
+    t = theses(:one)
+    t.authors.any?
+    assert_difference("Author.count", -1) { t.destroy }
+  end
+
+  test 'when a thesis is deleted, the associated user is not deleted' do
+    t = theses(:one)
+    assert t.users.count == 1
+    u = t.users.first
+    assert_includes(User.all, u) { t.destroy }
+  end
+
+  test 'thesis deletion does not delete other author entries for the associated user' do
+    t = theses(:one)
+    u = users(:yo)
+    assert_includes t.users, u
+    assert_equal 2, u.authors.count
+    assert_difference("u.authors.count", -1) { t.destroy }
+  end
+
   test 'invalid without right' do
     thesis = theses(:one)
     thesis.right = nil

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -133,4 +133,28 @@ class UserTest < ActiveSupport::TestCase
     assert(u2.theses.empty?)
     assert(u2.valid?)
   end
+
+  test 'cannot destroy a user with an associated thesis' do
+    u = users(:yo)
+    assert u.theses.any?
+    u.destroy
+    assert u.errors[:base].include? "Cannot delete record because dependent theses exist"
+    assert u.present?
+  end
+
+  test 'can destroy a user without an associated thesis' do
+    u = users(:bad)
+    assert_not u.theses.any?
+    assert_difference("User.count", -1) { u.destroy }
+  end
+
+  test 'can destroy a user once associated thesis has been destroyed' do
+    u = users(:yo)
+    assert u.theses.any?
+    u.theses.destroy_all
+    assert_not u.theses.any?
+    assert_difference("User.count", -1) do
+      u.destroy
+    end
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

The data model is set up in such a way that a Thesis with an associated
User cannot be destroyed. The desired behavior is that a Thesis can be
destroyed, and that will cascade to its associated Author entry without
destroying the User.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-182

#### How this addresses that need:

* Adds dependent: :destroy option to the has_many: :authors association
in the Thesis model.
* Adds test coverage confirming desired behavior.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO


#### Includes new or updated dependencies?

NO
