### PR TITLE
Add an augmented file upload behavior behind a querystring flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,19 @@ Example usage:
   lines so you'll need to be careful to reconstruct this
 - `rails debug:saml['tmp/your_saml_to_debug.txt']`
 
+## Alternate file upload feedback
+
+As a default behavior, the bulk file transfer form at `/transfer/new` uses the
+browser's built-in file input field, with slight javascript decoration to
+improve user feedback before and during file uploading.
+
+However, there is an alternate behavior available. This alternate, which has yet
+to be fully tested, can be accessed by appending any value for `upload` to the
+querystring (i.e. `/transfer/new?upload=alternate`). This alternative offers
+some additional capabilities via javascript decoration, such as appending to (or
+pruning from) a pending bulk file transfer. The file uploading itself is
+unaffected by this altenative.
+
 # Local deployment
 
 Use heroku local. We have also experimented with docker, and are retaining it in case we move toward dockerizing all the things in future.

--- a/app/views/transfer/new.html.erb
+++ b/app/views/transfer/new.html.erb
@@ -63,8 +63,8 @@
         hint: 'Do not upload a zip file.',
         hint_html: { id: 'transfer_files_ids-hint', class: 'col3q' }  %>
 
-  <div class='field-wrap'>
-    <div id="files_to_upload"></div>
+  <div class='field-wrap layout-1q3q layout-band'>
+    <div id="files_to_upload" class="col3q"></div>
   </div>
 
   <%= f.input :note, as: :text,
@@ -97,14 +97,20 @@
 <% end # Ends simple_form_for %>
 
   <script>
-    $("input:file").change(function () {
-        var filenames = '';
-        var fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
-        for (var i = 0; i < this.files.length; i++) {
-            filenames += '<li>' + this.files[i].name + '</li>';
-        }
-        $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>');
-    });
+    // Load file uploader based on querystring
+    var queryParams = new URLSearchParams(window.location.search);
+    if ( queryParams.has('upload') ) { // Any value for "upload" in querystring triggers the new uploader
+      $("input:file").change(listPendingFiles);
+    } else {
+      $("input:file").change(function () {
+          var filenames = '';
+          var fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
+          for (var i = 0; i < this.files.length; i++) {
+              filenames += '<li>' + this.files[i].name + '</li>';
+          }
+          $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>');
+      });
+    }
 
     $("#new_transfer").validate({
       invalidHandler: function(event, validator) {
@@ -120,4 +126,48 @@
         }
       }
     });
+
+    function listPendingFiles() {
+      let field = document.getElementById('transfer_files');
+      let filenames = '';
+      let fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
+      let fileadd = '<p><input type="file" id="add_files" onChange="mergeFiles(event)" multiple style="display: none;"><button onClick="addFiles(event)">Add more files to this transfer</button></p>';
+      for (var i = 0; i < field.files.length; i++) {
+          filenames += '<li>' + field.files[i].name + ' <a href="#" data-file="' + i + '" class="remove-file" onClick="removeFile(event)">(remove<span class="sr"> ' + field.files[i].name + '</span>)</a></li>';
+      }
+      $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>' + fileadd);
+    };
+
+    function removeFile(event) {
+      event.preventDefault();
+      let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
+
+      pendingFileArray.splice(event.target.dataset['file'], 1);
+
+      rebuildFiles(pendingFileArray);
+    }
+
+    function addFiles(event) {
+      event.preventDefault();
+      document.getElementById("add_files").click();
+    }
+
+    function mergeFiles(event) {
+      let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
+      let moreFilesArray = Array.from(document.getElementById('add_files').files);
+
+      newFilesArray = pendingFileArray.concat(moreFilesArray);
+
+      rebuildFiles(newFilesArray);
+    }
+
+    function rebuildFiles(newArray) {
+      let newTransfer = new DataTransfer();
+      newArray.forEach(function(item) {
+        let file = new File([item], item.name);
+        newTransfer.items.add(file);
+      });
+      document.getElementById('transfer_files').files = newTransfer.files;
+      listPendingFiles();
+    }
   </script>

--- a/app/views/transfer/new.html.erb
+++ b/app/views/transfer/new.html.erb
@@ -96,22 +96,7 @@
 
 <% end # Ends simple_form_for %>
 
-  <script>
-    // Load file uploader based on querystring
-    var queryParams = new URLSearchParams(window.location.search);
-    if ( queryParams.has('upload') ) { // Any value for "upload" in querystring triggers the new uploader
-      $("input:file").change(listPendingFiles);
-    } else {
-      $("input:file").change(function () {
-          var filenames = '';
-          var fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
-          for (var i = 0; i < this.files.length; i++) {
-              filenames += '<li>' + this.files[i].name + '</li>';
-          }
-          $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>');
-      });
-    }
-
+  <script type="text/javascript">
     $("#new_transfer").validate({
       invalidHandler: function(event, validator) {
         var errors = validator.numberOfInvalids();
@@ -126,48 +111,65 @@
         }
       }
     });
