### PR TITLE
ETD-174 Update field labels in Hold and Hold Source UIs

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,4 +34,11 @@ en:
     label:
       hold:
         grad_date: Degree date
-        
+        date_start: Start date
+        date_end: End date
+        created_at: Created on
+        updated_at: Updated on
+        case_number: TLO case number
+      hold_source:
+        created_at: Created on
+        updated_at: Updated on


### PR DESCRIPTION
#### Why these changes are being introduced:

The UX review of the Hold and Hold Source UIs requested changes to UI
field labels.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-174
* https://mitlibraries.atlassian.net/browse/ETD-106
* https://mitlibraries.atlassian.net/browse/ETD-170

#### How this addresses that need:

* Adds i18n translations for the following fields:
    * date_start
    * date_end
    * created_at
    * updated_at
    * case_number
* Adds a custom view for the Hold Source new form to make the title
singular

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
