### PR TITLE
Sets link to hold panel to open in new tab

### DIFF
--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -50,7 +50,7 @@
                                       label_html: { style: 'width: 50%' },
                                       input_html: { class: 'disabled', style: 'width: 40%', value: f.object.active_holds?? 'Yes' : 'No' },
                                       hint_html: { style: 'display: block' },
-                                      hint: link_to('See details in admin interface',admin_thesis_path(f.object)) %>
+                                      hint: link_to('See details in admin interface', admin_thesis_path(f.object), target: :_blank) %>
           
         </li>
         <li>


### PR DESCRIPTION
This adds the `target="_blank"` attribute to a specific link on the thesis processing form. This step is being done in response to staff user requests after testing.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-374

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
