### PR TITLE
Adds support for data uploads from Registrar

### DIFF
--- a/app/controllers/registrar_controller.rb
+++ b/app/controllers/registrar_controller.rb
@@ -1,0 +1,45 @@
+class RegistrarController < ApplicationController
+  before_action :require_user
+  before_action :authenticate_user!
+  load_and_authorize_resource
+  protect_from_forgery with: :exception
+
+  def new
+    @registrar = Registrar.new
+    @registrar.user = current_user
+  end
+
+  def create
+    @registrar = Registrar.new(registrar_params)
+    @registrar.user = current_user
+    @registrar.graduation_list.attach(params[:registrar][:graduation_list])
+    if @registrar.save
+      flash.notice = 'Thank you for submitting this Registrar file.'
+      redirect_to root_path()
+    else
+      flash[:error] = "Error saving Registrar file: #{@registrar.errors.full_messages}"
+      render 'new'
+    end
+  end
+
+  def show
+    @registrar = Registrar.find(params[:id])
+  end
+
+  private
+
+  def require_user
+    return if current_user
+    # Do NOT use ENV['FAKE_AUTH_ENABLED'] directly! Use the config. It performs
+    # an additional check to make sure we are not on the production server.
+    if Rails.configuration.fake_auth_enabled
+      redirect_to user_developer_omniauth_authorize_path
+    else
+      redirect_to user_saml_omniauth_authorize_path
+    end
+  end
+
+  def registrar_params
+    params.require(:registrar).permit(:graduation_list)
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,5 +58,7 @@ class Ability
     can :create, Transfer
     can :read, Transfer
     can :administrate, Admin
+    can :create, Registrar
+    can :read, Registrar
   end
 end

--- a/app/models/registrar.rb
+++ b/app/models/registrar.rb
@@ -1,0 +1,11 @@
+class Registrar < ApplicationRecord
+  belongs_to :user
+
+  has_one_attached :graduation_list
+
+  VALIDATION_MSGS = {
+    graduation_list: 'Required - Attaching a CSV file is required.',
+  }
+
+  validates :graduation_list, presence: true
+end

--- a/app/views/registrar/new.html.erb
+++ b/app/views/registrar/new.html.erb
@@ -1,0 +1,58 @@
+<%= content_for(:title, "Registrar Submission | MIT Libraries") %>
+
+<% content_for :additional_js do %>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"></script>
+<% end %>
+
+<%= simple_form_for(@registrar, url: '/registrar', html: { class: 'registrarSubmission' }, validate: true ) do |f| %>
+
+  <%= f.error_notification %>
+  <div class="alert alert-banner error" style="display: none;" role="alert" aria-invalid="true"></div>
+
+  <%= f.input :graduation_list, as: :file,
+        wrapper_html: { class: 'field-wrap' },
+        input_html: { class: 'field field-upload',
+                      multiple: false,
+                      direct_upload: true,
+                      data: { msg: Registrar::VALIDATION_MSGS[:graduation_list] },
+                      'aria-describedby': 'registrar_file_ids-hint' },
+        label: 'File to upload',
+        required: true,
+        hint: 'This would be the hint text describing the bulk files fields.',
+        hint_html: { id: 'registrar_file_ids-hint' }  %>
+
+  <div class='field-wrap'>
+    <div id="file_to_upload"></div>
+  </div>
+
+  <div class='field-wrap'>
+    <%= submit_tag 'Submit Registrar data', class: 'btn button-primary' %>
+  </div>
+
+<% end # Ends simple_form_for %>
+
+  <script>
+    $("input:file").change(function () {
+        var filenames = '';
+        var fileblurb = '<p>The following file will be uploaded when this form is submitted:</p>';
+        for (var i = 0; i < this.file.length; i++) {
+            filenames += '<li>' + this.file[i].name + '</li>';
+        }
+        $("#file_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>');
+    });
+
+    $("#new_registrar").validate({
+      invalidHandler: function(event, validator) {
+        var errors = validator.numberOfInvalids();
+        if (errors) {
+          var message = errors == 1
+            ? 'The form was not submitted successfully - one required field needs to be fixed.'
+            : 'The form was not submitted successfully - ' + errors + ' required fields need to be fixed.';
+          $("div.error").html(message);
+          $("div.error").show();
+        } else {
+          $("div.error").hide();
+        }
+      }
+    });
+  </script>

--- a/app/views/registrar/show.html.erb
+++ b/app/views/registrar/show.html.erb
@@ -1,0 +1,1 @@
+<%= content_for(:title, "Registrar Submission | MIT Libraries") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     root to: "theses#index"
   end
 
+  resources :registrar, only: [:new, :create, :show]
   resources :thesis, only: [:new, :create, :show]
   get 'process', to: 'thesis#process_theses', as: 'process'
   get 'process/:status', to: 'thesis#process_theses'

--- a/db/migrate/20210217183612_create_registrar.rb
+++ b/db/migrate/20210217183612_create_registrar.rb
@@ -1,0 +1,9 @@
+class CreateRegistrar < ActiveRecord::Migration[6.0]
+  def change
+    create_table :registrars do |t|
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_202602) do
+ActiveRecord::Schema.define(version: 2021_02_17_183612) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -122,6 +122,13 @@ ActiveRecord::Schema.define(version: 2021_02_11_202602) do
     t.index ["thesis_id"], name: "index_holds_on_thesis_id"
   end
 
