### PR TITLE
Create thesis processing queue

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -37,6 +37,15 @@ class ThesisController < ApplicationController
     end
   end
 
+  def select
+    @graduation = params[:graduation]
+    @thesis = Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', "Published")
+    if @graduation && @graduation != "all"
+      @thesis = @thesis.where('grad_date = ?', @graduation)
+    end
+    @terms = Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', "Published").select(:grad_date).map(&:grad_date).uniq.sort
+  end
+
   def show
     @thesis = Thesis.find(params[:id])
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,6 +62,7 @@ class Ability
     can :mark_downloaded, Thesis
     can :mark_withdrawn, Thesis
     can :process_theses, Thesis
+    can :select, Thesis
     can :stats, Thesis
     
     can :read, Transfer

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -10,6 +10,9 @@
           <%= nav_link_to("Submit thesis information", thesis_start_path) %>
 
           <% if user_signed_in? %>
+            <% if can? :select, Thesis %>
+              <%= nav_link_to("Process theses", thesis_select_path) %>
+            <% end %>
             <% if can? :process_theses, Thesis %>
               <%= nav_link_to("Process submissions", process_path) %>
               <%= nav_link_to("Stats", stats_path) %>

--- a/app/views/thesis/_select_empty.html.erb
+++ b/app/views/thesis/_select_empty.html.erb
@@ -1,0 +1,3 @@
+<tr class="empty">
+  <td colspan="5">No theses found</td>
+</tr>

