### PR TITLE
ETD-212 Implement public UI home page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,6 @@
 
 YES | NO
 
-
 #### Includes new or updated dependencies?
 
 YES | NO

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_resource_or_scope)
     if can?(:process_theses, Thesis)
       process_path
+    elsif can?(:create, Transfer)
+      new_transfer_path
     else
       new_thesis_path
     end

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -7,7 +7,7 @@
       <div class="wrap-bar">
         <nav class="local-nav" aria-label="Main menu">
           <%= nav_link_to("Home", root_path) %>
-          <%= nav_link_to("Submit Thesis", new_thesis_path) %>
+          <%= nav_link_to("Submit thesis information", new_thesis_path) %>
 
           <% if user_signed_in? %>
             <% if can? :process_theses, Thesis %>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -1,67 +1,29 @@
 <%= content_for(:title, "Thesis Submission | MIT Libraries") %>
 
 <div class="layout-3q1q layout-band">
+  <div class="col3q box-content">
+    <p><strong>Students -</strong> this tool allows you to review 
+    and submit your thesis information. This information will help 
+    us to more quickly catalog and make your thesis available in 
+    DSpace.</p>
+    <p><%= link_to('Submit information', new_thesis_path, class: 'btn button-primary') %></p>
+    <br/>
 
-  <div class="col3q">
-    <h3 class="title title-page">Preserve and share your scholarship</h3>
+    <p><strong>Department Administrators -</strong> this tool allows 
+    you to transfer your department or program’s theses to the MIT 
+    Libraries. <em>(Prior authorization required)</em></p>
+    <p><%= link_to('Transfer theses', new_transfer_path, class: 'btn button-primary') %></p>
+    <br/>
 
-    <div class="well">
-      <h4>May or September 2020 degree list candidates</h4>
-
-      <ul>
-        <li>Your thesis must be submitted electronically to your department or
-        program. For this degree period Libraries will not accept PDFs directly
-        from the author.</li>
-
-        <li>For doctoral theses only: after submitting your thesis to your
-        department, please use this site to submit your
-        <a href="https://libraries.mit.edu/wp-content/uploads/2019/08/umi-proquest-form.pdf">ProQuest form</a>
-        and a copy of your title and abstract pages.</li>
-      </ul>
-
-      <h4>Departments</h4>
-
-      Please do not submit via this site. Email
-      <a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help">mit-theses@mit.edu</a>
-      with any questions.
-
-    </div>
-
-    <p>
-      Adding your thesis or dissertation to MIT's DSpace thesis collection is a great way to preserve the record of your scholarship at MIT. Theses in DSpace are visible to anyone in the world, and will be preserved digitally for long term use and access.
-    </p>
-
-    <p>
-      Adding your thesis only takes a few minutes, and preserves color content, text searchability, and embedded links within your thesis.
-    </p>
-
-    <p>
-      Information about your thesis will be indexed by search engines like Google after your thesis is loaded into DSpace. All theses in DSpace can be accessed via a persistent URL (also called a handle) which will not change.
-    </p>
-
-    <p>
-      <% if user_signed_in? %>
-        <%= link_to('Get started', new_thesis_path, class: 'btn button-primary') %>
-      <% else %>
-        <% if Rails.configuration.fake_auth_enabled %>
-          <%= link_to("Sign in to get started", user_developer_omniauth_authorize_path, id: "sign_in", class: 'btn button-primary') %>
-        <% else %>
-          <%= link_to("Sign in to get started", user_saml_omniauth_authorize_path, id: "sign_in", class: 'btn button-primary') %>
-        <% end %>
-      <% end %>
-    </p>
-
+    <p><a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help">
+    Contact us</a> with any questions.</p>
   </div>
 
   <aside class="content-sup col1q-r" role="complementary">
     <div class="bit">
       <h3 class="title">Need help?</h3>
-        <p>
-          Email us at <a href="mailto:etheses-admin@mit.edu?Subject=Thesis%20submission%20help">etheses-admin@mit.edu</a> for further assistance.
-        </p>
-        <p><a href="https://libraries.mit.edu/archives/thesis-specs/index.html">Review the Thesis Specifications</a></p>
-        <p><a href="https://libguides.mit.edu/c.php?g=176367&p=1159611">Tips for a Successful e-submission</a></p>
-      </div>
-    </aside>
-
+      <p><a href="mailto:etheses-admin@mit.edu?Subject=Thesis%20submission%20help">
+        Contact us</a> with any questions.</p>
+    </div>
+  </aside>
 </div>

--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -40,13 +40,31 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     assert_equal(usercount + 1, User.count)
   end
 
-  test 'redirect to root path after login for normal users' do
+  test 'redirect to new thesis path after login for basic users' do
     mock_auth(users(:yo))
     follow_redirect!
     assert_equal '/thesis/new', @request.path
   end
 
-  test 'redirect to root path after login for admin users' do
+  test 'redirect to new transfer path after login for submitters' do
+    mock_auth(users(:transfer_submitter))
+    follow_redirect!
+    assert_equal '/transfer/new', @request.path
+  end
+
+  test 'redirect to thesis processing path after login for processors' do
+    mock_auth(users(:processor))
+    follow_redirect!
+    assert_equal '/process', @request.path
+  end
+
+  test 'redirect to thesis processing path after login for thesis admins' do
+    mock_auth(users(:thesis_admin))
+    follow_redirect!
+    assert_equal '/process', @request.path
+  end
+
+  test 'redirect to thesis processing path after login for admins' do
     mock_auth(users(:admin))
     follow_redirect!
     assert_equal '/process', @request.path

--- a/test/integration/nav_test.rb
+++ b/test/integration/nav_test.rb
@@ -20,7 +20,7 @@ class NavTest < ActionDispatch::IntegrationTest
     mock_auth(users(:basic))
     get new_thesis_path
     assert_select('.current') do |value|
-      assert(value.text.include?('Submit Thesis'))
+      assert(value.text.include?('Submit thesis information'))
     end
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

We need a landing page for the public UI to direct students and
transfer submitters to the correct form.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-212
* https://mitlibraries.atlassian.net/browse/ETD-209 (mockup)

#### How this addresses that need:

This modifies the existing static index page to reflect the new app's
purpose and functionality.

#### Side effects of this change:

* Transfer submitters are now redirected after login to the transfer
submission form.
* Removes an extra newline from the PR template (completely unrelated,
but it was irking me).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
