### PR TITLE
Resets files_complete when files are removed

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -81,6 +81,7 @@ class ThesisController < ApplicationController
   def process_theses_update
     thesis = Thesis.find(params[:id])
     removed = deleted_file_list
+    params[:thesis][:files_complete] = false if removed.count.positive?
     if thesis.update(thesis_params)
       flash[:success] = "<p>Your changes to '#{thesis.title}' have been saved.</p>".html_safe
       if removed.count.positive?

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -522,4 +522,29 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     # The flash message has a link back to the transfer with the file.
     assert_select 'div.alert ul li a', text: 'a_pdf.pdf', href: transfer_path(th), count: 1
   end
+
+  test 'removing a file from a thesis will reset files_complete flag' do
+    sign_in users(:processor)
+    tr = transfers(:valid)
+    th = theses(:publication_review_except_hold)
+    th.files_complete = true
+    th.save
+    assert(th.files_complete)
+    attach_files_to_records(tr, th)
+    patch thesis_process_update_path(theses(:publication_review_except_hold)),
+          params: {
+            thesis: {
+              title: 'My Almost-Ready Thesis',
+              issues_found: 'true',
+              files_attachments_attributes: {
+                '0': {
+                  id: th.files.first.id,
+                  _destroy: 1
+                }
+              }
+            }
+          }
+    th.reload
+    refute(th.files_complete)
+  end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Anytime a file is removed the thesis process should have to confirm
  all files are complete

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-370

How does this address that need:

* Sets Thesis.files_complete to false when we remove files

Document any side effects to this change:

* Files unattached not via the processing workflows will not reset the
  files_complete flag

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
