### PR TITLE
Removes extra period in "You are" partial

### DIFF
--- a/app/views/shared/_you_are.html.erb
+++ b/app/views/shared/_you_are.html.erb
@@ -1,4 +1,4 @@
 <p class="copy-sup">
   You are logged in and submitting as <%= current_user.display_name %> (<%= current_user.email %>).
-  Not you? <%= link_to("Sign out.", destroy_user_session_path, method: :delete) %>.
+  Not you? <%= link_to("Sign out", destroy_user_session_path, method: :delete) %>.
 </p>


### PR DESCRIPTION
** Why are these changes being introduced:

* There is a double period in the rendering of the "You are logged in"
  partial

** Relevant ticket(s):

* n/a

** How does this address that need:

* This removes the extra period.

** Document any side effects to this change:

* None

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
