### PR TITLE
Add thesis field to transfer processing form

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -142,6 +142,10 @@ ul.list-files {
   }
 }
 
+table.list-theses {
+  width: 100%;
+}
+
 // info
 .label.subtitle3 {
   margin-top: 2rem;

--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -28,12 +28,14 @@ class TransferController < ApplicationController
 
   def files
     @transfer = Transfer.find(params[:id])
-    flash[:success] = "This is a test of the files method.<br>".html_safe
+    @thesis = Thesis.find(params[:thesis])
+    flash[:success] = "This is a test of the files method.<br><br>".html_safe
     filelist = params[:transfer][:file_ids]
     filelist.each do |file|
       flash[:success] += ("File ID: " + file.to_s + "<br>").html_safe
     end
-    flash[:success] += "This has been a test of the files method. If this were an actual method, these " + filelist.count.to_s + " files would have been attached to the selected thesis."
+    flash[:success] += ("Thesis ID: " + @thesis.id.to_s + "<br><br>").html_safe
+    flash[:success] += "This has been a test of the files method. If this were an actual method, these " + filelist.count.to_s + " files would have been attached to the thesis."
     redirect_to transfer_path(@transfer.id)
   end
 
@@ -42,7 +44,13 @@ class TransferController < ApplicationController
   end
 
   def show
+    # Load the details of the requested Transfer record
     @transfer = Transfer.find(params[:id])
+
+    # Load the Thesis records for the period covered by this Transfer (the
+    # graduation month/year, and the department)
+    @theses = Thesis.where('grad_date = ?', @transfer.grad_date)
+    @theses = @theses.includes(:departments).where("departments.name_dw = ?", @transfer.department.name_dw).references(:departments)
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,6 +66,8 @@ class Ability
     
     can :read, Transfer
     can :select, Transfer
+    can :files, Transfer
+
     can :read, Hold
   end
 

--- a/app/views/transfer/_empty_target.html.erb
+++ b/app/views/transfer/_empty_target.html.erb
@@ -1,0 +1,3 @@
+<tr class="empty">
+  <td colspan="6">No theses found</td>
+</tr>

--- a/app/views/transfer/_thesis_target.html.erb
+++ b/app/views/transfer/_thesis_target.html.erb
@@ -1,0 +1,16 @@
+<tr>
+  <td><%= radio_button_tag "thesis", thesis_target.id, false, data: { msg: "Required - please select which thesis should receive the files." }, class: "required" %></td>
+  <td>
+    <label for="thesis_<%= thesis_target.id %>">
+      <% thesis_target.authors.each do |author| %>
+        <%= author.user.kerberos_id.to_s + ": " + author.user.display_name.to_s %><br>
+      <% end %>
+    </label>
+  </td>
+  <td><%= title_helper(thesis_target) %></td>
+  <td>
+    <% thesis_target.degrees.each do |degree| %>
+      <%= degree.name_dw %><br>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -1,5 +1,12 @@
 <%= content_for(:title, "Transfer Processing | MIT Libraries") %>
 
+<% content_for :additional_js do %>
+  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"></script>
+<% end %>
+
+<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+
 <p><%= link_to "Back to Transfer queue", transfer_select_path %></p>
 
 <h3 class="title title-page">Transfer from <%= @transfer.department.name_dw %> on <%= @transfer.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y at %l:%M %p') %></h3>
@@ -14,6 +21,10 @@
     <div class="col3q"><%= @transfer.department.name_dw %></div>
   </div>
   <div class="layout-band layout-1q3q">
+    <div class="col1q">Graduation Date:</div>
+    <div class="col3q"><%= @transfer.graduation_month %> <%= @transfer.graduation_year %></div>
+  </div>
+  <div class="layout-band layout-1q3q">
     <div class="col1q">Submitter:</div>
     <div class="col3q"><%= @transfer.user.display_name %></div>
   </div>
@@ -25,33 +36,76 @@
   <% end %>
 </div>
 
-<div class="alert alert-banner error" style="display: none;" role="alert" aria-invalid="true"></div>
+<%= form_tag(transfer_files_path, method: "post", id: "process_transfer") do %>
 
-<%= form_tag(transfer_files_path, method: "post") do %>
+  <% # f.error_notification %>
+  <div class="alert alert-banner error" style="display: none;" role="alert" aria-invalid="true"></div>
+
   <%= hidden_field_tag( 'id', @transfer.id ) %>
 
-  <div class="gridband layout-2c">
-    <div class="grid-item">
-      <h4>Assign these files ...</h4>
-      <fieldset>
-        <legend>Select the files to move</legend>
-        <ul class="list-unbulleted list-files">
-          <% @transfer.files.each do |file| %>
-            <li>
-              <label>
-              <%= check_box_tag "transfer[file_ids][]", file.id %>
-              <%= file.filename.to_s %>
-              </label>
-            </li>
-          <% end %>
-        </ul>
-      </fieldset>
+  <h4>Assign these files ...</h4>
+  <fieldset>
+    <legend>Select the files to move</legend>
+    <ul class="list-unbulleted list-files">
+      <% @transfer.files.each do |file| %>
+        <li>
+          <label>
+            <%= check_box_tag( "transfer[file_ids][]", file.id, false, data: { "msg" => "Required - please select at least one file to transfer." }, class: "required" ) %>
+            <%= file.filename.to_s %>
+          </label>
+        </li>
+      <% end %>
+    </ul>
+  </fieldset>
 
-    </div>
-    <div class="grid-item">
-      <h4>...to this thesis:</h4>
-    </div>
-  </div>
+  <h4 class="thesis-heading">...to this thesis:</h4>
+  <table class="table list-theses" id="thesisTargets">
+    <caption>Select the thesis to receive the files. If the needed thesis is not in this list, edit either the transfer or thesis record in <%= link_to("the administrative interface", admin_root_path) %> so they share a department and graduation date.</caption>
+    <thead>
+      <tr>
+        <th scope="col">Select</th>
+        <th scope="col">Authors</th>
+        <th scope="col">Title</th>
+        <th scope="col">Degrees</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render(partial: 'transfer/thesis_target', collection: @theses) || render('empty_target') %>
+    </tbody>
+  </table>
 
   <%= submit_tag('Transfer files', class: 'btn button-primary') %>
 <% end %>
+
+<script>
+  $(document).ready( function() {
+    if( document.getElementById('thesisTargets').getElementsByClassName('empty').length === 0) {
+      var table = $('#thesisTargets').DataTable({
+
+      });
+    }
+  });
+  $("#process_transfer").validate({
+    errorPlacement: function(error, element) {
+      if (element.attr("name") == "transfer[file_ids][]") {
+        error.insertBefore("ul.list-files");
+      } else if (element.attr("name") == "thesis") {
+        error.insertAfter("h4.thesis-heading");
+      } else {
+        error.insertAfter(element);
+      }
+    },
+    invalidHandler: function(event, validator) {
+      var errors = validator.numberOfInvalids();
+      if (errors) {
+        var message = errors == 1
+          ? 'The form was not submitted successfully - one required field needs to be fixed.'
+          : 'The form was not submitted successfully - ' + errors + ' required fields need to be fixed.';
+        $("div.error").html(message);
+        $("div.error").show();
+      } else {
+        $("div.error").hide();
+      }
+    }
+  });
+</script>


### PR DESCRIPTION
This completes building the transfer processing form UI, adding the table of relevant theses. Future work will complete the actual work requested by the form.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-279
* https://mitlibraries.atlassian.net/browse/ETD-280

#### Please note:

I'm curious if there is a better way to peform the filtering. In testing, it appears that thesis records which carry multiple departments are appearing in the filtered list, but when rendered these theses would only show the filtered department name. Reloading the record would restore both, but I'm somewhat concerned that the way the filtering is being done too aggressively (i.e. the record is being manipulated, and if saved we would lose some thesis-department links)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
