### PR TITLE
Open mailto links in a new window/tab

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -15,14 +15,14 @@
     <p><%= link_to('Transfer theses', new_transfer_path, class: 'btn button-primary') %></p>
     <br/>
 
-    <p><a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help">
+    <p><a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help" target="_blank">
     Contact us</a> with any questions.</p>
   </div>
 
   <aside class="content-sup col1q-r" role="complementary">
     <div class="bit">
       <h3 class="title">Need help?</h3>
-      <p><a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help">
+      <p><a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help" target="_blank">
         Contact us</a> with any questions.</p>
     </div>
   </aside>

--- a/app/views/thesis/_sidebar.html.erb
+++ b/app/views/thesis/_sidebar.html.erb
@@ -8,5 +8,5 @@
       </ul>
     </li>
   </ul>
-  <p>Questions? <a href="mailto:mit-theses@mit.edu">Contact us</a></p>
+  <p>Questions? <a href="mailto:mit-theses@mit.edu" target="_blank">Contact us</a></p>
 </div>

--- a/app/views/thesis/_welcome.html.erb
+++ b/app/views/thesis/_welcome.html.erb
@@ -12,5 +12,5 @@
       form</a> (PhDs only) directly to your departments.</li>
     <li>If needed, you can update certain fields until graduation day.</li>
   </ul>
-  <p>Please <a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help">contact us</a> with any questions.</p>
+  <p>Please <a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help" target="_blank">contact us</a> with any questions.</p>
 </div>

--- a/app/views/thesis/confirm.html.erb
+++ b/app/views/thesis/confirm.html.erb
@@ -7,6 +7,6 @@
   <li>Submit your thesis files with the <a href="https://libguides.mit.edu/c.php?g=176367&p=8229377#s-lg-box-wrapper-30716057">required filename format</a> and <a href="https://libraries.mit.edu/wp-content/uploads/2019/08/umi-proquest-form.pdf">Proquest form</a> (PhDs only) directly to your departments.</li>
   <li>If needed, you can update certain fields until graduation day.</li>
 </ul>
-<p><a href="mailto:mit-theses <mit-theses@mit.edu>">Contact us</a> with any questions.</p>
+<p><a href="mailto:mit-theses <mit-theses@mit.edu>" target="_blank">Contact us</a> with any questions.</p>
 <p>&nbsp;</p>
 <h4>Congratulations on (almost) finishing your degree!</h4>


### PR DESCRIPTION
#### Why these changes are being introduced:

If a user has configured a browser-based email client as their default,
then mailto links will open in the same window. We want those links to
open in a new window. This is stakeholder feedback on ETD-251.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-251

#### How this addresses that need:

Adds target="_blank" to mailto links in the landing page and thesis
partials.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
