### PR TITLE
Implements publication status, adds issues_found flag

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -102,6 +102,7 @@ class ThesisController < ApplicationController
                                    :graduation_year, :copyright_id, :author_note,
                                    :license_id, :department_ids, :degree_ids,
                                    :processor_note, :files_complete, :metadata_complete,
+                                   :issues_found,
                                    advisors_attributes: [:id, :name, :_destroy],
                                    department_theses_attributes: [:id, :thesis_id, :department_id, :_destroy],
                                    files_attachments_attributes: [:id, :purpose, :description],

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -15,6 +15,8 @@ class Author < ApplicationRecord
 
   validates :graduation_confirmed, exclusion: [nil]
 
+  after_save :update_thesis_status
+
   # Given a row of CSV data from registrar import, update graduation
   # confirmed attribute (if needed) to true or false based on CSV data
   def set_graduated_from_csv(row)
@@ -23,5 +25,12 @@ class Author < ApplicationRecord
       self.update!(graduation_confirmed: graduated)
       Rails.logger.info("Author " + self.user.name + " graduation status updated to " + graduated.to_s)
     end
+  end
+
+  # The thesis' publication_status is recalculated every time the record is
+  # saved, so in case this author's graduation status has changed, we force a
+  # recalculation.
+  def update_thesis_status
+    self.thesis.save
   end
 end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -27,6 +27,8 @@ class Hold < ApplicationRecord
   validates :date_end, presence: true
   validates :status, presence: true
 
+  after_save :update_thesis_status
+
   def degrees
     self.thesis.degrees.map { |d| d.name_dw}.join("\n")
   end
@@ -68,5 +70,11 @@ class Hold < ApplicationRecord
     end
     dates_released = released_versions.map { |version| version.changeset["updated_at"][1] }
     dates_released.sort.last
+  end
+
+  # The thesis' publication_status is recalculated every time the record is
+  # saved, so in case this hold's status has changed, we force a recalculation.
+  def update_thesis_status
+    self.thesis.save
   end
 end

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -65,7 +65,12 @@
                                           item_wrapper_class: 'field-radio fields-inline',
                                           label: 'Metadata ok' %>
         </li>
-        <li>Issues found</li>
+        <li>
+          <%= f.input :issues_found, as: :radio_buttons,
+                                     label_html: { style: 'width: 50%' },
+                                     item_wrapper_class: 'field-radio fields-inline',
+                                     label: 'Issues found' %>
+        </li>
       </ul>
     </div>
   </div>

--- a/db/migrate/20210621143516_add_issues_found_to_thesis.rb
+++ b/db/migrate/20210621143516_add_issues_found_to_thesis.rb
@@ -1,0 +1,5 @@
+class AddIssuesFoundToThesis < ActiveRecord::Migration[6.0]
+  def change
+    add_column :theses, :issues_found, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_11_192431) do
+ActiveRecord::Schema.define(version: 2021_06_21_143516) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 2021_05_11_192431) do
     t.integer "copyright_id"
     t.integer "license_id"
     t.string "dspace_handle"
+    t.boolean "issues_found", default: false, null: false
     t.index ["copyright_id"], name: "index_theses_on_copyright_id"
     t.index ["license_id"], name: "index_theses_on_license_id"
   end

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -44,3 +44,18 @@ seven:
   user: second
   thesis: with_hold
   graduation_confirmed: false
+
+review:
+  user: yo
+  thesis: publication_review
+  graduation_confirmed: true
+
+eight:
+  user: basic
+  thesis: publication_review_except_hold
+  graduation_confirmed: true
+
+nine:
+  user: basic
+  thesis: pending_publication
+  graduation_confirmed: true

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -59,3 +59,8 @@ nine:
   user: basic
   thesis: pending_publication
   graduation_confirmed: true
+
+ten:
+  user: basic
+  thesis: published
+  graduation_confirmed: true

--- a/test/fixtures/holds.yml
+++ b/test/fixtures/holds.yml
@@ -69,7 +69,27 @@ multiple_released:
   date_requested: 2021-01-03
   date_start: 2021-01-01
   date_end: 2021-04-01
-  hold_source: vpf
+  hold_source: vpr
   case_number: null
   status: released
   processing_notes: null
+
+update_to_change_thesis_status:
+  thesis: publication_review
+  date_requested: 2021-01-03
+  date_start: 2021-01-01
+  date_end: 2021-04-01
+  hold_source: vpr
+  case_number: null
+  status: released
+  processing_notes: "This gets updated to watch the thesis' publication_status change"
+
+update_to_release_thesis:
+  thesis: publication_review_except_hold
+  date_requested: 2021-01-03
+  date_start: 2021-01-01
+  date_end: 2021-04-01
+  hold_source: vpr
+  case_number: null
+  status: active
+  processing_notes: "This gets updated to watch the thesis' publication_status change"

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -18,6 +18,7 @@
 #  copyright_id       :integer
 #  license_id         :integer
 #  dspace_handle      :string
