### PR TITLE
ETD-175 Update date format in Hold and Hold Source UIs

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -17,8 +17,8 @@ class HoldDashboard < Administrate::BaseDashboard
     case_number: Field::String,
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     processing_notes: Field::Text,
-    created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    created_at: Field::Date,
+    updated_at: Field::Date,
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/hold_source_dashboard.rb
+++ b/app/dashboards/hold_source_dashboard.rb
@@ -12,8 +12,8 @@ class HoldSourceDashboard < Administrate::BaseDashboard
     holds: Field::HasMany,
     id: Field::Number,
     source: Field::Text,
-    created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    created_at: Field::Date,
+    updated_at: Field::Date,
   }.freeze
 
   # COLLECTION_ATTRIBUTES


### PR DESCRIPTION
#### Why these changes are being introduced:

The current administrate field (DateTime) for created_at and updated_at
includes the timestamp, which adds visual clutter. This change was
requested as part of the UX review of the Hold UI.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-175
* https://mitlibraries.atlassian.net/browse/ETD-106
* https://mitlibraries.atlassian.net/browse/ETD-170

#### How this addresses that need:

This removes the timestamp from the DateTime fields in the Hold and
Hold Source UIs. The changes can be verified by confirming no timestamps
in the created_at and updated_at fields on the Hold show view and the Hold 
Source index and show views.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO


#### Includes new or updated dependencies?

NO
