### PR TITLE
Filter list of theses on file selection during thesis processing

### DIFF
--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -65,7 +65,7 @@
         <% if file.blob.attachments.where('record_type = ?', "Thesis").count == 0 %>
         <li>
           <label>
-            <%= check_box_tag( "transfer[file_ids][]", file.id, false, data: { "msg" => "Required - please select at least one file to transfer." }, class: "required" ) %>
+            <%= check_box_tag( "transfer[file_ids][]", file.id, false, data: { "msg" => "Required - please select at least one file to transfer." }, class: "required checkbox-trigger-filter" ) %>
             <%= link_to rails_blob_path(file, disposition: 'inline'), target: :_blank do %>
               <%= file.filename.to_s %>
             <% end %>
@@ -107,11 +107,22 @@
 <script>
   $(document).ready( function() {
     if( document.getElementById('thesisTargets').getElementsByClassName('empty').length === 0) {
-      var table = $('#thesisTargets').DataTable({
-
-      });
+      var table = $('#thesisTargets').DataTable({});
     }
+    $(".checkbox-trigger-filter").change(function() {
+      if(this.checked) {
+        var filename = $(this).next().text();
+        if (filename.split('-').length > 1) {
+          var kerb = filename.split('-')[1]
+          if (document.getElementById('thesisTargets_filter').getElementsByTagName('input')[0].value=='') {
+            table.search(kerb).draw();
+          }
+        }
+      }
+    });
   });
+
+
   $("#process_transfer").validate({
     errorPlacement: function(error, element) {
       if (element.attr("name") == "transfer[file_ids][]") {


### PR DESCRIPTION
This adds a class to the checkboxes in the list of files on a transfer processing form, along with some javascript that detects clicks on those checkboxes. The javascript will add a search/filter value to the table of thesis records, provided the table is currently unfiltered.

If the table is already filtered (either by this feature or via manual entry), no action is taken. We have no way of determining whether any filtering was done by the user or not, so it is better that we leave it alone - and let the user manipulate the filter value themselves.

#### Ticket:

- https://mitlibraries.atlassian.net/browse/ETD-367

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
