### PR TITLE
ETD-186 Create UI for full listing of hold history

### DIFF
--- a/app/controllers/hold_controller.rb
+++ b/app/controllers/hold_controller.rb
@@ -1,0 +1,23 @@
+class HoldController < ApplicationController
+  before_action :require_user
+  before_action :authenticate_user!
+  load_and_authorize_resource
+  protect_from_forgery with: :exception
+
+  def show
+    @hold = Hold.find(params[:id])
+  end
+
+  private
+
+  def require_user
+    return if current_user
+    # Do NOT use ENV['FAKE_AUTH_ENABLED'] directly! Use the config. It performs
+    # an additional check to make sure we are not on the production server.
+    if Rails.configuration.fake_auth_enabled
+      redirect_to user_developer_omniauth_authorize_path
+    else
+      redirect_to user_saml_omniauth_authorize_path
+    end
+  end
+end

--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -15,7 +15,7 @@ class HoldDashboard < Administrate::BaseDashboard
       format: "%Y %B",
     ),
     hold_source: Field::BelongsTo,
-    id: Field::Number,
+    id: HoldHistoryField,
     date_requested: Field::Date,
     date_start: Field::Date,
     date_end: Field::Date,
@@ -35,7 +35,6 @@ class HoldDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-  id
   author_names
   grad_date
   thesis

--- a/app/fields/hold_history_field.rb
+++ b/app/fields/hold_history_field.rb
@@ -1,0 +1,4 @@
+require "administrate/field/base"
+
+class HoldHistoryField < Administrate::Field::Base
+end

--- a/app/helpers/hold_helper.rb
+++ b/app/helpers/hold_helper.rb
@@ -1,0 +1,23 @@
+module HoldHelper
+  def modified_by(version)
+    if user = User.find_by(id: version.whodunnit)
+      link_to user.kerberos_id, admin_user_path(user.id)
+    else
+      "User ID #{version.whodunnit} no longer active."
+    end
+  end
+
+  def render_hold_history_field(field_name, field_value)
+    # Set nil values to something that will display onscreen
+    field_value = "n/a" if field_value.nil? 
+
+    # For foreign key fields, return a link to the record
+    if field_name == 'thesis_id' && thesis = Thesis.find_by(id: field_value)
+      field_value = link_to thesis.title, admin_thesis_path(field_value)
+    elsif field_name == 'hold_source_id' && hold_source = HoldSource.find_by(id: field_value)
+      field_value = link_to hold_source.source, admin_hold_source_path(field_value)
+    end
+    
+    field_value
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,7 @@ class Ability
     can :stats, Thesis
     
     can :read, Transfer
+    can :read, Hold
   end
 
   # Library staff who can use the admin dashboards (which includes operations

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -40,7 +40,7 @@ class Hold < ApplicationRecord
   end
 
   def created_by
-    if self.versions.first.event == 'create'
+    if self.versions.present? && self.versions.first.event == 'create'
       creator_id = self.versions.first.whodunnit
       if user = User.find_by(id: creator_id)
         user.kerberos_id

--- a/app/views/fields/hold_history_field/_show.html.erb
+++ b/app/views/fields/hold_history_field/_show.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'View hold history', hold_history_path(field.data) %>

--- a/app/views/hold/show.html.erb
+++ b/app/views/hold/show.html.erb
@@ -1,0 +1,32 @@
+<%= content_for(:title, "Thesis Submission | MIT Libraries") %>
+
+<h3 class="hd-3"><%= "Full hold history: #{@hold.thesis.title}" %></h3>
+<p><%= link_to 'Return to hold record', admin_hold_path(@hold) %></p>
+<% @hold.versions.reverse_each do |version| %>
+  <div class="box-content">
+    <h4 class="hd-4">Version <%= version.index + 1 %></h4>
+    <ul class="list-unbulleted">
+      <li>Event type: <%= version.event %></li>
+      <li>Modified by: <%= modified_by(version) %></li>
+      <li>
+        <table class="table table-simplified table-cozy">
+          <tbody>
+            <tr>
+              <th scope="col">Field name</th>
+              <th scope="col">Previous value</th>
+              <th scope="col">New value</th>
+            </tr>
+            <% version.changeset.each do |key, value| %>
+              <tr>
+                <td><%= t("hold_history.#{key}") %></td>
+                <td><%= render_hold_history_field(key, value[0]) %></td>
+                <td><%= render_hold_history_field(key, value[1]) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </li>
+    </ul>
+  </div>
+  <br/>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,12 +30,22 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  hold_history:
+    id: Hold ID
+    thesis_id: Thesis
+    date_start: Start date
+    date_end: End date
+    created_at: Created on
+    updated_at: Updated on
+    case_number: TLO case number
+    processing_notes: Hold notes
   helpers:
     label:
       degree:
         name_dw: Name (Data Warehouse)
         name_dspace: Name (Dspace)
       hold:
+        id: Audit trail
         grad_date: Degree date
         date_start: Start date
         date_end: End date

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   get 'harvest', to: 'registrar#list_registrar', as: 'harvest'
   get 'harvest/:id', to: 'registrar#process_registrar',
                      as: 'process_registrar'
