### PR TITLE
Adds task to assist in examining SAML responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,21 @@ note: Base64 is required due to multiline ENV being weird to deal with.
 `URN_SURNAME` - `urn:oid:2.5.4.4` for MIT
 These have not been tried with testshib but there's a chance they're the same. These correspond to the `givenName` and `sn` fields in Shibboleth.
 
-`URN_DISPLAY_NAME` - `urn:oid:2.16.840.1.113730.3.1.241` for MIT. Possibly 
-the same in testshib, but we haven't confirmed. This corresponds to the 
+`URN_DISPLAY_NAME` - `urn:oid:2.16.840.1.113730.3.1.241` for MIT. Possibly
+the same in testshib, but we haven't confirmed. This corresponds to the
 `displayName` field in Shibboleth.
 
-
 `URN_UID` - `urn:oid:1.3.6.1.4.1.5923.1.1.1.6` should be good enough for both MIT and testshib. However, it is not guaranteed to be forever unique but MIT does not provide a truly unique option so this is the best we've got.
+
+NOTE: There is a rake task to help debug responses from the IdP.
+
+Example usage:
+
+- grab a SAML response from a production or staging log
+- remove all XML and quotes and put ONLY the raw encrypted SAML response into
+  a single line of a text file. NOTE: the response likely spans multiple logger
+  lines so you'll need to be careful to reconstruct this
+- `rails debug:saml['tmp/your_saml_to_debug.txt']`
 
 # Local deployment
 

--- a/lib/tasks/debug.rake
+++ b/lib/tasks/debug.rake
@@ -1,0 +1,22 @@
+require 'onelogin/ruby-saml'
+
+namespace :debug do
+  desc "Debug an encrypted saml response. Ensure SP cert and key are set in .env"
+  task :saml, :filepath do |t, args|
+    # Assumptions: you have extracted the saml response from logs and placed ONLY
+    # the response (not the XML!, not the quotes) into a file on a single line
+    saml_response = File.open(args[:filepath]).first
+
+    # see https://github.com/onelogin/ruby-saml#the-initialization-phase for more
+    # options depending on what you are debugging
+    settings = OneLogin::RubySaml::Settings.new
+    settings.certificate = Base64.strict_decode64(ENV['SP_CERTIFICATE'])
+    settings.private_key = Base64.strict_decode64(ENV['SP_PRIVATE_KEY'])
+
+    response = OneLogin::RubySaml::Response.new(saml_response, settings: settings)
+    # This should output all attributes we got back.
+    pp "-- START SAML RESPONSE --"
+    pp response.attributes
+    pp "-- END SAML RESPONSE --"
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* It is difficult to see what is in a production or staging SAML
  response as they are encrypted
* It is often useful to see what is included in a production or staging
  SAML response

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-275

How does this address that need:

* adds a rake task that will read SP key and cert from .env and then
  decrypt and output the SAML response

Document any side effects to this change:

- It remains a bit tedious to get the SAML response in a useful format.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