+#  issues_found       :boolean          default(FALSE), not null
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -101,6 +102,39 @@ multiple_holds:
   degrees: [one]
   status: 'active'
   processor_note: 'Multiple holds in various states'
+
+publication_review:
+  title: MyReadyThesis
+  abstract: "A thesis ready for review"
+  grad_date: 2021-06-01
+  departments: [one]
+  degrees: [one]
+  files_complete: true
+  metadata_complete: true
+  issues_found: false
+  publication_status: 'Publication review'
+
+publication_review_except_hold:
+  title: MyAlmostReadyThesis
+  abstract: "A thesis almost ready for review"
+  grad_date: 2021-06-01
+  departments: [one]
+  degrees: [one]
+  files_complete: true
+  metadata_complete: true
+  issues_found: false
+  publication_status: 'Not ready for publication'
+
+pending_publication:
+  title: MyPendingThesis
+  abstract: "A thesis that has been declared pending for publication"
+  grad_date: 2021-06-01
+  departments: [one]
+  degrees: [one]
+  files_complete: true
+  metadata_complete: true
+  issues_found: false
+  publication_status: 'Pending publication'
 
 june_2018:
   title: MyStringJune

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -136,6 +136,17 @@ pending_publication:
   issues_found: false
   publication_status: 'Pending publication'
 
+published:
+  title: MyPublishedThesis
+  abstract: "A thesis that has been published to DSpace@MIT"
+  grad_date: 2021-06-01
+  departments: [one]
+  degrees: [one]
+  files_complete: true
+  metadata_complete: true
+  issues_found: false
+  publication_status: 'Published'
+
 june_2018:
   title: MyStringJune
   abstract: MyText

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -112,7 +112,7 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
   test 'students can edit their advisor name via thesis form' do
     mock_auth(users(:yo))
     count = Advisor.count
-    sample = users(:yo).theses.third
+    sample = users(:yo).theses.fourth
     sample_advisor = sample.advisors.first
     assert_not_equal "Another Name", sample_advisor.name
 

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -561,30 +561,24 @@ class ThesisTest < ActiveSupport::TestCase
     thesis = theses(:one)
     assert thesis.valid?
     thesis.publication_status = nil
-    thesis.save
     assert_not thesis.valid?
   end
 
   test 'invalid without accepted publication status' do
     thesis = theses(:one)
     thesis.publication_status = 'Not ready for publication'
-    thesis.save
     assert thesis.valid?
 
     thesis.publication_status = 'Publication review'
-    thesis.save
     assert thesis.valid?
 
     thesis.publication_status = 'Pending publication'
-    thesis.save
     assert thesis.valid?
 
     thesis.publication_status = 'Published'
-    thesis.save
     assert thesis.valid?
 
     thesis.publication_status = 'Foo'
-    thesis.save
     assert_not thesis.valid?
   end
 
@@ -714,5 +708,31 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.save
     thesis.reload
     assert_equal 'Pending publication', thesis.publication_status
+  end
+
+  test 'Adding a new hold when a thesis is in "Published" will change nothing' do
+    thesis = theses(:published)
+    assert_equal 'Published', thesis.publication_status
+    hold = Hold.new({
+      "thesis" => thesis,
+      "date_requested" => "2021-01-03",
+      "date_start" => "2021-01-01",
+      "date_end" => "2021-04-01",
+      "hold_source" => HoldSource.first,
+      "status" => "active",
+    })
+    assert_equal true, hold.valid?
+    hold.save
+    thesis.reload
+    assert_equal 'Published', thesis.publication_status
+  end
+
+  test 'Flagging an issue when a thesis is in "Published" will change nothing' do
+    thesis = theses(:published)
+    assert_equal 'Published', thesis.publication_status
+    thesis.issues_found = true
+    thesis.save
+    thesis.reload
+    assert_equal 'Published', thesis.publication_status
   end
 end


### PR DESCRIPTION
This adds the `issues_found` flag, as well as an `update_status` method that will be called via lifecycle hooks whenever a thesis, hold, or author record is saved. The update_status method also relies on two new inversion helper methods that allow for the five qualifying conditions to be checked via `[a,b,c,d,e].all?` logic.

There is a guard check in the method that returns early if the thesis has already been picked up by the publication workflow.

I've tried to write unit tests pretty thoroughly on this work, to make sure that changes are happening as we expect. Hopefully they are sufficient, so I welcome some pretty tight scrutiny on all of this.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-343

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
