### PR TITLE
ETD-357 Add papertrail to Thesis and User models

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -22,6 +22,8 @@
 #
 
 class Thesis < ApplicationRecord
+  has_paper_trail
+  
   belongs_to :copyright, optional: true
   belongs_to :license, optional: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,8 @@
 #
 
 class User < ApplicationRecord
+  has_paper_trail
+
   # We need to initialize  some fields before validation, or
   # the record won't save.
   before_validation(on: :create) do

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -735,4 +735,21 @@ class ThesisTest < ActiveSupport::TestCase
     thesis.reload
     assert_equal 'Published', thesis.publication_status
   end
+
+  test 'editing thesis generates an audit trail' do
+    t = theses(:one)
+    assert_equal t.versions.count, 0
+    t.title = 'updated'
+    t.save
+    assert_equal t.versions.count, 1
+    assert_equal t.versions.last.event, 'update'
+  end
+
+  test 'audit records include the changeset' do
+    t = theses(:one)
+    t.title = 'updated'
+    t.save
+    change = t.versions.last
+    assert_equal change.changeset['title'], %w[MyString updated]
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -365,4 +365,21 @@ class UserTest < ActiveSupport::TestCase
     u.reload
     assert_equal count - 1, u.editable_theses.count
   end
+
+  test 'editing user generates an audit trail' do
+    u = users(:yo)
+    assert_equal u.versions.count, 0
+    u.given_name = 'Hello'
+    u.save
+    assert_equal u.versions.count, 1
+    assert_equal u.versions.last.event, 'update'
+  end
+
+  test 'audit records include the changeset' do
+    u = users(:yo)
+    u.given_name = 'Hello'
+    u.save
+    change = u.versions.last
+    assert_equal change.changeset['given_name'], %w[Yo Hello]
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Audit trails are needed for the User and Thesis models to enhance
registrar data import reporting.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-357

#### How this addresses that need:

This adds papertrail to Thesis and User models.

#### Side effects of this change:

As noted in the ticket, we may later want to expand papertrail to all
(or most) of the other models. For now, we are limiting scope to the
two models that directly affect the registrar data import.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
