### PR TITLE
Generate email report for data registrar import jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ end
 group :development do
   gem 'annotate'
   gem 'dotenv-rails'
+  gem 'letter_opener'
   gem 'listen'
   gem 'rubocop'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -356,6 +360,7 @@ DEPENDENCIES
   dotenv-rails
   json
   kaminari
+  letter_opener
   listen
   lograge
   mitlibraries-theme

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ this automatically. It is often nice in development as well.
 ### Development
 
 `MAINTAINER_EMAIL` - used for `to` field of virus detected emails.
-`THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails.
+`THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails. Also the email to which reports are sent.
+`MAINTAINER_EMAIL` - used for `cc` field of report emails.
 
 ### Production
 
@@ -99,8 +100,9 @@ Assigning roles and the `Admin` flag is done in the web UI.
 `SMTP_PASSWORD`
 `SMTP_PORT`
 `SMTP_USER`
-`THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails.
-`DISABLE_ALL_EMAIL` - emails won't be sent unless this is set to `false`
+`THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails. Also the email to which reports are sent.
+`MAINTAINER_EMAIL` - used for `cc` field of report emails.
+`DISABLE_ALL_EMAIL` - emails won't be sent unless this is set to `false`.
 
 In development, emails are written to a file in `tmp`. In testing, they are
 stored in memory. You still need the `THESIS_ADMIN_EMAIL` set for the tmp file

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,0 +1,12 @@
+class ReportMailer < ApplicationMailer
+  def registrar_import_email(registrar, results)
+    return unless ENV.fetch('DISABLE_ALL_EMAIL', 'true') == 'false' # allows PR builds to disable emails
+
+    @registrar = registrar
+    @results = results
+    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+         to: ENV['THESIS_ADMIN_EMAIL'],
+         cc: ENV['MAINTAINER_EMAIL'],
+         subject: 'Registrar data import summary')
+  end
+end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -23,7 +23,7 @@
 
 class Thesis < ApplicationRecord
   has_paper_trail
-  
+
   belongs_to :copyright, optional: true
   belongs_to :license, optional: true
 
@@ -127,6 +127,13 @@ class Thesis < ApplicationRecord
   # have graduated. Any author having not graduated results in a false/"No".
   def authors_graduated?
     authors.map(&:graduation_confirmed?).reduce(:&)
+  end
+
+  # This checks whether a thesis record is new, based on the most recent transaction. Once the record is updated or
+  # saved, this will evaluate to false. Normally we would use ActiveModel::Dirty for this, but that module doesn't work
+  # well for models with nested attributes.
+  def new_thesis?
+    transaction_include_any_action?([:create])
   end
 
   # This contains the logic for a thesis to have its status set to either

--- a/app/views/report_mailer/registrar_import_email.html.erb
+++ b/app/views/report_mailer/registrar_import_email.html.erb
@@ -1,0 +1,47 @@
+<p>Hello,</p>
+
+<p>Below is a report of the registrar data import job submitted on 
+  <%= @registrar.created_at.in_time_zone("America/New_York").strftime('%b %-d, %Y at %l:%M %p %Z') %>.</p>
+
+<p>Summary of processed theses:</p>
+
+<ul>
+  <li>Total theses in job: <%= @results[:read] %></li>
+  <li>Total theses successfully processed: <%= @results[:processed] %></li>
+  <li>Errors found: <%= @results[:errors].count %></li>
+  <li>New theses: <%= @results[:new_theses] %></li>
+  <li>Updated theses: <%= @results[:updated_theses] %></li>
+  <li>New authors: <%= @results[:new_users] %></li>
+  <li>New degrees: <%= @results[:new_degrees].count %></li>
+  <li>New DLCs: <%= @results[:new_depts].count %></li>
+</ul>
+
+<% if @results[:errors].any? %>
+  <p>The following errors require processor attention:</p>
+
+  <ul>
+    <% @results[:errors].each do |e| %>
+      <li><%= e %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @results[:new_degrees].any? %>
+  <p>The following degrees were newly added:</p>
+
+  <ul>
+    <% @results[:new_degrees].each do |degree| %>
+      <li><%= link_to degree.name_dw, admin_degree_url(degree) %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @results[:new_depts].any? %>
+  <p>The following DLCs were newly added:</p>
+
+  <ul>
+    <% @results[:new_depts].each do |dept| %>
+      <li><%= link_to dept.name_dw, admin_department_url(dept) %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,11 +33,10 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Send mail to tmp file.
-  config.action_mailer.raise_delivery_errors = true
+  # Use letter_opener to preview emails.
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :file
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-require "active_support/core_ext/integer/time"
+require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.log_level = ENV['LOG_LEVEL'] || :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -80,6 +80,7 @@ Rails.application.configure do
     authentication: 'login',
     enable_starttls_auto: true
   }
