### PR TITLE
ETD-107 Adds thesis author names to the Hold UI

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -9,6 +9,7 @@ class HoldDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     thesis: Field::BelongsTo,
+    author_names: Field::String,
     degrees: Field::String,
     grad_date: Field::DateTime.with_options(
       format: "%Y %B",
@@ -32,6 +33,7 @@ class HoldDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
   id
+  author_names
   grad_date
   thesis
   hold_source
@@ -44,6 +46,7 @@ class HoldDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
   thesis
+  author_names
   degrees
   grad_date
   hold_source

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -34,4 +34,8 @@ class Hold < ApplicationRecord
   def grad_date
     self.thesis.grad_date
   end
+
+  def author_names
+    self.thesis.users.map { |u| u.name }.join("; ")
+  end
 end

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -34,3 +34,13 @@ five:
   user: basic
   thesis: active
   graduation_confirmed: false
+
+six:
+  user: yo
+  thesis: with_hold
+  graduation_confirmed: false
+
+seven:
+  user: basic
+  thesis: with_hold
+  graduation_confirmed: false

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -98,4 +98,9 @@ class HoldTest < ActiveSupport::TestCase
     hold = holds(:valid)
     assert_equal Date.parse("2017-09-13"), hold.grad_date
   end
+
+  test 'can list associated author names' do
+    h = holds(:valid)
+    assert_equal "Robot, Basic; Yobot, Yo", h.author_names
+  end
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -128,7 +128,7 @@ class ThesisTest < ActiveSupport::TestCase
     t = theses(:one)
     u = users(:yo)
     assert_includes t.users, u
-    assert_equal 2, u.authors.count
+    assert_equal 3, u.authors.count
     assert_difference("u.authors.count", -1) { t.destroy }
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

Author names are crucial for processors to clarify the correct
Thesis-Hold association, as they are more consistent than thesis titles.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-107
* https://mitlibraries.atlassian.net/browse/ETD-177
* https://mitlibraries.atlassian.net/browse/ETD-106
* https://mitlibraries.atlassian.net/browse/ETD-170

#### How this addresses that need:

* Adds an `author_names` convenience method to the Hold model that maps
all of the Author names associated with the corresponding Thesis.
* Adds `author_names` field to the Hold admin dashboard show and index
views.

#### Side effects of this change:

None, but adding author info to the new and edit view will need to be
implemented separately (currently documented in ETD-177, linked above).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
