### PR TITLE
Configure codeclimate to use specific rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+plugins:
+  rubocop:
+    enabled: true
+    channel: rubocop-1-18-3


### PR DESCRIPTION
Why are these changes being introduced:

* The default rubocop for codeclimate is quite old
* rubocop was not enabled for this repo in codeclimate

Document any side effects to this change:

* We'll need to manually bump the rubocop version in the codeclimate
  config when we update rubocop and we won't be able to update rubocop
  until codeclimate has a new channel for the new rubocop version

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