+  config.action_mailer.default_url_options = { host: ENV['PREFERRED_DOMAIN'] || (ENV['HEROKU_APP_NAME'] + '.herokuapp.com') }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -101,7 +102,7 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/test/jobs/registrar_import_job_test.rb
+++ b/test/jobs/registrar_import_job_test.rb
@@ -24,6 +24,22 @@ class RegistrarImportJobTest < ActiveJob::TestCase
     results = RegistrarImportJob.perform_now(registrar)
     assert_equal 434, results[:read]
     assert_equal 433, results[:processed]
+    assert_equal 430, results[:new_theses]
+    assert_equal 3, results[:updated_theses]
+    assert_equal 430, results[:new_users]
+    assert_equal 42, results[:new_degrees].length
+    assert_equal 30, results[:new_depts].length
+    assert_equal 1, results[:errors].length
+    assert_includes results[:errors][0], 'Row #418 missing a Kerberos ID'
+
+    results = RegistrarImportJob.perform_now(registrar)
+    assert_equal 434, results[:read]
+    assert_equal 433, results[:processed]
+    assert_equal 0, results[:new_theses]
+    assert_equal 433, results[:updated_theses]
+    assert_equal 0, results[:new_users]
+    assert_equal 0, results[:new_degrees].length
+    assert_equal 0, results[:new_depts].length
     assert_equal 1, results[:errors].length
     assert_includes results[:errors][0], 'Row #418 missing a Kerberos ID'
   end

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class ReportMailerTest < ActionMailer::TestCase
+  test 'sends reports for registrar data imports' do
+    ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
+      registrar = registrar(:valid)
+      results = { read: 0, processed: 0, new_users: 0, new_theses: 1, updated_theses: 0, new_degrees: [], new_depts: [],
+                  errors: [] }
+      email = ReportMailer.registrar_import_email(registrar, results)
+
+      # Send the email, then test that it got queued
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      # Make sure it was sent to the right person with the right content. We are only testing a subset of the body
+      # rather than a full sample email to avoid future testing complications
+      assert_equal ['test@example.com'], email.from
+      assert_equal ['test@example.com'], email.to
+      assert_equal 'Registrar data import summary', email.subject
+      assert_match 'New theses: 1', email.body.to_s
+    end
+  end
+end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -752,4 +752,17 @@ class ThesisTest < ActiveSupport::TestCase
     change = t.versions.last
     assert_equal change.changeset['title'], %w[MyString updated]
   end
+
+  test 'evaluates whether a thesis is newly created' do
+    preexisting_thesis = theses(:one)
+    assert_equal false, preexisting_thesis.new_thesis?
+
+    new_thesis = Thesis.create(title: "wait till you see this new thesis you're not gonna believe it",
+                               graduation_month: 'February', graduation_year: '2020', users: [users(:yo)],
+                               degrees: [degrees(:one)], departments: [departments(:one)])
+    assert_equal true, new_thesis.new_thesis?
+
+    new_thesis.update(title: 'updated')
+    refute new_thesis.new_thesis?
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Processors and thesis admins need to see summary data about the
registrar import job, especially if there are any issues with it.
The job currently logs much of this information, but an email report
would be more useful for stakeholders to review.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-354
* https://mitlibraries.atlassian.net/browse/ETD-348
* https://mitlibraries.atlassian.net/browse/ETD-371

#### How this addresses that need:

This adds some data collection to the import job, as well as a mailer
that reports the following data:

* Number of theses in the job
* Number of theses processed
* Errors found (total number and list)
* New DLCs added (total number and list)
* New degrees added (total number and list)
* Number of new users
* Number of new theses
* Number of updated theses

#### Side effects of this change:

* The email is sent in the job rather than the controller so as to
access the results, but we may need to move that up to the controller
if it doesn't work.
* For new DLCs and degrees, we are dumping the results of the `inspect`
method, which may be difficult to read for end users. We should take a
look at this in the PR build before merging.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
