### PR TITLE
Updates thesis links on duplicate report

### DIFF
--- a/app/views/thesis/_duplicate_thesis.html.erb
+++ b/app/views/thesis/_duplicate_thesis.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to title_helper(duplicate_thesis), thesis_process_path(duplicate_thesis.id) %></td>
+  <td><%= link_to title_helper(duplicate_thesis), edit_admin_thesis_path(duplicate_thesis.id) %></td>
   <td>
     <% duplicate_thesis.users.each do |user| %>
       <%= user.display_name %><br>


### PR DESCRIPTION
This changes the links on the duplicate thesis report. They currently point to the processing form, but Mikki provided feedback that this wasn't useful in this context. A better target is the administrate UI's edit thesis form, because this form allows the staff to add more author records.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-378

#### Side effects

This is a mixing of the custom UI and the administrate UI, but I believe we already do this, and it seems more justifiable than building more custom UI elements.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
