### PR TITLE
Adds searchable flag to certain transfer fields

### DIFF
--- a/app/dashboards/transfer_dashboard.rb
+++ b/app/dashboards/transfer_dashboard.rb
@@ -8,11 +8,18 @@ class TransferDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    user: Field::BelongsTo,
-    department: Field::BelongsTo,
+    user: Field::BelongsTo.with_options(
+      searchable: true,
+      searchable_fields: ['kerberos_id', 'display_name']
+    ),
+    department: Field::BelongsTo.with_options(
+      searchable: true,
+      searchable_fields: ['name_dw', 'code_dw']
+    ),
     files_attachments: AttachmentField,
     id: Field::Number,
     grad_date: Field::DateTime.with_options(
+      searchable: true,
       format: "%Y %B"
     ),
     graduation_month: Field::Number,

--- a/app/dashboards/transfer_dashboard.rb
+++ b/app/dashboards/transfer_dashboard.rb
@@ -10,7 +10,7 @@ class TransferDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo.with_options(
       searchable: true,
-      searchable_fields: ['kerberos_id', 'display_name']
+      searchable_fields: ['kerberos_id', 'uid', 'display_name']
     ),
     department: Field::BelongsTo.with_options(
       searchable: true,


### PR DESCRIPTION
This enables staff searching of records within the admin transfer panel.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-334

One caveat is that this will make the graduation year searchable, but not the graduation month. Additionally, searching much match against one and only one field - so something like "SHASS Joe" will fail, even if both "SHASS" and "Joe" would each return an overlapping set of records.

Another caveat is that I haven't asked for stakeholder review of this change yet - without a robust set of records in a review app, I'm not sure how useful that would be. I'm thinking that we can take care of this after the code merges and it gets to the staging dataset.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
