### PR TITLE
ETD-352 Add processor note to searchable fields in thesis processing queue

### DIFF
--- a/app/views/thesis/_select_empty.html.erb
+++ b/app/views/thesis/_select_empty.html.erb
@@ -1,3 +1,3 @@
 <tr class="empty">
-  <td colspan="6">No theses found</td>
+  <td colspan="7">No theses found</td>
 </tr>

--- a/app/views/thesis/_select_thesis.html.erb
+++ b/app/views/thesis/_select_thesis.html.erb
@@ -13,4 +13,5 @@
   </td>
   <td><%= select_thesis.issues_found ? 'Yes' : 'No' %></td>
   <td><%= select_thesis.publication_status %></td>
+  <td><%= select_thesis.processor_note %></td>
 </tr>

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -39,6 +39,7 @@
       <th scope="col">Author(s)</th>
       <th scope="col">Issues found</th>
       <th scope="col">Status</th>
+      <th scope="col">Processor note</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
#### Why these changes are being introduced:

This was a requested change from the first round of thesis processing.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-352

#### How this addresses that need:

This makes processor_note a searchable field in the thesis processing
datatable. We are leaving the column visible for now, but we may
need hide it later if it creates too much clutter in the UI. Jess will
keep an eye on this while processing theses.

#### Side effects of this change:

This is the only text field that we are querying in the datatable,
so it's an open question as to whether this will perform adequately
at scale. We can adjust as needed based on what we see in prod.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
