### PR TITLE
WIP - Updates to thesis supervisor / advisor field behavior

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -6,6 +6,7 @@ class ThesisController < ApplicationController
 
   def new
     @thesis = Thesis.new
+    @thesis.association(:advisors).add_to_target(Advisor.new())
     @thesis.users = [current_user]
   end
 
@@ -31,6 +32,9 @@ class ThesisController < ApplicationController
 
   def edit
     @thesis = Thesis.find(params[:id])
+    if @thesis.advisors.count == 0
+      @thesis.association(:advisors).add_to_target(Advisor.new())
+    end
   end
 
   def show

--- a/app/views/thesis/_advisor_fields.html.erb
+++ b/app/views/thesis/_advisor_fields.html.erb
@@ -1,5 +1,7 @@
 <div class="nested-fields col3q">
-  <%= f.input :name, label: 'Name *',
+  <%= f.input :name, required: true,
+                     validate: { presence: true },
+                     label: 'Name *',
                      label_html: { class: 'col1q' },
                      wrapper_html: { class: 'layout-band layout-1q3q' },
                      input_html: { class: 'field field-text col3q' },

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -151,7 +151,7 @@
           <%= render 'advisor_fields', :f => advisor %>
         <% end %>
         <p class="links col3q">
-          <%= link_to_add_association 'Add supervisor', f, :advisors %>
+          <%= link_to_add_association 'Add another supervisor', f, :advisors %>
         </p>
       </div>
 
@@ -204,6 +204,9 @@
         $("div.error").hide();
       }
     }
+  });
+  $("form.thesisSubmission").on('cocoon:after-insert', function(e, insertedItem) {
+    $(insertedItem).find("input").focus();
   });
   $('#thesis_copyright_id').change(function() {
     conditionalLicenseField();

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -147,7 +147,7 @@
         <%= render 'advisor_fields', :f => advisor %>
       <% end %>
       <p class="links col3q">
-        <%= link_to_add_association 'Add supervisor', f, :advisors %>
+        <%= link_to_add_association 'Add another supervisor', f, :advisors %>
       </p>
     </div>
 
@@ -203,6 +203,9 @@
         min: 1861
       }
     }
+  });
+  $("#new_thesis").on('cocoon:after-insert', function(e, insertedItem) {
+    $(insertedItem).find("input").focus();
   });
   $('#thesis_copyright_id').change(function() {
     conditionalLicenseField();


### PR DESCRIPTION
This addresses three of the items on the pre-launch punchlist: 1b (initial field), 1c (add another supervisor), and 1e (focus). The final item, 1d (handling blank fields) is still in progress - but we've decided to get the stablished fixes through code review now so that other work can proceed with less chance of a merge conflict.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
