### PR TITLE
ETD-153 Add :restrict_with_error option to Thesis-Hold association

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -25,7 +25,7 @@ class Thesis < ApplicationRecord
   has_many :department_theses
   has_many :departments, through: :department_theses
 
-  has_many :holds
+  has_many :holds, dependent: :restrict_with_error
   has_many :hold_sources, through: :holds
 
   has_many :advisor_theses


### PR DESCRIPTION
#### Why these changes are being introduced:

When a user tries to delete a thesis with a hold in the admin UI,
the action fails due to the FK constraint. This is the behavior we want,
but we'd like to swallow the ActiveRecord::InvalidForeignKey error so
processors don't see a Rails error page.

To verify the changes, try deleting a thesis that has an associated hold in the admin UI. 
You should see a flash error like this: `Cannot delete record because dependent holds exist`.
Otherwise, if the thesis has no holds, it should delete successfully.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-153

#### How this addresses that need:

This adds the :restrict_with_error option to the has_many: :holds
association on the Thesis model, which displays a friendly flash message
instead of the Rails error page.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO


#### Includes new or updated dependencies?

NO
