### PR TITLE
Work in progress toward Transfer processing form

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -123,6 +123,25 @@ form.simple_form {
   }
 }
 
+// transfer processing form
+ul.list-files {
+  li {
+    padding: 0.5rem;
+
+    &:hover,
+    &:focus {
+      background: #ccc;
+    }
+
+    input {
+      height: 1em;
+      margin-right: 1em;
+      width: 1em;
+      vertical-align: middle;
+    }
+  }
+}
+
 // info
 .label.subtitle3 {
   margin-top: 2rem;

--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -26,6 +26,17 @@ class TransferController < ApplicationController
     end
   end
 
+  def files
+    @transfer = Transfer.find(params[:id])
+    flash[:success] = "This is a test of the files method.<br>".html_safe
+    filelist = params[:transfer][:file_ids]
+    filelist.each do |file|
+      flash[:success] += ("File ID: " + file.to_s + "<br>").html_safe
+    end
+    flash[:success] += "This has been a test of the files method. If this were an actual method, these " + filelist.count.to_s + " files would have been transferred."
+    redirect_to transfer_path(@transfer.id)
+  end
+
   def select
     @transfer = Transfer.all
   end
@@ -49,6 +60,6 @@ class TransferController < ApplicationController
 
   def transfer_params
     params.require(:transfer).permit(:graduation_month, :graduation_year, 
-                                     :department_id, :note)
+                                     :department_id, :note, :file_ids)
   end
 end

--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -33,7 +33,7 @@ class TransferController < ApplicationController
     filelist.each do |file|
       flash[:success] += ("File ID: " + file.to_s + "<br>").html_safe
     end
-    flash[:success] += "This has been a test of the files method. If this were an actual method, these " + filelist.count.to_s + " files would have been transferred."
+    flash[:success] += "This has been a test of the files method. If this were an actual method, these " + filelist.count.to_s + " files would have been attached to the selected thesis."
     redirect_to transfer_path(@transfer.id)
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,7 +44,6 @@ class Ability
     basic
     can :create, Transfer
     can :confirm, Transfer
-    can :read, Transfer, user_id: @user.id
   end
 
   # Library staff who process the thesis queue. They should be able to use the

--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -1,7 +1,57 @@
 <%= content_for(:title, "Transfer Processing | MIT Libraries") %>
 
-<h3 class="title title-page">Transfer file list</h3>
-
 <p><%= link_to "Back to Transfer queue", transfer_select_path %></p>
 
-<p>This will be the display of all files in this Transfer, for processing into Thesis records.</p>
+<h3 class="title title-page">Transfer from <%= @transfer.department.name_dw %> on <%= @transfer.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y at %l:%M %p') %></h3>
+
+<div class="well">
+  <div class="layout-band layout-1q3q">
+    <div class="col1q">Received:</div>
+    <div class="col3q"><%= @transfer.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y<br>%l:%M %p').html_safe %></div>
+  </div>
+  <div class="layout-band layout-1q3q">
+    <div class="col1q">Department:</div>
+    <div class="col3q"><%= @transfer.department.name_dw %></div>
+  </div>
+  <div class="layout-band layout-1q3q">
+    <div class="col1q">Submitter:</div>
+    <div class="col3q"><%= @transfer.user.display_name %></div>
+  </div>
+  <% if @transfer.note && @transfer.note.length > 0 %>
+    <div class="layout-band layout-1q3q">
+      <div class="col1q">Submitter's note:</div>
+      <div class="col3q"><%= @transfer.note %></div>
+    </div>
+  <% end %>
+</div>
+
+<div class="alert alert-banner error" style="display: none;" role="alert" aria-invalid="true"></div>
+
+<%= form_tag(transfer_files_path, method: "post") do %>
+  <%= hidden_field_tag( 'id', @transfer.id ) %>
+
+  <div class="gridband layout-2c">
+    <div class="grid-item">
+      <h4>Assign these files ...</h4>
+      <fieldset>
+        <legend>Select the files to move</legend>
+        <ul class="list-unbulleted list-files">
+          <% @transfer.files.each do |file| %>
+            <li>
+              <label>
+              <%= check_box_tag "transfer[file_ids][]", file.id %>
+              <%= file.filename.to_s %>
+              </label>
+            </li>
+          <% end %>
+        </ul>
+      </fieldset>
+
+    </div>
+    <div class="grid-item">
+      <h4>...to this thesis:</h4>
+    </div>
+  </div>
+
+  <%= submit_tag('Transfer files', class: 'btn button-primary') %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
   }
 
   get 'transfer/confirm', to: 'transfer#confirm', as: 'transfer_confirm'
+  post 'transfer/files', to: 'transfer#files', as: 'transfer_files'
   get 'transfer/select', to: 'transfer#select', as: 'transfer_select'
   resources :transfer, only: [:new, :create, :show]
 


### PR DESCRIPTION
This adds the first part of the transfer processing form. Along the way it also changes the ability model to restrict who can see this path, and it restructures the controller tests for Transfer records.

This work addresses two tickets:
https://mitlibraries.atlassian.net/browse/ETD-277
https://mitlibraries.atlassian.net/browse/ETD-278

**Special note:** I'm not thrilled by the approach taken by the last test in the controller test file, but I don't see an alternative other than re-doing the fixtures (which feels like work that's going to spiral). If that's needed, I'll do it - but I wanted to make that decision via code review.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
