### PR TITLE
Bugfix for broken Hold dashboard searches

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -8,9 +8,10 @@ class HoldDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    thesis: Field::BelongsTo,
-    author_names: Field::String,
-    degrees: Field::String,
+    thesis: Field::BelongsTo.with_options(searchable: true, 
+                                          searchable_fields: ['title']),
+    author_names: Field::Text,
+    degrees: Field::Text,
     grad_date: Field::DateTime.with_options(
       format: "%Y %B",
     ),
@@ -20,9 +21,9 @@ class HoldDashboard < Administrate::BaseDashboard
     date_start: Field::Date,
     date_end: Field::Date,
     date_released: Field::Date,
-    dates_thesis_files_received: Field::String,
+    dates_thesis_files_received: Field::Text,
     case_number: Field::String,
-    status: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    status: Field::Select.with_options(searchable: true, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
     processing_notes: Field::Text,
     created_by: Field::Text,
     created_at: Field::Date,
@@ -92,7 +93,9 @@ class HoldDashboard < Administrate::BaseDashboard
   #     open: ->(resources) { resources.where(open: true) }
   #   }.freeze
   COLLECTION_FILTERS = {
-    active: ->(resources) { resources.where(status: :active) }
+    active: ->(resources) { resources.where(status: :active) },
+    expired: ->(resources) { resources.where(status: :expired) },
+    released: ->(resources) { resources.where(status: :released) }
   }.freeze
 
   # Overwrite this method to customize how holds are displayed

--- a/test/integration/admin/admin_hold_test.rb
+++ b/test/integration/admin/admin_hold_test.rb
@@ -195,4 +195,31 @@ class AdminHoldDashboardTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "a[href='/hold_history/#{hold.id}']", "View hold history"
   end
+
+  test 'can filter active holds' do
+    mock_auth users(:thesis_admin)
+    get "/admin/holds?search=active%3A"
+    assert_response :success
+    assert_select 'a', 'active'
+    assert_select 'a', {count: 0, text: 'expired'}
+    assert_select 'a', {count: 0, text: 'released'}
+  end
+
+  test 'can filter expired holds' do
+    mock_auth users(:thesis_admin)
+    get "/admin/holds?search=expired%3A"
+    assert_response :success
+    assert_select 'a', 'expired'
+    assert_select 'a', {count: 0, text: 'active'}
+    assert_select 'a', {count: 0, text: 'released'}
+  end
+
+  test 'can filter released holds' do
+    mock_auth users(:thesis_admin)
+    get "/admin/holds?search=released%3A"
+    assert_response :success
+    assert_select 'a', 'released'
+    assert_select 'a', {count: 0, text: 'active'}
+    assert_select 'a', {count: 0, text: 'expired'}
+  end
  end


### PR DESCRIPTION
#### Why these changes are being introduced:

Certain fields in the Hold dashboard, which are generated via convenience
methods and not stored in the db,  were defined as Field::String. Because
Field::String is searchable by default, this caused the dashboard search
to break when it tried to query nonexistent columns.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-304

#### How this addresses that need:

This changes the offending fields to Field::Text, which are not
searchable by default.

#### Side effects of this change:

* When I fixed this bug, I noticed that the only searchable field was
status. I added thesis title as another searchable field, since there
aren't many Hold model fields that are searchable in administrate.
* Notably, status is searchable only if you add a colon to the
end of the querystring (e.g., 'active:'), due to some weirdness with
how collection filters work in administrate.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
