### PR TITLE
Allow removal of supervisor fields

### DIFF
--- a/app/assets/javascripts/student_thesis_form.js
+++ b/app/assets/javascripts/student_thesis_form.js
@@ -3,12 +3,21 @@
 
 // Hide/show license field based on copyright answer
 function conditionalLicenseField() {
-    var value = $("select#thesis_copyright_id option:selected").text();
-    if ('I hold copyright' == value) {
-      $("div.thesis_license").show();
-    } else {
-      $("div.thesis_license").hide();
-      $("select#thesis_license_id")[0].value = "";
-    }
+  var value = $("select#thesis_copyright_id option:selected").text();
+  if ('I hold copyright' == value) {
+    $("div.thesis_license").show();
+  } else {
+    $("div.thesis_license").hide();
+    $("select#thesis_license_id")[0].value = "";
+  }
 };
 
+// Hide/show "remove this supervisor" link if only one
+// field is present (one value is required)
+function hideOnlySupervisorLink() {
+  if ($("a.remove_fields").length == 1) {
+    $("a.remove_fields").addClass("only");
+  } else {
+    $("a.remove_fields").removeClass("only")
+  }
+}

--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -100,6 +100,25 @@ form.simple_form {
     height: 20px;
     width: 20px;
   }
+  .advisor.nested-fields {
+    margin-bottom: 1.5rem;
+
+    div.input {
+      float: left;
+      width: 75%;
+    }
+
+    aside {
+      float: right;
+      margin-left: 3%;
+      margin-top: 2rem;
+      width: 20%;
+
+      a.remove_fields.only {
+        display: none;
+      }
+    }
+  }
 }
 
 // info

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -138,7 +138,7 @@ class ThesisController < ApplicationController
                                    :graduation_year, :copyright_id, :author_note,
                                    :license_id, :department_ids, :degree_ids,
                                    users_attributes: [:id, :orcid, :preferred_name],
-                                   advisors_attributes: [:id, :name])
+                                   advisors_attributes: [:id, :name, :_destroy])
   end
 
   def sorted_theses(queryset, sort)

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -40,7 +40,8 @@ class Thesis < ApplicationRecord
 
   has_many_attached :files
 
-  accepts_nested_attributes_for :users, :advisors
+  accepts_nested_attributes_for :users
+  accepts_nested_attributes_for :advisors, allow_destroy: :true
 
   attr_accessor :graduation_year, :graduation_month
 

--- a/app/views/thesis/_advisor_fields.html.erb
+++ b/app/views/thesis/_advisor_fields.html.erb
@@ -1,11 +1,11 @@
-<div class="nested-fields col3q">
+<div class="advisor nested-fields col3q">
   <%= f.input :name, required: true,
                      validate: { presence: true },
                      label: 'Name *',
-                     label_html: { class: 'col1q' },
-                     wrapper_html: { class: 'layout-band layout-1q3q' },
-                     input_html: { class: 'field field-text col3q' },
+                     label_html: { class: '' },
+                     wrapper_html: { class: '' },
+                     input_html: { class: 'field field-text wide' },
                      hint: '(Enter as Last/Surname, First/Given name Middle name)',
-                     hint_html: { class: 'col3q' } %>
-  <br>&nbsp;
+                     hint_html: { class: '' } %>
+  <aside><%= link_to_remove_association "Remove this supervisor", f %></aside>
 </div>

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -206,12 +206,17 @@
     }
   });
   $("form.thesisSubmission").on('cocoon:after-insert', function(e, insertedItem) {
+    hideOnlySupervisorLink();
     $(insertedItem).find("input").focus();
+  });
+  $("form.thesisSubmission").on('cocoon:after-remove', function(e) {
+    hideOnlySupervisorLink();
   });
   $('#thesis_copyright_id').change(function() {
     conditionalLicenseField();
   });
   $(function() {
     conditionalLicenseField();
+    hideOnlySupervisorLink();
   });
 </script>

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -206,12 +206,17 @@
     }
   });
   $("#new_thesis").on('cocoon:after-insert', function(e, insertedItem) {
+    hideOnlySupervisorLink();
     $(insertedItem).find("input").focus();
+  });
+  $("#new_thesis").on('cocoon:after-remove', function(e) {
+    hideOnlySupervisorLink();
   });
   $('#thesis_copyright_id').change(function() {
     conditionalLicenseField();
   });
   $(function() {
     conditionalLicenseField();
+    hideOnlySupervisorLink();
   });
 </script>


### PR DESCRIPTION
This resolves the final aspect of ETD-240, enabling the user to remove thesis supervisor fields from the form under some conditions. This avoids the problem of a user having created too many fields, as well as allowing user to remove supervisors they have already identified.

At the same time, this change adds a check to the form logic to prevent the user from removing the _last_ supervisor field.

This is all possible because the supervisor fields are not backed by any authority, and all values are specific to each thesis. This work creates a side effect, however, of allowing orphan supervisors to accumulate - because when an existing supervisor is removed from a Thesis, the link is deleted but the supervisor record itself is kept. Eventually we will need a cleanup task, or to convert advisors to something backed by an authority.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
