### PR TITLE
ETD-230 Remove degree field from new thesis form

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -63,8 +63,6 @@ class Thesis < ApplicationRecord
 
   validates :departments, presence:
     { message: VALIDATION_MSGS[:departments] }
-  validates :degrees, presence:
-    { message: VALIDATION_MSGS[:degrees] }
 
   validates :files_complete, exclusion: [nil]
   validates :metadata_complete, exclusion: [nil]

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -94,20 +94,6 @@
                          hint: 'Select your primary department as listed on your title page. If additional departments are needed, use the Notes field below.',
                          hint_html: { id: 'thesis_departments_ids-hint', class: 'col3q' } %>
 
-    <% # TODO: Make Degrees an "add-another" field %>
-    <%= f.association :degrees, label_method: :name_dw, as: :select,
-                         include_hidden: false,
-                         collection: Degree.all.order(:name_dw),
-                         label: 'Degree *',
-                         label_html: { class: 'col1q' },
-                         wrapper_html: { class: 'field-wrap select layout-band layout-1q3q' },
-                         input_html: { class: 'field field-select col3q', multiple: false,
-                           data: { msg: Thesis::VALIDATION_MSGS[:degrees] },
-                           'aria-describedby': 'thesis_degrees_ids-hint'
-                         },
-                         hint: 'Select your primary degree as listed on your title page. If additional degrees are needed, use the Notes field below.',
-                         hint_html: { id: 'thesis_degrees_ids-hint', class: 'col3q' } %>
-
     <div class="layout-band layout-1q3q">
       <p class="col1q"><strong>Degree date *</strong></p>
       <div class="col3q">

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -62,14 +62,6 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
     assert_select 'span.error', text: Thesis::VALIDATION_MSGS[:departments]
   end
 
-  test 'invalid degrees message' do
-    mock_auth(users(:basic))
-    params = @thesis_params
-    params[:degree_ids] = nil
-    post thesis_index_path, params: { thesis: params }
-    assert_select 'span.error', text: Thesis::VALIDATION_MSGS[:degrees]
-  end
-
   test 'invalid files message' do
     skip("Unclear why this used to pass but now fails, but the data model never properly validated attached thesis so this failing is not surprising")
     mock_auth(users(:basic))

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -179,12 +179,6 @@ class ThesisTest < ActiveSupport::TestCase
     end
   end
 
-  test 'invalid without degree' do
-    thesis = theses(:one)
-    thesis.degrees = []
-    assert(thesis.invalid?)
-  end
-
   test 'can have multiple degrees' do
     thesis = theses(:one)
     thesis.degrees = [degrees(:one), degrees(:two)]


### PR DESCRIPTION
#### Why these changes are being introduced:

The degree drop-down is difficult to use due to duplicate entries. The
degree will always be supplied by the registrar, so we don’t need it from
creation.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-230

#### How this addresses that need:

This removes the degree validation from the thesis model and removes the
degree field from the new form.

#### Side effects of this change:

A confirmation email sent to a student that completes the new form will
show no degree associated with their thesis, which may be confusing.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
