### PR TITLE
Hotfixes: Adds missing asterisks, and name field label

### DIFF
--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -95,7 +95,7 @@
       </div>
 
       <div class="layout-1q3q layout-band field-wrap">
-        <div class="col1q"><strong>Degree date</strong></div>
+        <div class="col1q"><strong>Degree date *</strong></div>
         <div class="col3q">
           <%= f.object.graduation_month %>
           <%= f.object.graduation_year %>
@@ -128,7 +128,7 @@
 
       <div class="layout-band layout-1q3q field-wrap">
         <div class="col1q">
-          <strong>Thesis supervisor(s)</strong>
+          <strong>Thesis supervisor(s)*</strong>
           <p class="hint">(just supervisors, not entire committee)</p>
         </div>
         <%= f.simple_fields_for :advisors do |advisor| %>
@@ -142,6 +142,7 @@
       <%= f.input :abstract, as: :text,
                              required: true,
                              validate: { presence: true },
+                             label: 'Abstract *',
                              label_html: { class: 'col1q' },
                              wrapper_html: { class: 'field-wrap layout-1q3q layout-band' },
                              input_html: { class: 'field field-text col3q',

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -60,7 +60,7 @@
 
       <%= f.simple_fields_for :users do |u| %>
         <% if u.object.id == current_user.id %>
-          <%= u.input :preferred_name, label: 'Name as it appears on thesis',
+          <%= u.input :preferred_name, label: 'Name on thesis (if different than above)',
                                        label_html: { class: 'col1q' },
                                        wrapper_html: { class: 'field-wrap layout-1q3q layout-band' },
                                        input_html: { class: 'field field-text col3q' },

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -60,7 +60,7 @@
 
     <%= f.simple_fields_for :users do |u| %>
       <% if u.object.id == current_user.id %>
-        <%= u.input :preferred_name, label: 'Name as it appears on thesis',
+        <%= u.input :preferred_name, label: 'Name on thesis (if different than above)',
                                      label_html: { class: 'col1q' },
                                      wrapper_html: { class: 'field-wrap layout-1q3q layout-band' },
                                      input_html: { class: 'field field-text col3q' },

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -106,7 +106,7 @@
                          hint_html: { id: 'thesis_degrees_ids-hint', class: 'col3q' } %>
 
     <div class="layout-band layout-1q3q">
-      <p class="col1q"><strong>Degree date</strong></p>
+      <p class="col1q"><strong>Degree date *</strong></p>
       <div class="col3q">
         <span id="thesis_date_ids-hint" class="hint">For the degree date, enter the semester in which your degree will be conferred (typically your graduation semester).</span>
         <div class='group-inline'>
@@ -151,7 +151,7 @@
 
     <div class="layout-band layout-1q3q field-wrap">
       <div class="col1q">
-        <strong>Thesis supervisor(s)</strong>
+        <strong>Thesis supervisor(s)*</strong>
         <p class="hint">(just supervisors, not entire committee)</p>
       </div>
       <%= f.simple_fields_for :advisors do |advisor| %>


### PR DESCRIPTION
This implements two requested hotfixes:

- Adds asterisks to a few field labels (and label-like elements, like "Degree date" and "Thesis supervisor(s)". Also the Abstract field on the edit form, which was left off initially.
- Changes the label on the name field based on stakeholder feedback

Tickets:

- Abstract has no ticket
- Name change: https://mitlibraries.atlassian.net/browse/ETD-237

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
