### PR TITLE
ETD-419 Make the abstract field optional in thesis forms

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -52,7 +52,6 @@ class Thesis < ApplicationRecord
   attr_accessor :graduation_year, :graduation_month
 
   VALIDATION_MSGS = {
-    abstract: 'Required - Please provide an abstract.',
     copyright: 'Required - Please identify the copyright holder.',
     graduation_year: 'Required - Please input your year of graduation.',
     graduation_month: 'Required - Please select your month of graduation.',

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -164,14 +164,11 @@
       </div>
 
       <%= f.input :abstract, as: :text,
-                             required: true,
-                             validate: { presence: true },
-                             label: 'Abstract *',
+                             label: 'Abstract',
                              label_html: { class: 'col1q' },
                              wrapper_html: { class: 'field-row layout-1q3q layout-band' },
                              input_html: { class: 'field field-text col3q',
                                rows: 10,
-                               data: { msg: Thesis::VALIDATION_MSGS[:abstract] }
                              } %>
 
       <%= f.input :author_note, as: :text,

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -162,14 +162,11 @@
     </div>
 
     <%= f.input :abstract, as: :text,
-                           required: true,
-                           validate: { presence: true },
-                           label: 'Abstract *',
+                           label: 'Abstract',
                            label_html: { class: 'col1q' },
                            wrapper_html: { class: 'field-row layout-1q3q layout-band' },
                            input_html: { class: 'field field-text col3q',
                              rows: 10,
-                             data: { msg: Thesis::VALIDATION_MSGS[:abstract] }
                            } %>
 
       <%= f.input :author_note, as: :text,

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -210,14 +210,11 @@
     </div>
 
     <%= f.input :abstract, as: :text,
-                           required: true,
-                           validate: { presence: true },
-                           label: 'Abstract *',
+                           label: 'Abstract',
                            label_html: { class: 'col1q' },
                            wrapper_html: { class: 'field-row layout-1q3q layout-band' },
                            input_html: { class: 'field field-text col3q',
-                             rows: 10,
-                             data: { msg: Thesis::VALIDATION_MSGS[:abstract] }
+                             rows: 10
                            } %>
 
     <%= f.input :author_note, readonly: true,


### PR DESCRIPTION
#### Why these changes are being introduced:

Abstract is currently a required field in the thesis submission forms,
but bachelor's theses don't require it.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-419

#### How this addresses that need:

This removes the form validations that make abstract a required field.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
