### PR TITLE
Fix sorting and filtering bugs in DataTables implementations

### DIFF
--- a/app/views/thesis/_select_empty.html.erb
+++ b/app/views/thesis/_select_empty.html.erb
@@ -1,3 +1,3 @@
 <tr class="empty">
-  <td colspan="5">No theses found</td>
+  <td colspan="6">No theses found</td>
 </tr>

--- a/app/views/thesis/_select_thesis.html.erb
+++ b/app/views/thesis/_select_thesis.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td data-sort="<%= select_thesis.files.blobs.first.created_at %>"><%= link_to(select_thesis.files.blobs.first.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y<br>%l:%M %p').html_safe, thesis_process_path(select_thesis.id)) %></td>
-  <td><%= select_thesis.graduation_month[...3] %> <%= select_thesis.graduation_year %></td>
+  <td data-sort="<%= select_thesis.grad_date %>"><%= select_thesis.graduation_month[...3] %> <%= select_thesis.graduation_year %></td>
   <td>
     <% select_thesis.departments.each do |dept| %>
       <%= dept.name_dw %><br>

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -27,7 +27,7 @@
 <% end %>
 
 <div id="status-list" class="filter-row">
-  <button data-filter="*">Show all</button>
+  <button class="btn button-primary" data-filter="*">Show all</button>
 </div>
 
 <table class="table" id="thesisQueue" title="Thesis processing queue">
@@ -49,9 +49,22 @@
 <script type="text/javascript">
 $(document).ready( function () {
   if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
+    // Initialize DataTable, sorting by default on degree column (columns are zero-based)
     var table = $('#thesisQueue').DataTable({
       "order": [[ 1, "asc" ]]
     });
+
+    var _status = "*";
+
+    // Add filter for "Status" column to standard table behavior
+    // From: https://datatables.net/blog/2014-08-26#Complete-code
+    $.fn.dataTable.ext.search.push(
+      function( settings, data, dataIndex ) {
+        return ( data[5] === _status || _status === "*" )
+          ? true
+          : false
+      }
+    );
 
     // Populate filter buttons with found values for publication status
     var terms = [...new Set( table.columns(5).data()[0] )];
@@ -59,22 +72,17 @@ $(document).ready( function () {
       document
         .getElementById("status-list")
         .insertAdjacentHTML("beforeend", `
-        <button data-filter="${element}">${element}</button>
+        <button class="btn button-secondary" data-filter="${element}">${element}</button>
       `);
     });
 
-    // Perform filtering when buttons are clicked
-    $(".filter-row button").click(function() {
-      var needle = $(this).data("filter");
-      $.fn.dataTable.ext.search.push(
-        function( settings, data, dataIndex ) {
-          return ( data[5] === needle || needle === "*" )
-            ? true
-            : false
-        }
-      );
+    // Change highlighting and perform filtering when buttons are clicked
+    $("#status-list button").click(function() {
+      $("#status-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
+      $(this).removeClass("button-secondary").addClass("button-primary");
+
+      _status = $(this).data("filter");
       table.draw();
-      $.fn.dataTable.ext.search.pop();
     });
   };
 });

--- a/app/views/transfer/select.html.erb
+++ b/app/views/transfer/select.html.erb
@@ -9,7 +9,7 @@
 <h3 class="title title-page">Transfer Processing Queue</h3>
 
 <div id="term-list" class="filter-row">
-  <button data-filter="*">Show<br>all</button>
+  <button class="btn button-primary" data-filter="*">Show<br>all</button>
 </div>
 
 <table class="table" id="transferQueue">
@@ -31,9 +31,22 @@
 <script type="text/javascript">
 $(document).ready( function () {
   if( document.getElementById('transferQueue').getElementsByClassName('empty').length === 0 ) {
+    // Initialize DataTable, sorting by default on the degree column (columns are zero-based)
     var table = $('#transferQueue').DataTable({
       "order": [[ 1, "asc" ]]
     });
+
+    var _degreeDate = "*";
+
+    // Add filter for "Degree date" column to standard table behavior
+    // From: https://datatables.net/blog/2014-08-26#Complete-code
+    $.fn.dataTable.ext.search.push(
+      function( settings, data, dataIndex ) {
+        return ( data[1] === _degreeDate || _degreeDate === "*" )
+          ? true
+          : false
+      }
+    );
 
     // Populate filter buttons with found values
     var terms = [...new Set( table.columns(1).data()[0] )];
@@ -41,22 +54,17 @@ $(document).ready( function () {
       document
         .getElementById("term-list")
         .insertAdjacentHTML("beforeend", `
-        <button data-filter="${element}">${element.replace(' ', '<br>')}</button>
+        <button class="btn button-secondary" data-filter="${element}">${element.replace(' ', '<br>')}</button>
       `);
     });
 
-    // Perform filtering when buttons are clicked
-    $(".filter-row button").click(function() {
-      var needle = $(this).data("filter");
-      $.fn.dataTable.ext.search.push(
-        function( settings, data, dataIndex ) {
-          return ( data[1] === needle || needle === "*" )
-            ? true
-            : false
-        }
-      );
+    // Change highlighting and perform filtering when buttons are clicked
+    $("#term-list button").click(function() {
+      $("#term-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
+      $(this).removeClass("button-secondary").addClass("button-primary");
+
+      _degreeDate = $(this).data("filter");
       table.draw();
-      $.fn.dataTable.ext.search.pop();
     });
   }
 });


### PR DESCRIPTION
This addresses a few different bugs that have been noticed in our DataTables implementation:
1. Both the Thesis and Transfer queues have a problem in how we've implemented the custom filtering buttons. The buttons do not persist their behavior beyond that click action, so re-sorting the table resets the filtering.
2. The Thesis queue, specifically, does not sort by degree date accurately - it uses an alphabetical sort rather than a date sort.
3. The "no records" display on the thesis queue has the wrong number of columns - we never bumped the colspan attribute when we added the issues found column.

Each of these is fixed in a separate commit, because they are separate bugs. I didn't create a separate ticket for the second and third items.

This code review is happening prior to stakeholder review - if I'm forgetting the order here, please let me know and I'll get their input first.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-386

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
