### PR TITLE
Change creative commons link

### DIFF
--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -147,7 +147,7 @@
                                   wrapper_html: { class: 'field-row select layout-1q3q layout-band' },
                                   input_html: { class: 'field field-select col3q', multiple: false,
                                     aria: { describedby: 'thesis_license-hint' } },
-                                  hint: 'Not sure what to select? Learn more about <a href="https://creativecommons.org/licenses/" target="_blank">Creative Commons licenses</a>.'.html_safe,
+                                  hint: 'Not sure what to select? Learn more about <a href="https://chooser-beta.creativecommons.org/" target="_blank">Creative Commons licenses</a>.'.html_safe,
                                   hint_html: { class: 'col3q', id: 'thesis_license-hint' } %>
 
       <div class="field-row layout-band layout-1q3q">

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -145,7 +145,7 @@
                                 wrapper_html: { class: 'field-row select layout-1q3q layout-band' },
                                 input_html: { class: 'field field-select col3q', multiple: false,
                                   aria: { describedby: 'thesis_license-hint' } },
-                                hint: 'Not sure what to select? Learn more about <a href="https://creativecommons.org/licenses/" target="_blank">Creative Commons licenses</a>.'.html_safe,
+                                hint: 'Not sure what to select? Learn more about <a href="https://chooser-beta.creativecommons.org/" target="_blank">Creative Commons licenses</a>.'.html_safe,
                                 hint_html: { class: 'col3q', id: 'thesis_license-hint' } %>
 
     <div class="layout-band layout-1q3q field-row">

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -192,7 +192,7 @@
                                 wrapper_html: { class: 'field-row select layout-1q3q layout-band' },
                                 input_html: { class: 'field field-select col3q', multiple: false,
                                   aria: { describedby: 'thesis_license-hint' } },
-                                hint: 'Not sure what to select? Learn more about <a href="https://creativecommons.org/licenses/" target="_blank">Creative Commons licenses</a>.'.html_safe,
+                                hint: 'Not sure what to select? Learn more about <a href="https://chooser-beta.creativecommons.org/" target="_blank">Creative Commons licenses</a>.'.html_safe,
                                 hint_html: { class: 'col3q', id: 'thesis_license-hint' } %>
 
     <div class="field-row layout-band layout-1q3q">


### PR DESCRIPTION
#### Why these changes are being introduced:

This was additional stakeholder feedback on the student submission
form.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-390

#### How this addresses that need:

This updates the creative commons link on the student submission
forms.

#### Side effects of this change:

None at first, although the link is to a beta version of the site,
so we may need to update it in the future.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
