### PR TITLE
Maintain focus during removal of supervisor field

### DIFF
--- a/app/assets/javascripts/student_thesis_form.js
+++ b/app/assets/javascripts/student_thesis_form.js
@@ -15,9 +15,36 @@ function conditionalLicenseField() {
 // Hide/show "remove this supervisor" link if only one
 // field is present (one value is required)
 function hideOnlySupervisorLink() {
-  if ($("a.remove_fields").length == 1) {
+  var visible_fields = visibleAdvisorFields();
+  if ( visible_fields.length === 1 ) {
     $("a.remove_fields").addClass("only");
   } else {
     $("a.remove_fields").removeClass("only")
   }
+}
+
+// Sets the form's focus on the first visible supervisor
+// field. Called after one is removed, to ensure focus
+// is always defined.
+function focusOnFirstVisibleSupervisor() {
+  var visible_fields = visibleAdvisorFields();
+  $( $(visible_fields)[0] ).find("input[type=text]").focus();
+}
+
+// Shared function to count how many supervisor fields
+// are visible. This is needed because, when editing a
+// thesis record, the "remove this supervisor" link does
+// not actually remove the field from the DOM - so you
+// need to filter the list of fields by which have been
+// made invisible.
+//
+// This is called by both the focus and hideOnly functions
+// above.
+function visibleAdvisorFields() {
+  return $('div.advisor.nested-fields').filter(function() {
+    if ( $(this).attr('style')==='display: none;') {
+      return false;
+    }
+    return true;
+  });
 }

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -221,6 +221,7 @@
     $(insertedItem).find("input[type=text]").attr("aria-describedby", ts).focus();
   });
   $("form.thesisSubmission").on('cocoon:after-remove', function(e) {
+    focusOnFirstVisibleSupervisor();
     hideOnlySupervisorLink();
   });
   $('#thesis_copyright_id').change(function() {

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -223,6 +223,7 @@
     $(insertedItem).find("input[type=text]").attr("aria-describedby", ts).focus();
   });
   $("#new_thesis").on('cocoon:after-remove', function(e) {
+    focusOnFirstVisibleSupervisor();
     hideOnlySupervisorLink();
   });
   $('#thesis_copyright_id').change(function() {


### PR DESCRIPTION
This fixes the issue where focus is left undefined when a supervisor field is removed.

It also fixes a separate-but-related bug where the "remove this supervisor" link is not appropriately removed on the edit form in some conditions.

Note: I'm not sure how to use ANDI or Wave when changes like this are made - but I _have_ tested this code under keyboard navigation and using visual cues under my locally-installed browsers (Firefox, Chrome, and Safari).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
