### PR TITLE
Adds harvest and registrar paths to navigation

### DIFF
--- a/app/controllers/registrar_controller.rb
+++ b/app/controllers/registrar_controller.rb
@@ -15,7 +15,7 @@ class RegistrarController < ApplicationController
     @registrar.graduation_list.attach(params[:registrar][:graduation_list])
     if @registrar.save
       flash.notice = 'Thank you for submitting this Registrar file.'
-      redirect_to root_path()
+      redirect_to harvest_path()
     else
       flash[:error] = "Error saving Registrar file: #{@registrar.errors.full_messages}"
       render 'new'

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -17,6 +17,12 @@
             <% if can? :create, Transfer %>
               <%= nav_link_to("Transfer theses", new_transfer_path) %>
             <% end %>
+            <% if can? :create, Registrar %>
+              <%= nav_link_to("Upload CSV", new_registrar_path) %>
+            <% end %>
+            <% if can? :list_registrar, Registrar %>
+              <%= nav_link_to("Harvest CSV", harvest_path) %>
+            <% end %>
             <% if current_user.admin? || can?(:administrate, Admin) %>
               <%= link_to("Admin", admin_root_path, class: 'nav-item') %>
             <% end %>

--- a/test/controllers/registrar_controller_test.rb
+++ b/test/controllers/registrar_controller_test.rb
@@ -30,6 +30,9 @@ class RegistrarControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'confirmation of successful submission' do
+    @registrar = registrar(:valid)
+    f = Rails.root.join('test','fixtures','files','registrar.csv')
+    @registrar.graduation_list.attach(io: File.open(f), filename: 'registrar.csv')
     sign_in users(:thesis_admin)
     post '/registrar',
       params: {
@@ -39,7 +42,7 @@ class RegistrarControllerTest < ActionDispatch::IntegrationTest
       }
     assert_response :redirect
     follow_redirect!
-    assert_equal path, '/'
+    assert_equal path, harvest_path
     assert_not @response.body.include? "Error"
     assert @response.body.include? "Thank you for submitting this Registrar file."
   end

--- a/test/integration/nav_test.rb
+++ b/test/integration/nav_test.rb
@@ -11,7 +11,7 @@ class NavTest < ActionDispatch::IntegrationTest
 
   # Testing navigation link text
   test 'home page nav' do
-    get '/'
+    get root_path
     assert_select('.current') do |value|
       assert(value.text.include?('Home'))
     end
@@ -41,6 +41,25 @@ class NavTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'registrar page nav' do
+    mock_auth(users(:admin))
+    get new_registrar_path
+    assert_select('.current') do |value|
+      assert(value.text.include?('Upload CSV'))
+    end
+  end
+
+  test 'harvest page nav' do
+    @registrar = registrar(:valid)
+    f = Rails.root.join('test','fixtures','files','registrar.csv')
+    @registrar.graduation_list.attach(io: File.open(f), filename: 'registrar.csv')
+    mock_auth(users(:admin))
+    get harvest_path
+    assert_select('.current') do |value|
+      assert(value.text.include?('Harvest CSV'))
+    end
+  end
+
   test 'transfer page nav' do
     mock_auth(users(:admin))
     get new_transfer_path
@@ -62,6 +81,8 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", process_path, count: 0
       assert_select "a[href=?]", stats_path, count: 0
       assert_select "a[href=?]", new_transfer_path, count: 0
+      assert_select "a[href=?]", new_registrar_path, count: 0
+      assert_select "a[href=?]", harvest_path, count: 0
       assert_select "a[href=?]", admin_root_path, count: 0
     end
   end
@@ -79,6 +100,8 @@ class NavTest < ActionDispatch::IntegrationTest
       # Navigation should not include:
       assert_select "a[href=?]", process_path, count: 0
       assert_select "a[href=?]", stats_path, count: 0
+      assert_select "a[href=?]", new_registrar_path, count: 0
+      assert_select "a[href=?]", harvest_path, count: 0
       assert_select "a[href=?]", admin_root_path, count: 0
     end
   end
@@ -94,6 +117,8 @@ class NavTest < ActionDispatch::IntegrationTest
       # assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", process_path
       assert_select "a[href=?]", stats_path
+      assert_select "a[href=?]", new_registrar_path, count: 0
+      assert_select "a[href=?]", harvest_path, count: 0
       # assert_select "a[href=?]", admin_root_path
     end
   end
@@ -109,6 +134,8 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", process_path
       assert_select "a[href=?]", stats_path
+      assert_select "a[href=?]", new_registrar_path
+      assert_select "a[href=?]", harvest_path
       assert_select "a[href=?]", admin_root_path
     end
   end
@@ -124,6 +151,8 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", process_path
       assert_select "a[href=?]", stats_path
+      assert_select "a[href=?]", new_registrar_path
+      assert_select "a[href=?]", harvest_path
       assert_select "a[href=?]", admin_root_path
     end
   end


### PR DESCRIPTION
This adds two new links to the main navigation, scoped to those who can perform those actions. The first is for uploading a CSV file from the registrar, the second is to initiate harvesting of that file.

Please note: I've added a bit of setup to the navigation test fixtures now, to make sure that the /registrar path works as expected. This is how we deal with attachments for the model tests, but I wonder if the right step here isn't to actually change how our fixtures are defined.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
