### PR TITLE
Adds DSpace authority key field to department

### DIFF
--- a/app/dashboards/department_dashboard.rb
+++ b/app/dashboards/department_dashboard.rb
@@ -13,6 +13,7 @@ class DepartmentDashboard < Administrate::BaseDashboard
     name_dw: Field::String,
     code_dw: Field::String,
     name_dspace: Field::String,
+    authority_key_dspace: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -38,6 +39,7 @@ class DepartmentDashboard < Administrate::BaseDashboard
     name_dw
     code_dw
     name_dspace
+    authority_key_dspace
     created_at
     updated_at
   ].freeze
@@ -50,6 +52,7 @@ class DepartmentDashboard < Administrate::BaseDashboard
     name_dw
     code_dw
     name_dspace
+    authority_key_dspace
   ].freeze
 
   # Overwrite this method to customize how departments are displayed

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -2,12 +2,13 @@
 #
 # Table name: departments
 #
-#  id          :integer          not null, primary key
-#  name_dw     :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  code_dw     :string           default(""), not null
-#  name_dspace :string
+#  id                   :integer          not null, primary key
+#  name_dw              :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  code_dw              :string           default(""), not null
+#  name_dspace          :string
+#  authority_key_dspace :string
 #
 
 class Department < ApplicationRecord

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,11 @@ en:
       degree:
         name_dw: Name (Data Warehouse)
         name_dspace: Name (Dspace)
+      department:
+        authority_key_dspace: Authority Key (DSpace)
+        code_dw: Code (Data Warehouse)
+        name_dspace: Name (DSpace)
+        name_dw: Name (Data Warehouse)
       hold:
         id: Audit trail
         grad_date: Degree date

--- a/db/migrate/20210629202931_add_authority_key_to_departments.rb
+++ b/db/migrate/20210629202931_add_authority_key_to_departments.rb
@@ -1,0 +1,5 @@
+class AddAuthorityKeyToDepartments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :departments, :authority_key_dspace, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_143516) do
+ActiveRecord::Schema.define(version: 2021_06_29_202931) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2021_06_21_143516) do
     t.datetime "updated_at", null: false
     t.string "code_dw", default: "", null: false
     t.string "name_dspace"
+    t.string "authority_key_dspace"
     t.index ["code_dw"], name: "index_departments_on_code_dw", unique: true
     t.index ["name_dw"], name: "index_departments_on_name_dw"
   end

--- a/test/fixtures/departments.yml
+++ b/test/fixtures/departments.yml
@@ -2,12 +2,13 @@
 #
 # Table name: departments
 #
-#  id          :integer          not null, primary key
-#  name_dw     :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  code_dw     :string           default(""), not null
-#  name_dspace :string
+#  id                   :integer          not null, primary key
+#  name_dw              :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  code_dw              :string           default(""), not null
+#  name_dspace          :string
+#  authority_key_dspace :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
@@ -16,6 +17,7 @@ one:
   name_dw: Department of Aeronautics and Astronautics
   code_dw: 16
   name_dspace: Massachusetts Institute of Technology. Department of Aeronautics and Astronautics
+  authority_key_dspace: aero
 
 two:
   name_dw: Program in Anthropology

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -37,6 +37,12 @@ class DepartmentTest < ActiveSupport::TestCase
     assert(department.valid?)
   end
 
+  test 'valid without authority key' do
+    department = departments(:one)
+    department.authority_key_dspace = nil
+    assert(department.valid?)
+  end
+
   test 'can have multiple theses' do
     department = departments(:one)
     department.theses = [theses(:one), theses(:two)]

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -2,12 +2,13 @@
 #
 # Table name: departments
 #
-#  id          :integer          not null, primary key
-#  name_dw     :string           not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  code_dw     :string           default(""), not null
-#  name_dspace :string
+#  id                   :integer          not null, primary key
+#  name_dw              :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  code_dw              :string           default(""), not null
+#  name_dspace          :string
+#  authority_key_dspace :string
 #
 
 require 'test_helper'


### PR DESCRIPTION
This adds the authority key field to the Department model, in support of future SWORD submissions to DSpace. Field labels are handled via the i18n locales file.

*Please note* the original ticket calls for this field to be editable by thesis processors. We have thus far used the "admin" flag to achieve this ability, so no work is needed on this front. I've done a bit of work to see how processors could be given access to this area without the flag, and - while it is possible - there's some weirdness in how this change would happen that makes me want to set it aside for now. I will set up a separate PR for how that change would happen, to allow us to consider the change de-coupled from the immediate timeline of this project.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-347

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
