### PR TITLE
Update user dashboard to reflect submitters

### DIFF
--- a/app/assets/stylesheets/administrate.scss
+++ b/app/assets/stylesheets/administrate.scss
@@ -6,15 +6,19 @@
   border-top: 4px solid #000;
   .panel-heading {
     font-size: 1.6rem;
-    margin: 1.5rem 2rem .5rem 2rem;
+    margin: 1.5rem 2rem 0.5rem 2rem;
   }
   .panel-body {
-    margin: .5rem 2rem 1.5rem 2rem;
+    margin: 0.5rem 2rem 1.5rem 2rem;
   }
 }
 
 .new-hold-button {
-  margin-left: 2rem
+  margin-left: 2rem;
+}
+
+.new-submitter-button {
+  margin-top: 1rem;
 }
 
 #hold_dates_files_received {

--- a/app/controllers/admin/submitters_controller.rb
+++ b/app/controllers/admin/submitters_controller.rb
@@ -42,5 +42,13 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
+    def new
+      resource = new_resource
+      authorize_resource(resource)
+      resource.user_id = params[:user_id]
+      render locals: {
+        page: Administrate::Page::Form.new(dashboard, resource),
+      }
+    end
   end
 end

--- a/app/dashboards/submitter_dashboard.rb
+++ b/app/dashboards/submitter_dashboard.rb
@@ -23,7 +23,6 @@ class SubmitterDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
   user
   department
-  id
   created_at
   ].freeze
 

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -20,6 +20,7 @@ class UserDashboard < Administrate::BaseDashboard
     middle_name: Field::String,
     surname: Field::String,
     display_name: Field::String,
+    submitters: UserSubmitterField,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     role: Field::Select.with_options(
@@ -50,6 +51,7 @@ class UserDashboard < Administrate::BaseDashboard
     orcid
     email
     admin
+    submitters
     created_at
     updated_at
   ].freeze

--- a/app/fields/user_submitter_field.rb
+++ b/app/fields/user_submitter_field.rb
@@ -1,0 +1,4 @@
+require "administrate/field/base"
+
+class UserSubmitterField < Administrate::Field::HasMany
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -48,12 +48,19 @@ class Ability
   # but not the admin dashboards.
   def processor
     basic
+
+    can "index", :all
+    can "show", :all
+
+    can :manage, :submitter
+
+    can %i[read update], Thesis
+    can :annotate, Thesis
     can :mark_downloaded, Thesis
     can :mark_withdrawn, Thesis
-    can :annotate, Thesis
     can :process_theses, Thesis
     can :stats, Thesis
-    can :read, Thesis
+    
     can :read, Transfer
   end
 
@@ -61,11 +68,13 @@ class Ability
   # on departments).
   def thesis_admin
     processor
-    can %i[create update], Thesis
-    can :create, Transfer
-    can :read, Transfer
-    can :administrate, Admin
-    can :create, Registrar
-    can :read, Registrar
+
+    can :manage, :all  
+    cannot "destroy", :copyright
+    cannot "destroy", :degree
+    cannot "destroy", :department
+    cannot "destroy", :hold_source
+    cannot "destroy", :license
+    cannot "destroy", :thesis
   end
 end

--- a/app/views/admin/holds/_form.html.erb
+++ b/app/views/admin/holds/_form.html.erb
@@ -14,8 +14,6 @@ and renders all form fields for a resource's editable attributes.
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
 %>
 
-<% content_for(:custom_stylesheets) { stylesheet_link_tag "administrate" } %>
-
 <%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">

--- a/app/views/fields/user_submitter_field/_show.html.erb
+++ b/app/views/fields/user_submitter_field/_show.html.erb
@@ -34,5 +34,6 @@ from the associated resource class's dashboard.
   <%= t("administrate.fields.has_many.none", default: "–") %>
 <% end %>
 
-<br />
-<%= link_to("Authorize User to new Department as Submitter", new_admin_submitter_path(user_id: page.resource.id), class: 'button') %>
+<div class='new-submitter-button'>
+  <%= link_to("Authorize User to new Department as Submitter", new_admin_submitter_path(user_id: page.resource.id), class: 'button') %>
+</div>

