### PR TITLE
Removes aggregation on degree field in new thesis form

### DIFF
--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -93,7 +93,7 @@
     <% # TODO: Make Degrees an "add-another" field %>
     <%= f.association :degrees, label_method: :name_dw, as: :select,
                          include_hidden: false,
-                         collection: Degree.all.order(:name_dw).group(:name_dw),
+                         collection: Degree.all.order(:name_dw),
                          label_html: { class: 'col1q' },
                          wrapper_html: { class: 'field-wrap select layout-band layout-1q3q' },
                          input_html: { class: 'field field-select col3q', multiple: false,


### PR DESCRIPTION
This rolls back the aggregation that I tried to enact on the degree field of the new thesis form. While it had the desired effect locally with a SQLite database, the PG database on Heroku is throwing an error because the Degree ID field isn't involved in the aggregation:

The actual error encountered in the Heroku logs is:

```
ActionView::Template::Error (PG::GroupingError: ERROR:  column "degrees.id" must appear in the GROUP BY clause or be used in an aggregate function
```

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