-
-    function listPendingFiles() {
-      let field = document.getElementById('transfer_files');
-      let filenames = '';
-      let fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
-      let fileadd = '<p><input type="file" id="add_files" onChange="mergeFiles(event)" multiple style="display: none;"><button onClick="addFiles(event)">Add more files to this transfer</button></p>';
-      for (var i = 0; i < field.files.length; i++) {
-          filenames += '<li>' + field.files[i].name + ' <a href="#" data-file="' + i + '" class="remove-file" onClick="removeFile(event)">(remove<span class="sr"> ' + field.files[i].name + '</span>)</a></li>';
-      }
-      $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>' + fileadd);
-    };
-
-    function removeFile(event) {
-      event.preventDefault();
-      let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
-
-      pendingFileArray.splice(event.target.dataset['file'], 1);
-
-      rebuildFiles(pendingFileArray);
-    }
-
-    function addFiles(event) {
-      event.preventDefault();
-      document.getElementById("add_files").click();
-    }
-
-    function mergeFiles(event) {
-      let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
-      let moreFilesArray = Array.from(document.getElementById('add_files').files);
-
-      newFilesArray = pendingFileArray.concat(moreFilesArray);
-
-      rebuildFiles(newFilesArray);
-    }
-
-    function rebuildFiles(newArray) {
-      let newTransfer = new DataTransfer();
-      newArray.forEach(function(item) {
-        let file = new File([item], item.name);
-        newTransfer.items.add(file);
-      });
-      document.getElementById('transfer_files').files = newTransfer.files;
-      listPendingFiles();
-    }
   </script>
+
+  <% if request.query_parameters.keys.include?("upload") %>
+    <script type="text/javascript">
+      function listPendingFiles() {
+        let field = document.getElementById('transfer_files');
+        let filenames = '';
+        let fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
+        let fileadd = '<p><input type="file" id="add_files" onChange="mergeFiles(event)" multiple style="display: none;"><button onClick="addFiles(event)">Add more files to this transfer</button></p>';
+        for (var i = 0; i < field.files.length; i++) {
+            filenames += '<li>' + field.files[i].name + ' <a href="#" data-file="' + i + '" class="remove-file" onClick="removeFile(event)">(remove<span class="sr"> ' + field.files[i].name + '</span>)</a></li>';
+        }
+        $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>' + fileadd);
+      };
+
+      function removeFile(event) {
+        event.preventDefault();
+        let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
+
+        pendingFileArray.splice(event.target.dataset['file'], 1);
+
+        rebuildFiles(pendingFileArray);
+      };
+
+      function addFiles(event) {
+        event.preventDefault();
+        document.getElementById("add_files").click();
+      };
+
+      function mergeFiles(event) {
+        let pendingFileArray = Array.from(document.getElementById('transfer_files').files);
+        let moreFilesArray = Array.from(document.getElementById('add_files').files);
+
+        newFilesArray = pendingFileArray.concat(moreFilesArray);
+
+        rebuildFiles(newFilesArray);
+      };
+
+      function rebuildFiles(newArray) {
+        let newTransfer = new DataTransfer();
+        newArray.forEach(function(item) {
+          let file = new File([item], item.name);
+          newTransfer.items.add(file);
+        });
+        document.getElementById('transfer_files').files = newTransfer.files;
+        listPendingFiles();
+      };
+
+      $("input:file").change(listPendingFiles);
+    </script>
+  <% else %>
+    <script type="text/javascript">
+      $("input:file").change(function () {
+          var filenames = '';
+          var fileblurb = '<p>The following files will be uploaded when this form is submitted:</p>';
+          for (var i = 0; i < this.files.length; i++) {
+              filenames += '<li>' + this.files[i].name + '</li>';
+          }
+          $("#files_to_upload").html(fileblurb + '<ul>' + filenames + '</ul>');
+      });
+    </script>
+  <% end %>


### PR DESCRIPTION
Following the decision to wrap up work on ETD-320, this is my attempt to cleanly finish the work-in-progress on an augmented file upload behavior.

This implements a switch in the new transfer form, activated by appending any value for `upload` to the querystring at the `/transfer/new` path (i.e. `/transfer/new?upload`). Adding this flag will activate the switch, which calls a different set of decoration functions.

These functions result in "remove" and "add more" controls appearing on the pending file list, allowing the user to append and remove files from the list before submitting the form.

**Please note!**

This work has gone through a fair amount of browser testing (Safari, Firefox, and Chrome on a Mac, and Edge on Windows), and some developer testing via WAVE and ANDI to confirm accessibility. It has _not_ been thoroughly tested by accessibility experts, however. Should this work be revived in the future, those who finish the work should engage that type of testing to ensure that an accessibility problem is not introduced by this code.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-320

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
