### PR TITLE
ETD-178 Update fields in Hold and Hold Source UIs

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -9,6 +9,10 @@ class HoldDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     thesis: Field::BelongsTo,
+    degrees: Field::String,
+    grad_date: Field::DateTime.with_options(
+      format: "%Y %B",
+    ),
     hold_source: Field::BelongsTo,
     id: Field::Number,
     date_requested: Field::Date,
@@ -28,6 +32,7 @@ class HoldDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   id
+  grad_date
   thesis
   hold_source
   status
@@ -39,6 +44,8 @@ class HoldDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
   thesis
+  degrees
+  grad_date
   hold_source
   id
   date_requested

--- a/app/dashboards/hold_source_dashboard.rb
+++ b/app/dashboards/hold_source_dashboard.rb
@@ -9,6 +9,7 @@ class HoldSourceDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     active_holds: Field::Number,
+    expired_holds: Field::Number,
     holds: Field::HasMany,
     id: Field::Number,
     source: Field::Text,
@@ -25,6 +26,7 @@ class HoldSourceDashboard < Administrate::BaseDashboard
   id
   source
   active_holds
+  expired_holds
   holds
   created_at
   ].freeze
@@ -34,7 +36,6 @@ class HoldSourceDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
   holds
   id
-  source
   created_at
   updated_at
   ].freeze
@@ -43,7 +44,6 @@ class HoldSourceDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-  holds
   source
   ].freeze
 

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -26,4 +26,12 @@ class Hold < ApplicationRecord
   validates :date_start, presence: true
   validates :date_end, presence: true
   validates :status, presence: true
+
+  def degrees
+    self.thesis.degrees.map { |d| d.name}.join("\n")
+  end
+
+  def grad_date
+    self.thesis.grad_date
+  end
 end

--- a/app/models/hold_source.rb
+++ b/app/models/hold_source.rb
@@ -15,4 +15,8 @@ class HoldSource < ApplicationRecord
   def active_holds
     return self.holds.count { |hold| hold.status == 'active' }
   end
+
+  def expired_holds
+    return self.holds.count { |hold| hold.status == 'expired' }
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,8 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  helpers:
+    label:
+      hold:
+        grad_date: Degree date
+        

--- a/test/fixtures/holds.yml
+++ b/test/fixtures/holds.yml
@@ -23,3 +23,23 @@ valid:
   case_number: null
   status: active
   processing_notes: null
+
+expired:
+  thesis: downloaded
+  date_requested: 2017-09-01
+  date_start: 2017-09-01
+  date_end: 2067-12-31
+  hold_source: tlo
+  case_number: null
+  status: expired
+  processing_notes: null
+
+also_expired:
+  thesis: downloaded
+  date_requested: 2017-09-01
+  date_start: 2017-09-01
+  date_end: 2067-12-31
+  hold_source: tlo
+  case_number: null
+  status: expired
+  processing_notes: null

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -79,7 +79,7 @@ with_hold:
   grad_date: 2017-09-13
   right: one
   departments: [one]
-  degrees: [one]
+  degrees: [one, two]
   status: 'active'
   processor_note: 'Something sensitive'
 

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -520,12 +520,6 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_equal needle, hold_source.source
   end
 
-  test 'editing hold_sources lists which holds that source has requested' do
-    mock_auth(users(:thesis_admin))
-    get "/admin/hold_sources/#{hold_sources(:tlo).id}/edit"
-    assert_select "div.field-unit__field", text: theses(:with_hold).title
-  end
-
   test 'thesis admins can access author dashboard' do
     mock_auth(users(:thesis_admin))
     get "/admin/authors"

--- a/test/models/hold_source_test.rb
+++ b/test/models/hold_source_test.rb
@@ -20,4 +20,14 @@ class HoldSourceTest < ActiveSupport::TestCase
     holdsource.source = nil
     assert(holdsource.invalid?)
   end
+
+  test 'counts active holds associated with source' do
+    source = hold_sources(:tlo)
+    assert source.active_holds == 1
+  end
+
+  test 'counts expired holds associated with source' do
+    source = hold_sources(:tlo)
+    assert source.expired_holds == 2
+  end
 end

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -88,4 +88,14 @@ class HoldTest < ActiveSupport::TestCase
     change = hold.versions.last
     assert_equal change.changeset["case_number"], [nil, "2"]
   end
+
+  test 'can list associated degrees' do
+    hold = holds(:valid)
+    assert_equal "MFA\nJD", hold.degrees
+  end
+
+  test 'can list associated grad date' do
+    hold = holds(:valid)
+    assert_equal Date.parse("2017-09-13"), hold.grad_date
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

This is part of the work to implement recommendations made in the UX
review of the Hold and Hold Source UI. This changeset is detailed in
ETD-178, and originated in ETD-106 (see links in relevant tickets
section).

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-178
* https://mitlibraries.atlassian.net/browse/ETD-106
* https://mitlibraries.atlassian.net/browse/ETD-170

#### How this addresses that need:

* Adds degrees field to Hold show view
* Adds degree date (thesis.grad_date) field to Hold show and index views
* Removes holds field from Hold Source create and edit views
* Removes source field from Hold Source show view
* Adds expired_holds field to Hold Source index view

#### Side effects of this change:

It was requested that we remove the holds field from the Hold Source
create view, but administrate requires us to remove it from the edit
view as well. We should confirm with stakeholders during QA that this 
is acceptable.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
