### PR TITLE
Adds coauthors field to thesis model

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -99,7 +99,7 @@ class ThesisController < ApplicationController
   end
 
   def thesis_params
-    params.require(:thesis).permit(:title, :abstract, :graduation_month,
+    params.require(:thesis).permit(:title, :abstract, :coauthors, :graduation_month,
                                    :graduation_year, :right_id,
                                    :department_ids, :degree_ids)
   end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -39,6 +39,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     metadata_complete: Field::Boolean,
     holds: Field::HasMany,
     advisors: Field::HasMany,
+    coauthors: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -60,6 +61,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     id
     users
     title
+    coauthors
     abstract
     grad_date
     right
@@ -91,6 +93,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     degrees
     advisors
     title
+    coauthors
     abstract
     status
     publication_status

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -15,6 +15,7 @@
 #  files_complete     :boolean          default(FALSE), not null
 #  metadata_complete  :boolean          default(FALSE), not null
 #  publication_status :string           default("Not ready for publication"), not null
+#  coauthors          :string
 #
 
 class Thesis < ApplicationRecord

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -52,6 +52,10 @@
                              data: { msg: Thesis::VALIDATION_MSGS[:abstract] }
                            } %>
 
+    <%= f.input :coauthors, label: 'Coauthors',
+                        wrapper_html: { class: 'field-wrap' },
+                        input_html: { class: 'field field-text wide' } %>
+
     <%= f.association :departments, label_method: :name, as: :select,
                          collection: Department.order(:name),
                          validate: { presence: true },

--- a/db/migrate/20210225164332_add_coauthors_to_thesis.rb
+++ b/db/migrate/20210225164332_add_coauthors_to_thesis.rb
@@ -1,0 +1,5 @@
+class AddCoauthorsToThesis < ActiveRecord::Migration[6.0]
+  def change
+  	add_column :theses, :coauthors, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_183612) do
+ActiveRecord::Schema.define(version: 2021_02_25_164332) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_183612) do
     t.boolean "files_complete", default: false, null: false
     t.boolean "metadata_complete", default: false, null: false
     t.string "publication_status", default: "Not ready for publication", null: false
+    t.string "coauthors"
     t.index ["right_id"], name: "index_theses_on_right_id"
   end
 

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -15,6 +15,7 @@
 #  files_complete     :boolean          default(FALSE), not null
 #  metadata_complete  :boolean          default(FALSE), not null
 #  publication_status :string           default("Not ready for publication"), not null
+#  coauthors          :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -27,6 +28,7 @@ one:
   departments: [one]
   degrees: [one]
   advisors: [first]
+  coauthors: 'My co-author'
 
 two:
   title:  Can apparent superluminal neutrino speeds be explained as a quantum weak measurement?

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -8,6 +8,7 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
       degree_ids: Degree.first.id,
       title: 'yoyos are cool',
       abstract: 'We discovered it with science',
+      coauthors: 'My co-author',
       graduation_month: 'June',
       graduation_year: Time.zone.today.year,
       files: fixture_file_upload('test/fixtures/files/a_pdf.pdf',
@@ -58,6 +59,20 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
     params[:files] = nil
     post thesis_index_path, params: { thesis: params }
     assert_select "input.required[data-msg='#{Thesis::VALIDATION_MSGS[:files]}']"
+  end
+
+  test 'coauthor field' do
+    mock_auth(users(:basic))
+    orig_count = Thesis.count
+    sample = @thesis_params
+    post thesis_index_path, params: { thesis: sample }
+    assert_equal Thesis.count, orig_count + 1
+    assert_equal 'My co-author', Thesis.last.coauthors
+
+    sample[:coauthors] = nil
+    post thesis_index_path, params: { thesis: sample }
+    assert_equal Thesis.count, orig_count + 2
+    assert_equal Thesis.last.coauthors, ''
   end
 
   test 'indicates active user' do

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -15,6 +15,7 @@
 #  files_complete     :boolean          default(FALSE), not null
 #  metadata_complete  :boolean          default(FALSE), not null
 #  publication_status :string           default("Not ready for publication"), not null
+#  coauthors          :string
 #
 
 require 'test_helper'
@@ -310,6 +311,15 @@ class ThesisTest < ActiveSupport::TestCase
 
     thesis.graduation_month = 'December'
     assert thesis.invalid?
+  end
+
+  test 'coauthors field can be populated or nil' do
+    thesis = theses(:one)
+    thesis.coauthors = nil
+    assert thesis.valid?
+
+    thesis.coauthors = 'My freeloader'
+    assert thesis.valid?
   end
 
   test 'a thesis may have a hold' do


### PR DESCRIPTION
## Why are these changes being introduced:

* Part of the upcoming Registrar data import workflow will involve a
  text string for each thesis containing the author's coauthors. The
  import workflow will not attempt to reconcile multiple coauthors,
  leaving that for manual work by a staff member. To enable that work,
  we need to store this text string for later use.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-192

## How does this address that need:

* This adds a simple (nullable) string field to the Thesis model for
  "coauthors". This field is also added to the Thesis Submission form,
  the administrative dashboard (thesis display and thesis form).
* Relevant tests are added for this field as an optional element.

## Document any side effects to this change:

Not a side effect, but testing this branch has revealed an existing bug in the application, which has been recorded in Jira as https://mitlibraries.atlassian.net/browse/ETD-193

### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