+  get 'hold_history/:id', to: 'hold#show', as: 'hold_history'
 
   devise_for :users, :controllers => {
     :omniauth_callbacks => 'users/omniauth_callbacks'

--- a/test/controllers/hold_controller_test.rb
+++ b/test/controllers/hold_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class HoldControllerTest < ActionDispatch::IntegrationTest
+  test "thesis admins can view hold history" do
+    sign_in users(:thesis_admin)
+    @hold = Hold.first
+    get hold_history_path(@hold)
+    assert_response :success
+  end
+
+  test "processors can view hold history" do
+    sign_in users(:processor)
+    @hold = Hold.first
+    get hold_history_path(@hold)
+    assert_response :success
+  end
+
+  test "basic users cannot view hold history" do
+    sign_in users(:basic)
+    @hold = Hold.first
+    assert_raises CanCan::AccessDenied do
+      get hold_history_path(@hold)
+    end
+  end
+
+  test "anonymous users cannot view hold history" do
+    @hold = Hold.first
+    get hold_history_path(@hold)
+    assert_response :redirect
+  end
+end

--- a/test/integration/admin_dashboard_test.rb
+++ b/test/integration/admin_dashboard_test.rb
@@ -700,6 +700,14 @@ class AdminDashboardTest < ActionDispatch::IntegrationTest
     assert_select "select[name=?]", "hold[thesis_id]"
   end
 
+  test 'custom field displays link to hold history' do
+    mock_auth(users(:thesis_admin))
+    hold = holds(:valid)
+    get "/admin/holds/#{hold.id}"
+    assert_response :success
+    assert_select "a[href='/hold_history/#{hold.id}']", "View hold history"
+  end
+
   # Hold_sources
   test 'accessing hold_sources panel does not work with basic rights' do
     mock_auth(users(:basic))

--- a/test/integration/hold_test.rb
+++ b/test/integration/hold_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class HoldIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+    @hold_params = {
+     thesis_id: theses(:two).id,
+     date_requested: "2021-03-15",
+     date_start: "2021-03-15",
+     date_end: "2021-03-15",
+     hold_source_id: hold_sources(:tlo).id,
+     case_number: "",
+     status: "active",
+     processing_notes: "", }
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'returns the kerb of the user who modified the record version' do
+    user = users(:thesis_admin)
+    mock_auth user
+    orig_count = Hold.count
+    post admin_holds_path, params: { hold: @hold_params }
+    hold = Hold.last
+    assert_equal orig_count + 1, Hold.count
+    assert_equal 1, hold.versions.length
+
+    get hold_history_path(hold)
+    assert_select "li", "Modified by: thesis_admin"
+    assert_select "a[href='/admin/users/#{user.id}']", "thesis_admin"
+  end
+
+  test 'returns useful text if user who modified no longer exists' do
+    user = User.new(uid: 'expendable@mit.edu', email: 'expendable@mit.edu', 
+                    kerberos_id: 'expendable', admin: true)
+    user.save
+    mock_auth user
+    orig_hold_count = Hold.count
+    post admin_holds_path, params: { hold: @hold_params }
+    hold = Hold.last
+    assert_equal orig_hold_count + 1, Hold.count
+    assert_equal 1, hold.versions.length
+
+    orig_user_count = User.count
+    user.destroy
+    assert_equal orig_user_count - 1, User.count
+
+    mock_auth users(:thesis_admin)
+    get hold_history_path(hold)
+    assert_select "li", "Modified by: User ID #{user.id} no longer active."
+  end
+
+  test "nil fields are converted to n/a" do
+    mock_auth users(:thesis_admin)
+    orig_hold_count = Hold.count
+    post admin_holds_path, params: { hold: @hold_params }
+    hold = Hold.last
+    assert_equal orig_hold_count + 1, Hold.count
+    assert_equal 1, hold.versions.length
+
+    get hold_history_path(hold)
+    assert_equal true, hold.versions.first.changeset { |k, v| v[0].nil? }.any?
+    assert_select "td", "n/a"
+  end
+
+  test 'thesis_id field is rendered as a link to the thesis' do
+    mock_auth users(:thesis_admin)
+    orig_hold_count = Hold.count
+    post admin_holds_path, params: { hold: @hold_params }
+    hold = Hold.last
+    assert_equal orig_hold_count + 1, Hold.count
+    assert_equal 1, hold.versions.length
+
+    get hold_history_path(hold)
+    assert_select "a[href='/admin/theses/#{hold.thesis_id}']", hold.thesis.title
+  end
+
+  test 'hold_source_id field is rendered as a link to the hold source' do
+    mock_auth users(:thesis_admin)
+    orig_hold_count = Hold.count
+    post admin_holds_path, params: { hold: @hold_params }
+    hold = Hold.last
+    assert_equal orig_hold_count + 1, Hold.count
+    assert_equal 1, hold.versions.length
+
+    get hold_history_path(hold)
+    assert_select "a[href='/admin/hold_sources/#{hold.hold_source_id}']", hold.hold_source.source
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need a way to see the full audit trail for a Hold record. Only some
paper_trail fields are currently visible in the Hold administrate UI.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-186

#### How this addresses that need:

* Adds a hold history page (the Hold show page) that displays audit
information for a given Hold record. Initially, I chose to display the
following fields for each version:
    * The event type (e.g., create/update/destroy);
    * The user who modified the record; and
    * Everything in the version changeset.
* Adds a custom field, hold_history, to administrate, to provide a link
to the hold history page from the Hold dashboard.
* Adds Hold#show method to route to the hold history page.

#### Side effects of this change:

* Added complexity: we now have a Hold controller with a show method, a
corresponding view and route, and a Hold helper.
* In order to get the custom field to work and display as desired, I
added an i18n translate to render the ID field in the Hold dashboard
as 'Hold history'. We may need to rework this later, if for some reason
we want to display the Hold ID in a different context.
* Because I chose to create this view outside of administrate, it uses
the regular Thing layout. This might be confusing to users since they
will be coming to this view from the admin dashboard, which has a
different layout.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
