### PR TITLE
ETD-354 Reword language in registrar import email

### DIFF
--- a/app/views/report_mailer/registrar_import_email.html.erb
+++ b/app/views/report_mailer/registrar_import_email.html.erb
@@ -6,8 +6,8 @@
 <p>Summary of processed theses:</p>
 
 <ul>
-  <li>Total theses in job: <%= @results[:read] %></li>
-  <li>Total theses successfully processed: <%= @results[:processed] %></li>
+  <li>Total rows in CSV: <%= @results[:read] %></li>
+  <li>Total rows processed: <%= @results[:processed] %></li>
   <li>Errors found: <%= @results[:errors].count %></li>
   <li>New theses: <%= @results[:new_theses] %></li>
   <li>Updated theses: <%= @results[:updated_theses] %></li>


### PR DESCRIPTION
#### Why these changes are being introduced:

Stakeholder feedback on this email was to changing the wording from
'total theses' to 'total rows', as each row is not necessarily a
distinct thesis.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-354

#### How this addresses that need:

This makes the requested changes.

#### Side effects of this change:

None

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