+  create_table "registrars", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_registrars_on_user_id"
+  end
+
   create_table "rights", force: :cascade do |t|
     t.text "statement", null: false
     t.datetime "created_at", null: false
@@ -200,6 +207,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_202602) do
   add_foreign_key "authors", "users"
   add_foreign_key "holds", "hold_sources"
   add_foreign_key "holds", "theses"
+  add_foreign_key "registrars", "users"
   add_foreign_key "submitters", "departments"
   add_foreign_key "submitters", "users"
   add_foreign_key "transfers", "departments"

--- a/test/controllers/registrar_controller_test.rb
+++ b/test/controllers/registrar_controller_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class RegistrarControllerTest < ActionDispatch::IntegrationTest
+  test 'submit redirects to login' do
+    get '/registrar/new'
+    assert_response :redirect
+    assert_redirected_to '/users/auth/saml'
+  end
+
+  test 'view redirects to login' do
+    get "/registrar/#{registrar(:valid).id}"
+    assert_response :redirect
+    assert_redirected_to '/users/auth/saml'
+  end
+
+  test 'thesis_admins can submit and view registrar' do
+    sign_in users(:thesis_admin)
+    get '/registrar/new'
+    assert_response :success
+    get "/registrar/#{registrar(:valid).id}"
+    assert_response :success
+  end
+
+  test 'admins can submit and view a registrar' do
+    sign_in users(:admin)
+    get '/registrar/new'
+    assert_response :success
+    get "/registrar/#{registrar(:valid).id}"
+    assert_response :success
+  end
+
+  test 'confirmation of successful submission' do
+    sign_in users(:thesis_admin)
+    post '/registrar',
+      params: {
+        registrar: {
+          graduation_list: fixture_file_upload('files/registrar.csv', 'text/csv')
+        }
+      }
+    assert_response :redirect
+    follow_redirect!
+    assert_equal path, '/'
+    assert_not @response.body.include? "Error"
+    assert @response.body.include? "Thank you for submitting this Registrar file."
+  end
+
+  test 'flash message if invalid submission' do
+    sign_in users(:thesis_admin)
+    post '/registrar',
+      params: {
+        registrar: {
+          graduation_list: nil
+        }
+      }
+    assert_equal path, '/registrar'
+    assert @response.body.include? "Error saving Registrar file:"
+  end
+
+  test 'basic user cannot submit or view a registrar' do
+    sign_in users(:basic)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/new"
+    end
+    sign_in users(:basic)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/#{registrar(:valid).id}"
+    end
+  end
+
+  test 'processors cannot submit or view a registrar' do
+    sign_in users(:processor)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/new"
+    end
+    sign_in users(:processor)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/#{registrar(:valid).id}"
+    end
+  end
+
+  test 'transfer_submitters cannot submit or view a registrar' do
+    sign_in users(:transfer_submitter)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/new"
+    end
+    sign_in users(:transfer_submitter)
+    assert_raises CanCan::AccessDenied do
+      get "/registrar/#{registrar(:valid).id}"
+    end
+  end
+end

--- a/test/fixtures/files/registrar.csv
+++ b/test/fixtures/files/registrar.csv
@@ -1,0 +1,2 @@
+﻿this,is,a,test
+this,is,another,test

--- a/test/fixtures/registrar.yml
+++ b/test/fixtures/registrar.yml
@@ -1,0 +1,2 @@
+valid:
+  user: admin

--- a/test/models/registrar_test.rb
+++ b/test/models/registrar_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class RegistrarTest < ActiveSupport::TestCase
+  setup do
+    @registrar = registrar(:valid)
+    f = Rails.root.join('test','fixtures','files','registrar.csv')
+    @registrar.graduation_list.attach(io: File.open(f), filename: 'registrar.csv')
+  end
+
+  teardown do
+    @registrar.graduation_list.purge
+  end
+
+  test 'valid registrar' do
+    assert @registrar.valid?
+  end
+
+  test 'invalid without file' do
+    @registrar.graduation_list.purge
+    assert @registrar.invalid?
+  end
+end


### PR DESCRIPTION
This creates a Registrar model to support uploading a CSV file that we'll get from the Registrar's office. There is an upload form, a (blank) show route, and test coverage to keep our current coverage level in place. I've confirmed that the uploaded file ends up in our s3 bucket.

Some notes on some specific choices I've made, in case any adjustments are needed:

* Both `admin` and `thesis_admin` roles have access to this form. I think I've written tests sufficient to clarify this, but I confess that at times the role system and admin flag trip me up.
* Jeremy commented on this already, but there is a user attribute on this model. I'm not sure if that's what's needed, but this may be a question for Helen.
* Do we need a MIME type check on the uploaded CSV file? The ticket mentions not doing anything with the uploaded file, and I'm not sure if this is part of that or not. I think I know how we'd do it if it's needed now, but didn't want to borrow trouble.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