--- a/app/views/fields/user_submitter_field/_show.html.erb
+++ b/app/views/fields/user_submitter_field/_show.html.erb
@@ -1,0 +1,38 @@
+<%#
+Yanked the entire first section of this code from
+https://github.com/thoughtbot/administrate/blob/master/app/views/fields/has_many/_show.html.erb
+%>
+<%#
+# HasMany Show Partial
+This partial renders a has_many relationship,
+to be displayed on a resource's show page.
+By default, the relationship is rendered
+as a table of the first few associated resources.
+The columns of the table are taken
+from the associated resource class's dashboard.
+## Local variables:
+- `field`:
+  An instance of [Administrate::Field::HasMany][1].
+  Contains methods to help display a table of associated resources.
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/HasMany
+%>
+<% if field.resources.any? %>
+  <% order = field.order_from_params(params.fetch(field.name, {})) %>
+  <% page_number = params.fetch(field.name, {}).fetch(:page, nil) %>
+  <%= render(
+    "collection",
+    collection_presenter: field.associated_collection(order),
+    collection_field_name: field.name,
+    page: page,
+    resources: field.resources(page_number, order),
+    table_title: field.name,
+  ) %>
+  <% if field.more_than_limit? %>
+    <%= paginate field.resources(page_number), param_name: "#{field.name}[page]" %>
+  <% end %>
+<% else %>
+  <%= t("administrate.fields.has_many.none", default: "–") %>
+<% end %>
+
+<br />
+<%= link_to("Authorize User to new Department as Submitter", new_admin_submitter_path(user_id: page.resource.id), class: 'button') %>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -22,7 +22,7 @@ By default, it renders:
     <%= content_for(:title) %> - <%= application_title %>
   </title>
   <%= render "stylesheet" %>
-  <%= yield :custom_stylesheets %>
+  <%= stylesheet_link_tag "administrate" %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,3 +46,5 @@ en:
       hold_source:
         created_at: Created on
         updated_at: Updated on
+      user:
+        submitters: Authorized Submitter for

--- a/test/integration/admin_submitter_dashboard_test.rb
+++ b/test/integration/admin_submitter_dashboard_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class AdminSubmitterDashboardTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'accessing submitter dashboard as basic user redirects to root' do
+    mock_auth(users(:basic))
+    get '/admin/submitters/new'
+    assert_response :redirect
+  end
+
+  test 'accessing submitter dashboard as transfer submitter redirects' do
+    mock_auth(users(:transfer_submitter))
+    get '/admin/submitters/new'
+    assert_response :redirect
+  end
+
+  test 'accessing submitter dashboard as thesis_process is allowed' do
+    mock_auth(users(:processor))
+    get '/admin/submitters/new'
+    assert_response :success
+  end
+
+  test 'new submitter form has no selection with no user_id param' do
+    mock_auth(users(:processor))
+    get '/admin/submitters/new'
+    assert_response :success
+    assert_select('select#submitter_user_id option[selected]', false)
+  end
+
+  test 'new submitter form pre-selects user when user_id param is present' do
+    mock_auth(users(:processor))
+    get "/admin/submitters/new?user_id=#{users(:basic).id}"
+    assert_response :success
+
+    assert_equal(
+      assert_select('select#submitter_user_id option[selected]').first['value'],
+      users(:basic).id.to_s
+    )
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* It is difficult for our staff to quickly see which users are
  authorized submitters for various departments
* Making it so looking up the user and being able to quickly see which
  departments they can submit to will allow for initial setup and
  ongoing maintainance more efficient

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-181

How does this address that need:

* adds Submitters to the User show dashboard
* creates a custom field to jumpstart create a new Submitter

Document any side effects to this change:

The custom field is forked from the gem's `has_many` code. If there are
changes upstream, we'll need to move them locally to this forked copy.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO


#### Includes new or updated dependencies?

NO
