### PR TITLE
ETD-341 Display additional data in hold history view

### DIFF
--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -40,24 +40,22 @@ class Hold < ApplicationRecord
   end
 
   def created_by
-    if self.versions.present? && self.versions.first.event == 'create'
-      creator_id = self.versions.first.whodunnit
-      if user = User.find_by(id: creator_id)
-        user.kerberos_id
-      else
-        "User ID #{creator_id} no longer active."
-      end
+    return unless self.versions.present? && self.versions.first.event == 'create'
+    creator_id = self.versions.first.whodunnit
+    if user = User.find_by(id: creator_id)
+      user.kerberos_id
+    else
+      "User ID #{creator_id} no longer active."
     end
   end
 
   # This may later list just the info for the file flagged 'primary', once 
   # we implement that feature.
   def dates_thesis_files_received
-    if self.thesis.present? && self.thesis.files.present?
-      self.thesis.files.map do |file| 
-        "#{file.created_at.strftime('%Y-%m-%d')} (#{file.blob.filename})"
-      end.join("; ")
-    end
+    return unless self.thesis.present? && self.thesis.files.present?
+    self.thesis.files.map do |file| 
+      "#{file.created_at.strftime('%Y-%m-%d')} (#{file.blob.filename})"
+    end.join("; ")
   end
 
   # In the unlikely scenario that the the status was changed to 'released' 

--- a/app/views/hold/show.html.erb
+++ b/app/views/hold/show.html.erb
@@ -2,6 +2,12 @@
 
 <h3 class="hd-3"><%= "Full hold history: #{@hold.thesis.title}" %></h3>
 <p><%= link_to 'Return to hold record', admin_hold_path(@hold) %></p>
+<ul class="list-unbulleted">
+  <li>Author name(s): <%= @hold.author_names %></li>
+  <li>Dates thesis files received: <%= @hold.dates_thesis_files_received %></li>
+  <li>Degree(s): <%= @hold.degrees %></li>
+  <li>Degree date: <%= @hold.grad_date %></li>
+</ul>
 <% @hold.versions.reverse_each do |version| %>
   <div class="box-content">
     <h4 class="hd-4">Version <%= version.index + 1 %></h4>


### PR DESCRIPTION
#### Why these changes are being introduced:

Certain data associated with a hold (author names, degree information,
and dates thesis files received) are not included in the hold history
page because these fields are not part of the Hold model and are
therefore not under audit control.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-341

#### How this addresses that need:

This adds the current values of the fields mentioned to the top of the
hold history for users to reference while reviewing a hold's audit
trail.

#### Side effects of this change:

I refactored a couple of conditionals into guard clauses in the Hold model.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
