### PR TITLE
ETD-250 Change degree year field to a select

### DIFF
--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -104,12 +104,13 @@
                                wrapper_html: { class: 'field-wrap' },
                                input_html: { class: 'field field-select', data: { msg: Thesis::VALIDATION_MSGS[:graduation_month] },
                                'aria-describedby': 'thesis_date_ids-hint' } %>
-          <%= f.input :graduation_year, label: 'Year *', as: :string,
+          <%= f.input :graduation_year, label: 'Year *',
+                                        collection: [Date.today.last_year.strftime('%Y'), 
+                                                     Date.today.strftime('%Y'), 
+                                                     Date.today.next_year.strftime('%Y')],
                               wrapper_html: { class: 'field-wrap' },
                               input_html: { class: 'field field-select',
-                                data: { msg: Thesis::VALIDATION_MSGS[:graduation_year] },
-                              type: 'number',
-                              step: 1 } %>
+                                data: { msg: Thesis::VALIDATION_MSGS[:graduation_year] } } %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### Why these changes are being introduced:

The degree year field in the thesis form is currently free text, but
the stakeholders would prefer that it be a drop-down with last year,
current year, and next year as the options.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-250

#### How this addresses that need:

* Changes the field in thesis/new to a select using simpleform's collection
option, which allows us to specify the values in an array.
* Uses the `last_year` and `next_year` methods on the `Date` object to
evaluate which years to add to the collection.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
