### PR TITLE
Handle nil thesis titles in title_helper

### DIFF
--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -87,7 +87,7 @@ module ThesisHelper
   # Handles UI situations where a thesis may not have a title but we need to
   # provide a link via its (undefined) title.
   def title_helper(thesis)
-    return "Untitled thesis" if thesis.title.strip.length < 1
+    return "Untitled thesis" unless thesis.title.present?
     thesis.title
   end
 end

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -163,4 +163,19 @@ class ThesisHelperTest < ActionView::TestCase
 
     assert_equal 2019, latest_year
   end
+
+  test 'title helper can handle nils' do
+    @thesis = Thesis.new
+    assert_equal 'Untitled thesis', title_helper(@thesis)
+  end
+
+  test 'title helper can empty titles' do
+    @thesis = Thesis.new(title: '')
+    assert_equal 'Untitled thesis', title_helper(@thesis)
+  end
+
+  test 'title helper passes title if populated' do
+    @thesis = Thesis.new(title: 'yolo title!')
+    assert_equal 'yolo title!', title_helper(@thesis)
+  end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Some registrar loaded data does not have a title
* We need to display a list of theses to users if they have more than
  one thesis
* The helper method to display "Untitled thesis" only handled empty
  strings
* This change adds handling nils to that method as well.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-273

How does this address that need:

* Returns our expected text for nil thesis titles

Document any side effects to this change:

* Added regression tests in the helper for both empty, nil and populated
  titles

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
