### PR TITLE
Add DSpace handle to thesis model

### DIFF
--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -41,6 +41,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     coauthors: Field::String,
     copyright: Field::BelongsTo,
     license: Field::BelongsTo,
+    dspace_handle: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -74,6 +75,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     holds
     status
     publication_status
+    dspace_handle
     author_note
     processor_note
     metadata_complete

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -17,6 +17,7 @@
 #  coauthors          :string
 #  copyright_id       :integer
 #  license_id         :integer
+#  dspace_handle      :string
 #
 
 class Thesis < ApplicationRecord

--- a/db/migrate/20210511192431_add_dspace_handle_to_thesis.rb
+++ b/db/migrate/20210511192431_add_dspace_handle_to_thesis.rb
@@ -1,0 +1,5 @@
+class AddDspaceHandleToThesis < ActiveRecord::Migration[6.0]
+  def change
+    add_column :theses, :dspace_handle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_17_165853) do
+ActiveRecord::Schema.define(version: 2021_05_11_192431) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -187,6 +187,7 @@ ActiveRecord::Schema.define(version: 2021_03_17_165853) do
     t.string "coauthors"
     t.integer "copyright_id"
     t.integer "license_id"
+    t.string "dspace_handle"
     t.index ["copyright_id"], name: "index_theses_on_copyright_id"
     t.index ["license_id"], name: "index_theses_on_license_id"
   end

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -17,6 +17,7 @@
 #  coauthors          :string
 #  copyright_id       :integer
 #  license_id         :integer
+#  dspace_handle      :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -17,6 +17,7 @@
 #  coauthors          :string
 #  copyright_id       :integer
 #  license_id         :integer
+#  dspace_handle      :string
 #
 
 require 'csv'
@@ -253,6 +254,13 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.save
     assert thesis.valid?
   end
+
+    test 'can have dspace handle' do
+      thesis = theses(:one)
+      thesis.dspace_handle = 'https://example.com/12345.54321'
+      thesis.save
+      assert thesis.valid?
+    end
 
   test 'invalid without files complete' do
     thesis = theses(:one)


### PR DESCRIPTION
#### Why these changes are being introduced:
When theses are published to DSpace, the SWORD submission will return a handle that we want to store in this system.

#### How this addresses that need:
* Adds dspace_handle field to the thesis model with corresponding test
* Adds dspace_handle field to admin view of thesis info (note, does not add this field to the edit form, as it is not intended to be edited other than by the SWORD submission job)

#### Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/ETD-296

#### Developer
- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer
- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?
YES

#### Includes new or updated dependencies?
NO
