### PR TITLE
User friendly authorization error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :ensure_domain
 
+  rescue_from CanCan::AccessDenied do
+    redirect_to root_path, alert: 'Not authorized.'
+  end
+
   def new_session_path(_scope)
     root_path
   end

--- a/test/controllers/hold_controller_test.rb
+++ b/test/controllers/hold_controller_test.rb
@@ -18,9 +18,10 @@ class HoldControllerTest < ActionDispatch::IntegrationTest
   test "basic users cannot view hold history" do
     sign_in users(:basic)
     @hold = Hold.first
-    assert_raises CanCan::AccessDenied do
-      get hold_history_path(@hold)
-    end
+    get hold_history_path(@hold)
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test "anonymous users cannot view hold history" do

--- a/test/controllers/registrar_controller_test.rb
+++ b/test/controllers/registrar_controller_test.rb
@@ -58,35 +58,44 @@ class RegistrarControllerTest < ActionDispatch::IntegrationTest
 
   test 'basic user cannot submit or view a registrar' do
     sign_in users(:basic)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/new"
-    end
+    get "/registrar/new"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+
     sign_in users(:basic)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/#{registrar(:valid).id}"
-    end
+    get "/registrar/#{registrar(:valid).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'processors cannot submit or view a registrar' do
     sign_in users(:processor)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/new"
-    end
+    get "/registrar/new"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+
     sign_in users(:processor)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/#{registrar(:valid).id}"
-    end
+    get "/registrar/#{registrar(:valid).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'transfer_submitters cannot submit or view a registrar' do
     sign_in users(:transfer_submitter)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/new"
-    end
+    get "/registrar/new"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+
     sign_in users(:transfer_submitter)
-    assert_raises CanCan::AccessDenied do
-      get "/registrar/#{registrar(:valid).id}"
-    end
+    get "/registrar/#{registrar(:valid).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'Loading a request page initiates the import job' do

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -68,9 +68,10 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'user cannot view another user thesis' do
     sign_in users(:bad)
-    assert_raises CanCan::AccessDenied do
-      get "/thesis/#{theses(:one).id}"
-    end
+    get "/thesis/#{theses(:one).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'anonymous user cannot view another user thesis' do
@@ -182,9 +183,10 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'basic users cannot see submissions processing page' do
     sign_in users(:basic)
-    assert_raises(CanCan::AccessDenied) do
-      get process_path
-    end
+    get process_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'processor users can see submissions processing page' do
@@ -622,9 +624,10 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
   test 'basic users cannot mark as downloaded' do
     sign_in users(:basic)
     thesis = theses(:active)
-    assert_raises CanCan::AccessDenied do
-      post mark_downloaded_url(thesis), xhr: true
-    end
+    post mark_downloaded_url(thesis), xhr: true
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
     assert_equal 'active', thesis.reload.status
   end
 
@@ -682,9 +685,10 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
   test 'basic users cannot mark as withdrawn' do
     sign_in users(:basic)
     thesis = theses(:active)
-    assert_raises CanCan::AccessDenied do
-      post mark_withdrawn_url(thesis), xhr: true
-    end
+    post mark_withdrawn_url(thesis), xhr: true
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
     assert_equal 'active', thesis.reload.status
   end
 
@@ -755,10 +759,12 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     orig_note = thesis.processor_note
     target_note = 'Best consumed with scooby snacks'
     note_field_id = "note_#{thesis.id}"
-    assert_raises CanCan::AccessDenied do
-      post annotate_url(thesis),
-        params: Hash[note_field_id, target_note], xhr: true
-    end
+    post annotate_url(thesis),
+      params: Hash[note_field_id, target_note], xhr: true
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+
     assert_equal orig_note, thesis.reload.processor_note
   end
 
@@ -803,9 +809,10 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
 
   test 'basic users cannot see stats' do
     sign_in users(:basic)
-    assert_raises CanCan::AccessDenied do
-      get stats_path
-    end
+    get stats_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'thesis processors can see stats' do

--- a/test/controllers/transfer_controller_test.rb
+++ b/test/controllers/transfer_controller_test.rb
@@ -28,20 +28,24 @@ class TransferControllerTest < ActionDispatch::IntegrationTest
 
   test 'basic user cannot submit or view a transfer' do
     sign_in users(:basic)
-    assert_raises CanCan::AccessDenied do
-      get "/transfer/new"
-    end
+    get "/transfer/new"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+
     sign_in users(:basic)
-    assert_raises CanCan::AccessDenied do
-      get "/transfer/#{transfers(:valid).id}"
-    end
+    get "/transfer/#{transfers(:valid).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'processor cannot submit a transfer' do
     sign_in users(:processor)
-    assert_raises CanCan::AccessDenied do
-      get "/transfer/new"
-    end
+    get "/transfer/new"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'transfer submitter can view their own transfer' do
@@ -52,9 +56,10 @@ class TransferControllerTest < ActionDispatch::IntegrationTest
 
   test 'transfer submitter cannot view transfers they did not submit' do
     sign_in users(:transfer_submitter)
-    assert_raises CanCan::AccessDenied do
-      get "/transfer/#{transfers(:alsovalid).id}"
-    end
+    get "/transfer/#{transfers(:alsovalid).id}"
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'thesis admin can view any transfer' do

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -220,9 +220,10 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
   # Thesis editing form
   test 'cannot request edit page for not-your-theses' do
     mock_auth(users(:basic))
-    assert_raises CanCan::AccessDenied do
-      get thesis_path(theses(:one))
-    end
+    get thesis_path(theses(:one))
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
   end
 
   test 'can load edit page for your thesis' do


### PR DESCRIPTION
Why are these changes being introduced:

* there are states in the app where a user might click a link that they
  are not authorized to access. Ideally, we'd not display that link.
  For now, we are redirecting to root and displaying a message they are
  not authorized rather than throwing an exception.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-215

How does this address that need:

* We are now redirecint all authorization errors to root with a message
  they are not authorized.

Document any side effects to this change:

* The result is now a 200 instead of a 403. For this application that
  seems fine as it will only occur for authenticated human users.
* Tests had to be updated to reflect it was no longer a 403.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
