### PR TITLE
ETD-177 Add logic to create a Hold through Thesis

### DIFF
--- a/app/assets/stylesheets/administrate.scss
+++ b/app/assets/stylesheets/administrate.scss
@@ -1,0 +1,18 @@
+.panel {
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  border-top: 4px solid #000;
+  .panel-heading {
+    font-size: 1.6rem;
+    margin: 1.5rem 2rem .5rem 2rem;
+  }
+  .panel-body {
+    margin: .5rem 2rem 1.5rem 2rem;
+  }
+}
+
+.new-hold-button {
+  margin-left: 2rem
+}

--- a/app/controllers/admin/holds_controller.rb
+++ b/app/controllers/admin/holds_controller.rb
@@ -42,5 +42,13 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
+    def new
+      resource = new_resource
+      authorize_resource(resource)
+      resource.thesis_id = params[:thesis_id]
+      render locals: {
+        page: Administrate::Page::Form.new(dashboard, resource),
+      }
+    end
   end
 end

--- a/app/dashboards/author_dashboard.rb
+++ b/app/dashboards/author_dashboard.rb
@@ -8,9 +8,12 @@ class AuthorDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    user: Field::BelongsTo,
-    thesis: Field::BelongsTo,
     id: Field::Number,
+    user: Field::BelongsTo.with_options(
+      searchable: true,
+      searchable_fields: ['kerberos_id', 'uid', 'display_name']
+    ),
+    thesis: Field::BelongsTo,
     graduation_confirmed: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -22,7 +25,6 @@ class AuthorDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  id
   user
   thesis
   graduation_confirmed
@@ -31,7 +33,6 @@ class AuthorDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  id
   user
   thesis
   graduation_confirmed

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -33,9 +33,9 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    id
     display_name
     email
+    kerberos_id
     role
     theses
   ].freeze
@@ -45,7 +45,6 @@ class UserDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     display_name
     theses
-    id
     uid
     kerberos_id
     orcid

--- a/app/views/admin/holds/_form.html.erb
+++ b/app/views/admin/holds/_form.html.erb
@@ -1,0 +1,45 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name).singularize
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes.each do |attribute| -%>
+    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/holds/_form.html.erb
+++ b/app/views/admin/holds/_form.html.erb
@@ -14,6 +14,8 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
+<% content_for(:custom_stylesheets) { stylesheet_link_tag "administrate" } %>
+
 <%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
@@ -34,10 +36,25 @@ and renders all form fields for a resource's editable attributes.
   <% end %>
 
   <% page.attributes.each do |attribute| -%>
-    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
-      <%= render_field attribute, f: f %>
-    </div>
-  <% end -%>
+    <% if params[:thesis_id] && attribute.name == 'thesis' %>
+      <div class="panel">
+        <%= hidden_field_tag 'hold[thesis_id]', params[:thesis_id] %>
+        <div class="panel-heading">Thesis info</div>
+        <div class="panel-body">
+          <ul class="list-unbulleted">
+            <li>Title: <%= attribute.data.title %></li>
+            <li>Author(s): <%= attribute.data.users.map { |author| author.name }.join("; ") %></li>
+            <li>Degree(s): <%= attribute.data.degrees.map { |degree| degree.name }.join("; ") %></li>
+            <li>Degree date: <%= attribute.data.grad_date %></li>
+          </ul>
+        </div>
+      </div>
+    <% else %>
+      <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+        <%= render_field attribute, f: f %>
+      </div>
+    <% end %>
+  <% end %>
 
   <div class="form-actions">
     <%= f.submit %>

--- a/app/views/admin/theses/show.html.erb
+++ b/app/views/admin/theses/show.html.erb
@@ -1,0 +1,49 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute, page: page %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/admin/theses/show.html.erb
+++ b/app/views/admin/theses/show.html.erb
@@ -16,7 +16,8 @@ as well as a link to its edit page.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
 %>
 
-<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.resource.title) } %>
+<% content_for(:custom_stylesheets) { stylesheet_link_tag "administrate" } %>
 
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
@@ -25,10 +26,17 @@ as well as a link to its edit page.
 
   <div>
     <%= link_to(
-      t("administrate.actions.edit_resource", name: page.page_title),
+      t("administrate.actions.edit_resource", name: page.resource.title),
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+  <div class="new-hold-button">
+    <%= link_to(
+      t("administrate.actions.new_resource", name: 'hold'),
+      [:new, namespace, "hold", {thesis_id: page.resource.id}],
+      class: "button",
+    ) if valid_action?(:new) && show_action?(:new, 'hold') %>
   </div>
 </header>
 

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -1,0 +1,41 @@
+<%#
+# Application Layout
+
+This view template is used as the layout
+for every page that Administrate generates.
+
+By default, it renders:
+- Navigation
+- Content for a search bar
+  (if provided by a `content_for` block in a nested page)
+- Flashes
+- Links to stylesheets and JavaScripts
+%>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+<head>
+  <meta charset="utf-8">
+  <meta name="ROBOTS" content="NOODP">
+  <meta name="viewport" content="initial-scale=1">
+  <title>
+    <%= content_for(:title) %> - <%= application_title %>
+  </title>
+  <%= render "stylesheet" %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+  <%= render "icons" %>
+
+  <div class="app-container">
+    <%= render "navigation" -%>
+
+    <main class="main-content" role="main">
+      <%= render "flashes" -%>
+      <%= yield %>
+    </main>
+  </div>
+
+  <%= render "javascript" %>
+</body>
+</html>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -22,6 +22,7 @@ By default, it renders:
     <%= content_for(:title) %> - <%= application_title %>
   </title>
   <%= render "stylesheet" %>
+  <%= yield :custom_stylesheets %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( administrate.css )


### PR DESCRIPTION
#### Why these changes are being introduced:

When creating or editing a hold, processors need to be able to clearly
identify its parent record. The selectize drop-down displays the title,
but processors also need to be able to search by author name and kerb ID,
and the corresponding degree info must be visible.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-177

#### How this addresses that need:

* Adds a 'New hold' button to the Thesis show page that links to a new
Hold form prepopulated with information about the corresponding Thesis.
* Overrides the administrate HoldsController#new action to work with the
thesis_id param.
* Adds a search field to the Authors dashboard index page to search by 
display_name, kerberos_id, and uid.
* Adds kerberos_id to Users dashboard index page to provide another 
path to access the desired thesis.
* Adds a new stylesheet for the thesis info panel (anticipating that
we may need additional custom CSS for administrate in the future).

#### Side effects of this change:

* Additional maintenance overhead from customizing upstream view files
* After extensive internal discussions in EngX, we still don't have an
effective means of clarifying the associated thesis when editing a hold.
The best approach so far is to modify the display_resource method for
the thesis dashboard, which is not ideal as it affects other parts of
the UI. More info on this problem is available in the JIRA ticket.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
