### PR TITLE
ETD-353 Make author names searchable on Hold dashboard

### DIFF
--- a/app/dashboards/hold_dashboard.rb
+++ b/app/dashboards/hold_dashboard.rb
@@ -10,6 +10,10 @@ class HoldDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     thesis: Field::BelongsTo.with_options(searchable: true, 
                                           searchable_fields: ['title']),
+    users: Field::HasMany.with_options(
+      searchable: true,
+      searchable_fields: ['kerberos_id', 'uid', 'display_name']
+    ),
     author_names: Field::Text,
     degrees: Field::Text,
     grad_date: Field::DateTime.with_options(

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -19,6 +19,7 @@ class Hold < ApplicationRecord
 
   belongs_to :thesis
   belongs_to :hold_source
+  has_many :users, through: :thesis
 
   enum status: [ :active, :expired, :released ]
 

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -120,4 +120,11 @@ class HoldTest < ActiveSupport::TestCase
     h = holds(:valid)
     assert_equal "Student, Second; Yobot, Yo", h.author_names
   end
+
+  test 'can access associated users' do
+    h = holds(:valid)
+    assert_equal 2, h.users.length
+    assert_equal 'Second Student', h.users.first.display_name
+    assert_equal 'Yo Yobot', h.users.second.display_name
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Author names were not searchable in the Hold dashboard because
administrate accesses them from a convenience method rather than the
User model, causing the the Active Record query to fail.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-353

#### How this addresses that need:

This adds an association to the User model on the Hold model, and a
corresponding 'users' attribute to the Hold dashboard, which is searchable
on display_name, uid, and kerberos_id. These are the same fields that are
currently searchable on the Author dashboard, but we can add more fields
if it proves useful.

#### Side effects of this change:

None, aside from the new association. We are still using the author_names
convenience method to display the names in the UI, since the has_many
association renders in a not-so-useful way in administrate.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
