### PR TITLE
Improve rendering of abstracts in email

### DIFF
--- a/app/views/receipt_mailer/receipt_email.html.erb
+++ b/app/views/receipt_mailer/receipt_email.html.erb
@@ -24,7 +24,7 @@ The information we have on record is listed below.</p>
 <strong>ORCID iD:</strong> <%= @user.orcid %><br>
 </p>
 
-<p style="margin-left: 40px;">
+<div style="margin-left: 40px;">
 <strong>Thesis title:</strong> <%= @thesis.title %><br>
 <strong>Name as it appears on your thesis:</strong> <%= @user.preferred_name %><br>
 <strong>Co-author:</strong> <%= @thesis.coauthors %><br>
@@ -34,9 +34,10 @@ The information we have on record is listed below.</p>
 <strong>Copyright holder:</strong> <%= @thesis.copyright.holder %><br>
 <strong>License:</strong> <%= @thesis.license_id? ? @thesis.license.display_description : "" %><br>
 <strong>Thesis supervisors:</strong> <%= @thesis.advisors.map { |a| a.name }.join('; ') %><br>
-<strong>Abstract:</strong> <%= @thesis.abstract %><br>
+<strong>Abstract:</strong><br>
+<%= simple_format(@thesis.abstract, {}, wrapper_tag: "p") %>
 <strong>Notes:</strong> <%= @thesis.author_note %><br>
-</p>
+</div>
 
 <p>Let us know if you have any questions. And again, congratulations 
 on finishing (or almost finishing) your degree!</p>

--- a/test/fixtures/receipt_mailer/receipt_email
+++ b/test/fixtures/receipt_mailer/receipt_email
@@ -34,7 +34,7 @@ The information we have on record is listed below.</p>
 <strong>ORCID iD:</strong> <br>
 </p>
 
-<p style="margin-left: 40px;">
+<div style="margin-left: 40px;">
 <strong>Thesis title:</strong> MyString<br>
 <strong>Name as it appears on your thesis:</strong> Robot, Admin<br>
 <strong>Co-author:</strong> My co-author<br>
@@ -44,9 +44,10 @@ The information we have on record is listed below.</p>
 <strong>Copyright holder:</strong> MIT<br>
 <strong>License:</strong> No Creative Commons License<br>
 <strong>Thesis supervisors:</strong> Addy McAdvisor<br>
-<strong>Abstract:</strong> MyText<br>
+<strong>Abstract:</strong><br>
+<p>MyText</p>
 <strong>Notes:</strong> <br>
-</p>
+</div>
 
 <p>Let us know if you have any questions. And again, congratulations 
 on finishing (or almost finishing) your degree!</p>


### PR DESCRIPTION
This updates how abstracts are rendered in the receipt email which is sent to students, in order to better respect the user input around line breaks and carriage returns.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

_Quick note about a11y testing:_ I'm not aware of how to use ANDI or Wave on an email, but I did listen to the resulting email in my Outlook using Mac's VoiceOver. I may be missing something, but the contents of the email seemed to be read correctly. I'm not aware of any gotchas in email accessibility beyond this check.

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
