### PR TITLE
Converts License field to conditionally display

### DIFF
--- a/app/assets/javascripts/student_thesis_form.js
+++ b/app/assets/javascripts/student_thesis_form.js
@@ -1,0 +1,14 @@
+// This is the shared javascript for the new and edit thesis forms that are
+// used by students.
+
+// Hide/show license field based on copyright answer
+function conditionalLicenseField() {
+    var value = $("select#thesis_copyright_id option:selected").text();
+    if ('I hold copyright' == value) {
+      $("div.thesis_license").show();
+    } else {
+      $("div.thesis_license").hide();
+      $("select#thesis_license_id")[0].value = "";
+    }
+};
+

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -188,4 +188,10 @@
       }
     }
   });
+  $('#thesis_copyright_id').change(function() {
+    conditionalLicenseField();
+  });
+  $(function() {
+    conditionalLicenseField();
+  });
 </script>

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -211,4 +211,10 @@
       }
     }
   });
+  $('#thesis_copyright_id').change(function() {
+    conditionalLicenseField();
+  });
+  $(function() {
+    conditionalLicenseField();
+  });
 </script>


### PR DESCRIPTION
This writes a small javascript function to read the state of the Copyright field, and set the state of the License field according to what it finds. This function is then called both during initial page load, and then also by a change() listener on the Copyright field.

This could probably have been either a Javascript object, or written in native javascript with no jQuery. I'm open to refactoring this if whomever reviews it would like.

Ticket: https://mitlibraries.atlassian.net/browse/ETD-236

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