--- a/app/views/thesis/_select_thesis.html.erb
+++ b/app/views/thesis/_select_thesis.html.erb
@@ -1,0 +1,15 @@
+<tr>
+  <td data-sort="<%= select_thesis.files.blobs.first.created_at %>"><%= select_thesis.files.blobs.first.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y<br>%l:%M %p').html_safe %></td>
+  <td><%= select_thesis.graduation_month[...3] %> <%= select_thesis.graduation_year %></td>
+  <td>
+    <% select_thesis.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td>
+    <% select_thesis.users.each do |user| %>
+      <%= user.display_name %><br>
+    <% end %>
+  </td>
+  <td><%= select_thesis.publication_status %></td>
+</tr>

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -1,0 +1,52 @@
+<%= content_for(:title, "Thesis Processing | MIT Libraries") %>
+
+<% content_for :additional_js do %>
+  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+<% end %>
+
+<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+
+<h3 class="title title-page">Thesis Processing Queue</h3>
+
+<%= render 'shared/you_are' %>
+
+<%= form_tag(thesis_select_path, method: "get") do %>
+  <label>
+    Show only theses from: 
+    <select name="graduation">
+      <option value="all">All terms</option>
+      <% @terms.each do |term| %>
+        <option value="<%= term %>"<%= ' selected="selected"'.html_safe if @graduation.to_s == term.to_s %>>
+          <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
+        </option>
+      <% end %>
+    </select>    
+  </label>
+
+  <%= submit_tag('Apply filter', class: 'btn button-primary') %>
+<% end %>
+
+<table class="table" id="thesisQueue" title="Thesis processing queue">
+  <thead>
+    <tr>
+      <th scope="col">File transfer date</th>
+      <th scope="col">Degree date</th>
+      <th scope="col">Department(s)</th>
+      <th scope="col">Author(s)</th>
+      <th scope="col">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render(partial: 'thesis/select_thesis', collection: @thesis) || render('select_empty') %>
+  </tbody>
+</table>
+
+<script type="text/javascript">
+$(document).ready( function () {
+  if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
+    var table = $('#thesisQueue').DataTable({
+      "order": [[ 1, "asc" ]]
+    });
+  };
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get 'thesis/start', to: 'thesis#start', as: 'thesis_start'
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
+  get 'thesis/select', to: 'thesis#select', as: 'thesis_select'
   resources :registrar, only: [:new, :create, :show]
   resources :thesis, only: [:new, :create, :edit, :show, :update]
   get 'process', to: 'thesis#process_theses', as: 'process'

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -43,7 +43,7 @@ two:
   license: sacrificial
 
 downloaded:
-  title: MyString
+  title: MyStringDownloaded
   abstract: MyText
   grad_date: 2017-09-01
   departments: [one]
@@ -51,7 +51,7 @@ downloaded:
   status: 'downloaded'
 
 withdrawn:
-  title: MyString
+  title: MyStringWithdrawn
   abstract: MyText
   grad_date: 2017-09-01
   departments: [one]
@@ -59,15 +59,15 @@ withdrawn:
   status: 'withdrawn'
 
 active:
-  title: MyString
+  title: MyStringActive
   abstract: MyText
-  grad_date: 2017-09-01
+  grad_date: 2018-09-01
   departments: [one]
   degrees: [one]
   status: 'active'  # The default, but specified for testing purposes.
 
 with_note:
-  title: MyString
+  title: MyStringNote
   abstract: MyText
   grad_date: 2017-09-01
   departments: [one]
@@ -85,35 +85,35 @@ with_hold:
   processor_note: 'Something sensitive'
 
 june_2018:
-  title: MyString
+  title: MyStringJune
   abstract: MyText
   grad_date: 2018-06-01
   departments: [one]
   degrees: [one]
 
 september_2018:
-  title: MyString
+  title: MyStringSeptember
   abstract: MyText
   grad_date: 2018-09-01
   departments: [one]
   degrees: [one]
 
 february_2019:
-  title: MyString
+  title: MyStringFebruary
   abstract: MyText
   grad_date: 2019-02-01
   departments: [one]
   degrees: [one]
 
 june_2019:
-  title: MyString
+  title: MyString2019
   abstract: MyText
   grad_date: 2019-06-01
   departments: [one]
   degrees: [one]
 
 september_2019:
-  title: MyString
+  title: MyStringSept2019
   abstract: MyText
   grad_date: 2019-09-01
   departments: [one]

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -76,7 +76,7 @@ class ThesisHelperTest < ActionView::TestCase
     # september_2019
     # multi_depts
 
-    expected = { "Sep 2017"=>5, "Jun 2018"=>1, "Sep 2018"=>1,
+    expected = { "Sep 2017"=>4, "Jun 2018"=>1, "Sep 2018"=>2,
                  "Feb 2019"=>2, "Jun 2019"=>1, "Sep 2019"=>1}
     assert_equal expected, grouped_theses
   end
@@ -109,7 +109,7 @@ class ThesisHelperTest < ActionView::TestCase
 
     # Expects the theses as noted in the 3 tests above to exist.
 
-    expected = { "Sep 2017"=>7, "Jun 2018"=>1, "Sep 2018"=>1,
+    expected = { "Sep 2017"=>6, "Jun 2018"=>1, "Sep 2018"=>2,
                  "Feb 2019"=>2, "Jun 2019"=>1, "Sep 2019"=>1}
     assert_equal expected, grouped_theses
   end

--- a/test/integration/nav_test.rb
+++ b/test/integration/nav_test.rb
@@ -25,6 +25,14 @@ class NavTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'thesis queue page nav' do
+    mock_auth(users(:admin))
+    get thesis_select_path
+    assert_select('.current') do |value|
+      assert(value.text.include?('Process theses'))
+    end
+  end
+
   test 'processing page nav' do
     mock_auth(users(:admin))
     get process_path
@@ -86,6 +94,7 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", thesis_start_path
 
       # Navigation should not include:
+      assert_select "a[href=?]", thesis_select_path, count: 0
       assert_select "a[href=?]", process_path, count: 0
       assert_select "a[href=?]", stats_path, count: 0
       assert_select "a[href=?]", new_transfer_path, count: 0
@@ -107,6 +116,7 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", new_transfer_path
 
       # Navigation should not include:
+      assert_select "a[href=?]", thesis_select_path, count: 0
       assert_select "a[href=?]", process_path, count: 0
       assert_select "a[href=?]", stats_path, count: 0
       assert_select "a[href=?]", transfer_select_path, count: 0
@@ -124,6 +134,7 @@ class NavTest < ActionDispatch::IntegrationTest
     assert_select "nav" do
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
+      assert_select "a[href=?]", thesis_select_path
       # assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", process_path
@@ -142,6 +153,7 @@ class NavTest < ActionDispatch::IntegrationTest
     assert_select "nav" do
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
+      assert_select "a[href=?]", thesis_select_path
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", process_path
@@ -160,6 +172,7 @@ class NavTest < ActionDispatch::IntegrationTest
     assert_select "nav" do
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
+      assert_select "a[href=?]", thesis_select_path
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", process_path


### PR DESCRIPTION
This implements the thesis processing queue at /thesis/select, a parallel construct to the transfer processing queue that was introduced in the last sprint. The queue currently contains no links or action steps, which will be introduced in future tickets.

Ticket: https://mitlibraries.atlassian.net/browse/ETD-308

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
