### PR TITLE
Adds filter buttons for thesis publication status

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -165,6 +165,11 @@ table.list-theses {
   width: 100%;
 }
 
+// DataTables filter buttons
+.filter-row {
+  margin: 1.5rem 0;
+}
+
 // info
 .label.subtitle3 {
   margin-top: 2rem;

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -26,6 +26,10 @@
   <%= submit_tag('Apply filter', class: 'btn button-primary') %>
 <% end %>
 
+<div id="status-list" class="filter-row">
+  <button data-filter="*">Show all</button>
+</div>
+
 <table class="table" id="thesisQueue" title="Thesis processing queue">
   <thead>
     <tr>
@@ -46,6 +50,30 @@ $(document).ready( function () {
   if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
     var table = $('#thesisQueue').DataTable({
       "order": [[ 1, "asc" ]]
+    });
+
+    // Populate filter buttons with found values for publication status
+    var terms = [...new Set( table.columns(4).data()[0] )];
+    terms.forEach(element => {
+      document
+        .getElementById("status-list")
+        .insertAdjacentHTML("beforeend", `
+        <button data-filter="${element}">${element}</button>
+      `);
+    });
+
+    // Perform filtering when buttons are clicked
+    $(".filter-row button").click(function() {
+      var needle = $(this).data("filter");
+      $.fn.dataTable.ext.search.push(
+        function( settings, data, dataIndex ) {
+          return ( data[4] === needle || needle === "*" )
+            ? true
+            : false
+        }
+      );
+      table.draw();
+      $.fn.dataTable.ext.search.pop();
     });
   };
 });


### PR DESCRIPTION
This repeats the filter buttons that we used on the transfer processing queue, building a row of filter buttons on the thesis queue that focus on publication_status.

Bonus: CodeClimate doesn't seem to complain about the duplicated javascript!

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-345

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
