### PR TITLE
Only display unassigned files by default

### DIFF
--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -34,7 +34,6 @@ class TransferController < ApplicationController
 
       ReceiptMailer.virus_detected_email(@transfer).deliver_later
       redirect_to transfer_confirm_path
-
   end
 
   def files
@@ -47,7 +46,7 @@ class TransferController < ApplicationController
       thesis.files.attach(file.blob)
       flash[:success] += (file.filename.to_s + "<br>").html_safe
     end
-    redirect_to transfer_path(transfer.id)
+    redirect_to transfer_path(transfer.id, view_all: params[:view_all] || 'false')
   end
 
   def select

--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -47,22 +47,36 @@
   <%= hidden_field_tag( 'id', @transfer.id ) %>
 
   <h4>Assign these files ...</h4>
+
+  <%= hidden_field_tag( 'view_all', params[:view_all] || 'false' ) %>
+
+  <% if params[:view_all] == 'true' %>
+    <%= link_to('View only unassigned', url_for(view_all: false), class: 'btn button-secondary') %>
+    <%= link_to('View all', url_for(view_all: true), class: 'btn button-secondary is-disabled') %>
+  <% else %>
+    <%= link_to('View only unassigned', url_for(view_all: false), class: 'btn button-secondary is-disabled') %>
+    <%= link_to('View all', url_for(view_all: true), class: 'btn button-secondary') %>
+  <% end %>
+
   <fieldset>
     <legend>Select the files to move</legend>
     <ul class="list-unbulleted list-files">
       <% @transfer.files.each do |file| %>
+        <% if file.blob.attachments.where('record_type = ?', "Thesis").count == 0 %>
         <li>
-          <% if file.blob.attachments.where('record_type = ?', "Thesis").count == 0 %>
           <label>
             <%= check_box_tag( "transfer[file_ids][]", file.id, false, data: { "msg" => "Required - please select at least one file to transfer." }, class: "required" ) %>
             <%= link_to rails_blob_path(file, disposition: 'inline'), target: :_blank do %>
               <%= file.filename.to_s %>
             <% end %>
           </label>
-          <% else %>
-            <span class="assigned"><%= link_to rails_blob_path(file, disposition: 'inline'), target: :_blank do %><%= file.filename.to_s %><% end %></span> attached to "<%= link_to( title_helper( file.blob.attachments.where('record_type = ?', "Thesis").first.record ), thesis_process_path( file.blob.attachments.where('record_type = ?', "Thesis").first.record ) ) %>"
-          <% end %>
         </li>
+        <% else %>
+          <% next unless params[:view_all] == 'true' %>
+          <li>
+            <span class="assigned"><%= link_to rails_blob_path(file, disposition: 'inline'), target: :_blank do %><%= file.filename.to_s %><% end %></span> attached to "<%= link_to( title_helper( file.blob.attachments.where('record_type = ?', "Thesis").first.record ), thesis_process_path( file.blob.attachments.where('record_type = ?', "Thesis").first.record ) ) %>"
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </fieldset>


### PR DESCRIPTION
Why are these changes being introduced:

* The list of files can be quite large in some cases
* Scrolling through files that have already been processed can be
  annoying and inefficeint
* Most of the time, it is not useful to see the already assigned files

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-366

How does this address that need:

* Enables conditional display of the already assigned files during
  the Transfer processing workflow
* The default is to not display assigned files

Document any side effects to this change:

* Choosing to display assigned files should be sticking throughout the
  processing of that Transfer but would need to be reapplied when
  changing to a different Transfer. Being sticky beyond what we have
  implemented here would require using a session or local storage which
  didn't seem necessary at this time but wouldn't be difficult to
  implemente in the future if that is the desired behavior.
* The display of the `<li>` elements had to be adjusted slightly to
  prevent blank `<li>`s being displayed for the files we are skipping.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
