### PR TITLE
Implements a duplicate thesis report

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -30,6 +30,14 @@ class ThesisController < ApplicationController
     end
   end
 
+  def deduplicate
+    @thesis = Thesis.where.not("coauthors = ?", "")
+    if params[:graduation] && params[:graduation] != "all"
+      @thesis = @thesis.where('grad_date = ?', params[:graduation])
+    end
+    @terms = Thesis.where.not("coauthors = ?", "").select(:grad_date).map(&:grad_date).uniq.sort
+  end
+
   def edit
     @thesis = Thesis.find(params[:id])
     if @thesis.advisors.count == 0

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,7 @@ class Ability
 
     can %i[read update], Thesis
     can :annotate, Thesis
+    can :deduplicate, Thesis
     can :mark_downloaded, Thesis
     can :mark_withdrawn, Thesis
     can :process_theses, Thesis

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -12,6 +12,7 @@
           <% if user_signed_in? %>
             <% if can? :select, Thesis %>
               <%= nav_link_to("Process theses", thesis_select_path) %>
+              <%= nav_link_to("Duplicate report", thesis_deduplicate_path) %>
             <% end %>
             <% if can? :create, Transfer %>
               <%= nav_link_to("Transfer theses", new_transfer_path) %>

--- a/app/views/thesis/_duplicate_thesis.html.erb
+++ b/app/views/thesis/_duplicate_thesis.html.erb
@@ -1,0 +1,15 @@
+<tr>
+  <td><%= link_to title_helper(duplicate_thesis), thesis_process_path(duplicate_thesis.id) %></td>
+  <td>
+    <% duplicate_thesis.users.each do |user| %>
+      <%= user.display_name %><br>
+    <% end %>
+  </td>
+  <td><%= duplicate_thesis.coauthors %></td>
+  <td>
+    <% duplicate_thesis.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td><%= duplicate_thesis.graduation_month[...3] %> <%= duplicate_thesis.graduation_year %></td>
+</tr>

--- a/app/views/thesis/deduplicate.html.erb
+++ b/app/views/thesis/deduplicate.html.erb
@@ -1,0 +1,52 @@
+<%= content_for(:title, "Duplicate Theses Report | MIT Libraries") %>
+
+<% content_for :additional_js do %>
+  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+<% end %>
+
+<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+
+<h3 class="title title-page">Theses with co-author(s)</h3>
+
+<%= render 'shared/you_are' %>
+
+<%= form_tag(thesis_deduplicate_path, method: "get") do %>
+  <label>
+    Show only theses from: 
+    <select name="graduation">
+      <option value="all">All terms</option>
+      <% @terms.each do |term| %>
+        <option value="<%= term %>"<%= ' selected="selected"'.html_safe if params[:graduation].to_s == term.to_s %>>
+          <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
+        </option>
+      <% end %>
+    </select>    
+  </label>
+
+  <%= submit_tag('Apply filter', class: 'btn button-primary') %>
+<% end %>
+
+<table class="table" id="thesisQueue" title="Thesis processing queue">
+  <thead>
+    <tr>
+      <th scope="col">Title</th>
+      <th scope="col">Author(s)</th>
+      <th scope="col">Coauthor(s)</th>
+      <th scope="col">Department(s)</th>
+      <th scope="col">Degree date</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render(partial: 'thesis/duplicate_thesis', collection: @thesis) || render('select_empty') %>
+  </tbody>
+</table>
+
+<script type="text/javascript">
+$(document).ready( function () {
+  if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
+    var table = $('#thesisQueue').DataTable({
+      "order": [[ 1, "asc" ]]
+    });
+  };
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   end
 
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
+  get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'
   get 'thesis/:id/process', to: 'thesis#process_theses', as: 'thesis_process'
   patch 'thesis/:id/process', to: 'thesis#process_theses_update', as: 'thesis_process_update'
   get 'thesis/select', to: 'thesis#select', as: 'thesis_select'

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -15,6 +15,11 @@ one:
   thesis: one
   graduation_confirmed: false
 
+oneco:
+  user: basic
+  thesis: coauthor
+  graduation_confirmed: false
+
 two:
   user: yo
   thesis: two

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -65,6 +65,7 @@ active:
   grad_date: 2018-09-01
   departments: [one]
   degrees: [one]
+  coauthors: 'Coauthor, Student'
   status: 'active'  # The default, but specified for testing purposes.
 
 with_note:
@@ -187,3 +188,13 @@ multi_depts:
   abstract: MyText
   grad_date: 2019-02-01
   degrees: [one]
+
+coauthor:
+  title: MyString
+  abstract: MyText
+  grad_date: 2017-09-01
+  departments: [one]
+  degrees: [one]
+  coauthors: 'Yobot, Yo'
+  copyright: mit
+  license: nocc

--- a/test/integration/nav_test.rb
+++ b/test/integration/nav_test.rb
@@ -33,6 +33,14 @@ class NavTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'thesis deduplicate page nav' do
+    mock_auth(users(:admin))
+    get thesis_deduplicate_path
+    assert_select('.current') do |value|
+      assert(value.text.include?('Duplicate report'))
+    end
+  end
+
   test 'registrar page nav' do
     mock_auth(users(:admin))
     get new_registrar_path
@@ -79,6 +87,7 @@ class NavTest < ActionDispatch::IntegrationTest
 
       # Navigation should not include:
       assert_select "a[href=?]", thesis_select_path, count: 0
+      assert_select "a[href=?]", thesis_deduplicate_path, count: 0
       assert_select "a[href=?]", new_transfer_path, count: 0
       assert_select "a[href=?]", transfer_select_path, count: 0
       assert_select "a[href=?]", new_registrar_path, count: 0
@@ -99,6 +108,7 @@ class NavTest < ActionDispatch::IntegrationTest
 
       # Navigation should not include:
       assert_select "a[href=?]", thesis_select_path, count: 0
+      assert_select "a[href=?]", thesis_deduplicate_path, count: 0
       assert_select "a[href=?]", transfer_select_path, count: 0
       assert_select "a[href=?]", new_registrar_path, count: 0
       assert_select "a[href=?]", harvest_path, count: 0
@@ -115,6 +125,7 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
       assert_select "a[href=?]", thesis_select_path
+      assert_select "a[href=?]", thesis_deduplicate_path
       # assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", new_registrar_path, count: 0
@@ -132,6 +143,7 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
       assert_select "a[href=?]", thesis_select_path
+      assert_select "a[href=?]", thesis_deduplicate_path
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", new_registrar_path
@@ -149,6 +161,7 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select "a[href=?]", root_path
       assert_select "a[href=?]", thesis_start_path
       assert_select "a[href=?]", thesis_select_path
+      assert_select "a[href=?]", thesis_deduplicate_path
       assert_select "a[href=?]", new_transfer_path
       assert_select "a[href=?]", transfer_select_path
       assert_select "a[href=?]", new_registrar_path


### PR DESCRIPTION
This implements a new view under the thesis model, `/thesis/deduplicate`. The layout of this view is very similar to the thesis processing queue, using DataTables for interactions with the displayed records.

The criteria for determining which records are displayed on this view are simple: does the thesis record have a populated "coauthor" field?

Records are displayed with a link to that thesis' processing form, allowing staff to modify records after analyzing each to determine which thesis should move forward into DSpace@MIT.

Further details of this work are in the linked ticket.

#### Tickets

- https://mitlibraries.atlassian.net/browse/ETD-191

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
