### PR TITLE
Fix minor coauthor bug in registrar import

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -170,7 +170,7 @@ class Thesis < ApplicationRecord
       thesis = theses.first
       if thesis.coauthors.blank?
         thesis.coauthors = row['Thesis Coauthor']
-      elsif thesis.coauthors.exclude? row['Thesis Coauthor']
+      elsif thesis.coauthors.exclude? row['Thesis Coauthor'].to_s
         thesis.coauthors += "; " + row['Thesis Coauthor']
       end
       thesis.degrees << degree unless thesis.degrees.include?(degree)

--- a/test/jobs/registrar_import_job_test.rb
+++ b/test/jobs/registrar_import_job_test.rb
@@ -21,7 +21,8 @@ class RegistrarImportJobTest < ActiveJob::TestCase
     results = RegistrarImportJob.perform_now(registrar)
     assert_equal 434, results[:read]
     assert_equal 433, results[:processed]
-    assert_equal 1, results[:errors]
+    assert_equal 1, results[:errors].length()
+    assert_includes results[:errors][0], "Row #418 missing a Kerberos ID"
   end
 
 end


### PR DESCRIPTION
Why these changes are being introduced:
In preparing for registrar data import on production, a small bug was
identified where a blank coauthor field in the CSV caused an error
while updating an existing thesis.

How this addresses that need:
* Updates the Thesis.create_or_update_from_csv method to convert a nil
  value from the CSV coauthor field to a string, enabling the desired
  logic

Side effects of this change:
* Also updated the registrar_import_job result output to display any
  errors encountered, just to make the final results clear in the logs
  at the end of the job.

Relevant ticket(s):
NA

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
