### PR TITLE
Add rake tasks to seed degrees and departments

### DIFF
--- a/db/migrate/20210317165853_update_dw_name_in_departments.rb
+++ b/db/migrate/20210317165853_update_dw_name_in_departments.rb
@@ -1,0 +1,15 @@
+class UpdateDwNameInDepartments < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        remove_index :departments, :name_dw
+        add_index :departments, :name_dw
+      end
+
+      dir.down do
+        remove_index :departments, :name_dw
+        add_index :departments, :name_dw, unique: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_212632) do
+ActiveRecord::Schema.define(version: 2021_03_17_165853) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -124,7 +124,7 @@ ActiveRecord::Schema.define(version: 2021_03_05_212632) do
     t.string "code_dw", default: "", null: false
     t.string "name_dspace"
     t.index ["code_dw"], name: "index_departments_on_code_dw", unique: true
-    t.index ["name_dw"], name: "index_departments_on_name_dw", unique: true
+    t.index ["name_dw"], name: "index_departments_on_name_dw"
   end
 
   create_table "hold_sources", force: :cascade do |t|

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,37 @@
+require 'csv'
+require 'open-uri'
+
+namespace :db do
+  desc "Seed the database with degrees from a Degree Seeds CSV file"
+  task :seed_degrees, [:file_url] => :environment do |t, args|
+    csv_data = URI.open(args[:file_url])
+    CSV.new(csv_data, encoding: "bom|utf-8", headers: true).each.with_index(2) do |row, i|
+      Rails.logger.info("Processing row " + i.to_s)
+      degree = Degree.from_csv(row)
+      if degree.name_dspace.blank?
+        degree.update(name_dspace: row['Degree Name DSpace'])
+        Rails.logger.info("Degree DSpace name added: " + degree.name_dspace)
+      end
+      unless degree.degree_type
+        degree.update(degree_type: DegreeType.find_by(name: row['THING Degree Type']))
+        Rails.logger.info("Degree type added: " + degree.degree_type.name)
+      end
+      Rails.logger.info("Degree complete: " + degree.inspect)
+    end
+  end
+
+  desc "Seed the database with departments from a Department Seeds CSV file"
+  task :seed_departments, [:file_url] => :environment do |t, args|
+    csv_data = URI.open(args[:file_url])
+    CSV.new(csv_data, encoding: "bom|utf-8", headers: true).each.with_index(2) do |row, i|
+      Rails.logger.info("Processing row " + i.to_s)
+      department = Department.from_csv(row)
+      if department.name_dspace.blank?
+        department.update(name_dspace: row['Department Name DSpace'])
+        Rails.logger.info("Department DSpace name added: " + department.name_dspace)
+      end
+      Rails.logger.info("Department complete: " + department.inspect)
+    end
+  end
+
+end


### PR DESCRIPTION
Why these changes are being introduced:
We have several hundred official degrees and departments with unique
codes and names from the Data Warehouse that need to be seeded to the
database. Ideally this process will be repeatable for initial testing
and future dev/test/staging database resets.

How this addresses that need:
* Adds two db-namespaced rake tasks, one to seed the degrees and
  another to seed the departments.

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/etd-169

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
