### PR TITLE
Fix a typo in the import job

### DIFF
--- a/app/jobs/registrar_import_job.rb
+++ b/app/jobs/registrar_import_job.rb
@@ -32,7 +32,7 @@ class RegistrarImportJob < ActiveJob::Base
         logger.info("Thesis is #{thesis.inspect}")
       rescue RuntimeError
         e = "Multiple theses found for author #{user.name} for term #{grad_date.to_s}, requires Processor attention. CSV row ##{i.to_s}: #{row.inspect}"
-        Logger.warn(e)
+        logger.warn(e)
         results[:errors] << e
         next
       end


### PR DESCRIPTION
#### Why these changes are being introduced:
A typo in the import job caused the job to crash when an expected error was logged. This fixes it.

#### How this addresses that need:
* Fixes the typo

#### Side effects of this change:
Note: because this is semi-urgent, this commit does not update tests to ensure that this particular rescue block is covered. I will add a Jira ticket for that to make sure the tests are updated ASAP.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
