### PR TITLE
ETD-176 Add relevant audit trail fields to Holds UI

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -20,7 +20,7 @@ class HoldDashboard < Administrate::BaseDashboard
     date_start: Field::Date,
     date_end: Field::Date,
     date_released: Field::Date,
-    date_thesis_file_received: Field::Date,
+    dates_thesis_files_received: Field::String,
     case_number: Field::String,
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     processing_notes: Field::Text,
@@ -58,7 +58,7 @@ class HoldDashboard < Administrate::BaseDashboard
   date_requested
   date_start
   date_end
-  date_thesis_file_received
+  dates_thesis_files_received
   case_number
   status
   processing_notes

--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -19,9 +19,12 @@ class HoldDashboard < Administrate::BaseDashboard
     date_requested: Field::Date,
     date_start: Field::Date,
     date_end: Field::Date,
+    date_released: Field::Date,
+    date_thesis_file_received: Field::Date,
     case_number: Field::String,
     status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     processing_notes: Field::Text,
+    created_by: Field::Text,
     created_at: Field::Date,
     updated_at: Field::Date,
   }.freeze
@@ -40,6 +43,7 @@ class HoldDashboard < Administrate::BaseDashboard
   status
   date_requested
   date_end
+  date_released
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -54,9 +58,11 @@ class HoldDashboard < Administrate::BaseDashboard
   date_requested
   date_start
   date_end
+  date_thesis_file_received
   case_number
   status
   processing_notes
+  created_by
   created_at
   updated_at
   ].freeze

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -47,11 +47,14 @@ class Hold < ApplicationRecord
     end
   end
 
-  # Per internal discussions, we are setting this to the create date of 
-  # the parent thesis, which may be slightly different than the date the 
-  # file(s) were transferred.
-  def date_thesis_file_received
-    self.thesis.created_at.strftime('%Y-%m-%d')
+  # This may later list just the info for the file flagged 'primary', once 
+  # we implement that feature.
+  def dates_thesis_files_received
+    if self.thesis.files.present?
+      self.thesis.files.map do |file| 
+        "#{file.created_at.strftime('%Y-%m-%d')} (#{file.blob.filename})"
+      end.join("\n")
+    end
   end
 
   # In the unlikely scenario that the the status was changed to 'released' 

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -42,8 +42,11 @@ class Hold < ApplicationRecord
   def created_by
     if self.versions.first.event == 'create'
       creator_id = self.versions.first.whodunnit
-      user = User.find_by(id: creator_id)
-      user.kerberos_id
+      if user = User.find_by(id: creator_id)
+        user.kerberos_id
+      else
+        "User ID #{creator_id} no longer active."
+      end
     end
   end
 

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -38,4 +38,29 @@ class Hold < ApplicationRecord
   def author_names
     self.thesis.users.map { |u| u.name }.join("; ")
   end
+
+  def created_by
+    if self.versions.first.event == 'create'
+      creator_id = self.versions.first.whodunnit
+      user = User.find_by(id: creator_id)
+      user.kerberos_id
+    end
+  end
+
+  # Per internal discussions, we are setting this to the create date of 
+  # the parent thesis, which may be slightly different than the date the 
+  # file(s) were transferred.
+  def date_thesis_file_received
+    self.thesis.created_at.strftime('%Y-%m-%d')
+  end
+
+  # In the unlikely scenario that the the status was changed to 'released' 
+  # multiple times, this assumes we want the most recent date released.
+  def date_released
+    released_versions = self.versions.select do |version| 
+      version.changeset["status"][1] == 'released' if version.changeset["status"].present?
+    end
+    dates_released = released_versions.map { |version| version.changeset["updated_at"][1] }
+    dates_released.sort.last
+  end
 end

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -89,10 +89,18 @@ class HoldTest < ActiveSupport::TestCase
     assert_equal change.changeset["case_number"], [nil, "2"]
   end
 
-  test 'can return the formatted parent thesis create date' do
+  test 'can list the create dates and names of the parent thesis files' do
     h = holds(:valid)
-    created_at = h.thesis.created_at.strftime('%Y-%m-%d')
-    assert_equal created_at, h.date_thesis_file_received
+    f = Rails.root.join('test','fixtures','files','a_pdf.pdf')
+    h.thesis.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
+    thesis_file = h.thesis.files.first
+    assert_equal "a_pdf.pdf", thesis_file.filename.to_s
+    assert_equal h.dates_thesis_files_received, "#{thesis_file.created_at.strftime('%Y-%m-%d')} (#{thesis_file.filename.to_s})"
+
+    f2 = Rails.root.join('test','fixtures','files','registrar.csv')
+    h.thesis.files.attach(io: File.open(f2), filename: 'registrar.csv')
+    dates_display = h.thesis.files.map { |file| "#{file.created_at.strftime('%Y-%m-%d')} (#{file.filename.to_s})" }.join("\n")
+    assert_equal h.dates_thesis_files_received, dates_display
   end
 
   test 'can list associated degrees' do

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -95,12 +95,15 @@ class HoldTest < ActiveSupport::TestCase
     h.thesis.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
     thesis_file = h.thesis.files.first
     assert_equal "a_pdf.pdf", thesis_file.filename.to_s
-    assert_equal h.dates_thesis_files_received, "#{thesis_file.created_at.strftime('%Y-%m-%d')} (#{thesis_file.filename.to_s})"
+    assert_includes h.dates_thesis_files_received, thesis_file.created_at.strftime('%Y-%m-%d')
+    assert_includes h.dates_thesis_files_received, "a_pdf.pdf"
 
     f2 = Rails.root.join('test','fixtures','files','registrar.csv')
     h.thesis.files.attach(io: File.open(f2), filename: 'registrar.csv')
-    dates_display = h.thesis.files.map { |file| "#{file.created_at.strftime('%Y-%m-%d')} (#{file.filename.to_s})" }.join("\n")
-    assert_equal h.dates_thesis_files_received, dates_display
+    create_dates = h.thesis.files.map { |file| file.created_at.strftime('%Y-%m-%d') }
+    filenames = h.thesis.files.map { |file| file.filename.to_s }
+    assert create_dates.each { |date| h.dates_thesis_files_received.include?(date) }
+    assert filenames.each { |fname| h.dates_thesis_files_received.include?(fname) }
   end
 
   test 'can list associated degrees' do

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -89,6 +89,12 @@ class HoldTest < ActiveSupport::TestCase
     assert_equal change.changeset["case_number"], [nil, "2"]
   end
 
+  test 'can return the formatted parent thesis create date' do
+    h = holds(:valid)
+    created_at = h.thesis.created_at.strftime('%Y-%m-%d')
+    assert_equal created_at, h.date_thesis_file_received
+  end
+
   test 'can list associated degrees' do
     hold = holds(:valid)
     assert_equal "MFA\nJD", hold.degrees


### PR DESCRIPTION
#### Why these changes are being introduced:

Processors need certain information regarding a Hold's audit trail in the
admin UI:

* The date the hold was released
* The date the thesis file was received
* The user who created the hold

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-176

#### How this addresses that need:

* Adds new fields to the Hold dashboard: created_by,
dates_thesis_files_received, date_released.
* Adds convenience methods to the Hold model to access the necessary
data.

#### Side effects of this change:

We haven't yet implemented the primary flag for thesis files, so in this 
iteration, date_thesis_file_received becomes dates_thesis_files_received 
and lists the names and create dates of all associated files.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
