### PR TITLE
Initial reporting dashboard

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -199,3 +199,9 @@ ul.thesis-start {
     margin-bottom: 1em;
   }
 }
+
+// reports styles
+.hero-text {
+  font-size: 200%;
+  font-weight: bolder;
+}

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -1,0 +1,32 @@
+class ReportController < ApplicationController
+  before_action :require_user
+  before_action :authenticate_user!
+  load_and_authorize_resource except: :create
+  protect_from_forgery with: :exception
+
+  include ThesisHelper
+
+  def index
+    term = params[:graduation] ? params[:graduation].to_s : 'all'
+    report = Report.new
+    theses = Thesis.all
+    @terms = report.extract_terms theses
+    subset = filter_theses_by_term theses
+    @data = report.dashboard_data subset, term
+    @table = report.dashboard_tables subset
+  end
+
+  private
+
+  def require_user
+    return if current_user
+
+    # Do NOT use ENV['FAKE_AUTH_ENABLED'] directly! Use the config. It performs
+    # an additional check to make sure we are not on the production server.
+    if Rails.configuration.fake_auth_enabled
+      redirect_to user_developer_omniauth_authorize_path
+    else
+      redirect_to user_saml_omniauth_authorize_path
+    end
+  end
+end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -19,6 +19,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     title: Field::String,
     abstract: Field::Text,
     grad_date: Field::DateTime.with_options(
+      searchable: true,
       format: '%Y %B'
     ),
     graduation_month: Field::Text,

--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -6,4 +6,10 @@ module ThesisHelper
 
     thesis.title
   end
+
+  def filter_theses_by_term(theses)
+    return theses.where('grad_date = ?', params[:graduation]) if params[:graduation] && params[:graduation] != 'all'
+
+    theses
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,6 +53,8 @@ class Ability
 
     can :manage, :submitter
 
+    can :index, Report
+
     can %i[read update], Thesis
     can :annotate, Thesis
     can :deduplicate, Thesis

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,92 @@
+class Report
+  delegate :url_helpers, to: 'Rails.application.routes'
+
+  def card_files(collection, term)
+    subset = collection.joins(:files_attachments)
+    {
+      'value' => subset.pluck(:id).uniq.count,
+      'label' => 'have files attached',
+      'note' => 'Only theses with a status of "Not ready for publication" and "Publication review" will be visible '\
+                'in the processing queue.',
+      'link' => {
+        'url' => url_helpers.thesis_select_path(graduation: term),
+        'text' => "See #{subset.where('publication_status != ?', 'Published').pluck(:id).uniq.count} unpublished "\
+                  'theses in processing queue'
+      }
+    }
+  end
+
+  def card_issues(collection)
+    {
+      'value' => collection.where('issues_found = ?', true).count,
+      'label' => 'flagged with issues'
+    }
+  end
+
+  def card_overall(collection, term)
+    {
+      'value' => collection.count,
+      'label' => 'thesis records',
+      'link' => {
+        'url' => url_helpers.admin_theses_path(search: term),
+        'text' => 'See all in admin dashboard'
+      }
+    }
+  end
+
+  def dashboard_data(collection, term)
+    result = {}
+    result['overall'] = card_overall collection, term
+    result['files'] = card_files collection, term
+    result['issues'] = card_issues collection
+    result
+  end
+
+  def dashboard_tables(collection)
+    result = {}
+    result['status'] = table_status collection
+    result['copyright'] = table_copyright collection
+    result
+  end
+
+  def extract_terms(collection)
+    collection.pluck(:grad_date).uniq.sort
+  end
+
+  def table_populate_defaults(data, values)
+    values.each do |value|
+      data[value] = '0' unless data[value]
+    end
+  end
+
+  def table_status(collection)
+    result = collection.group(:publication_status).count
+    table_populate_defaults result, Thesis.publication_statuses
+    {
+      'title' => 'Thesis counts by publication status',
+      'summary' => 'This table presents a summary of thesis records by their publication status. The second column '\
+                   'gives the status, while the first column gives how many records have that status.',
+      'column' => 'Publication status',
+      'data' => result
+    }
+  end
+
+  def table_copyright(collection)
+    result = {}
+    collection.group(:copyright).count.each do |record|
+      if record[0].instance_of?(NilClass)
+        result['Undefined'] = record[1]
+      else
+        result[record[0].holder] = record[1]
+      end
+    end
+    table_populate_defaults result, Copyright.pluck(:holder)
+    {
+      'title' => 'Thesis counts by copyright',
+      'summary' => 'This table presents a summary of thesis records by their copyright status. The second column '\
+                   'names the copyright holder, while the first column shows how many records have that copyright.',
+      'column' => 'Copyright holder',
+      'data' => result
+    }
+  end
+end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -98,6 +98,7 @@ class Thesis < ApplicationRecord
   scope :valid_months_only, lambda {
     select { |t| VALID_MONTHS.include? t.grad_date.strftime('%B') }
   }
+  scope :publication_statuses, -> { PUBLICATION_STATUS_OPTIONS }
 
   # This inverts the issues_found field, so that the checks inside the
   # update_status method below are all written the same way.

--- a/app/views/layouts/_site_nav.html.erb
+++ b/app/views/layouts/_site_nav.html.erb
@@ -12,7 +12,6 @@
           <% if user_signed_in? %>
             <% if can? :select, Thesis %>
               <%= nav_link_to("Process theses", thesis_select_path) %>
-              <%= nav_link_to("Duplicate report", thesis_deduplicate_path) %>
             <% end %>
             <% if can? :create, Transfer %>
               <%= nav_link_to("Transfer theses", new_transfer_path) %>
@@ -25,6 +24,9 @@
             <% end %>
             <% if can? :list_registrar, Registrar %>
               <%= nav_link_to("Harvest CSV", harvest_path) %>
+            <% end %>
+            <% if can? :index, Report %>
+              <%= nav_link_to("Report", report_index_path) %>
             <% end %>
             <% if current_user.admin? || can?(:administrate, Admin) %>
               <%= link_to("Admin", admin_root_path, class: 'nav-item') %>

--- a/app/views/report/_card.html.erb
+++ b/app/views/report/_card.html.erb
@@ -1,0 +1,9 @@
+<p class="box-content card-<%= card[0] %> inline-action">
+  <span class="message hero-text"><%= card[1]["value"] %> <%= card[1]["label"] %></span>
+  <% if card[1]["link"] %>
+    <span class="actions"><%= link_to( card[1]["link"]["text"], card[1]["link"]["url"] ) %></span>
+  <% end %>
+</p>
+<% if card[1]['note'] %>
+  <p><em><%= card[1]['note'] %></em></p>
+<% end %>

--- a/app/views/report/_table.html.erb
+++ b/app/views/report/_table.html.erb
@@ -1,0 +1,25 @@
+<h4 class="title"><%= table[1]['title'] %></h4>
+<table class='table table-simplified table-<%= table[0] %>' <% if table[1]['summary'] %>summary="<%= table[1]['summary'] %>"<% end %>>
+  <% if table[1]['caption'] %>
+    <caption>
+      <%= table[1]['caption'] %>
+    </caption>
+  <% end %>
+  <thead>
+    <tr>
+      <th scope="col">Count</th>
+      <th scope="col"><%= table[1]['column'] %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% table[1]['data'].each do |row| %>
+      <tr>
+        <td><%= row[1] %></td>
+        <td><%= row[0] %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<% if table[1]['note'] %>
+  <p><em><%= table[1]['note'] %></em></p>
+<% end %>

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -1,0 +1,20 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Thesis reporting dashboard</h3>
+
+    <%= render 'shared/defined_terms_filter' %>
+
+    <%= render(partial: 'card', collection: @data) %>
+
+    <hr>
+
+    <%= render(partial: 'table', collection: @table) %>
+
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_defined_terms_filter.html.erb
+++ b/app/views/shared/_defined_terms_filter.html.erb
@@ -1,0 +1,15 @@
+<%= form_tag(nil, method: "get") do %>
+  <label>
+    Include only theses from: 
+    <select name="graduation">
+      <option value="all">All terms</option>
+      <% @terms.each do |term| %>
+        <option value="<%= term %>"<%= ' selected="selected"'.html_safe if params[:graduation].to_s == term.to_s %>>
+          <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
+        </option>
+      <% end %>
+    </select>    
+  </label>
+
+  <%= submit_tag('Apply filter', class: 'btn button-primary') %>
+<% end %>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -1,0 +1,13 @@
+<div class="bit">
+  <h4 class="title">Available reports</h3>
+  <nav aria-label="Available reports submenu">
+    <ul>
+      <% if can?(:index, Report) %>
+        <li><%= link_to("Thesis dashboard", report_index_path) %></li>
+      <% end %>
+      <% if can?(:select, Thesis) %>
+        <li><%= link_to("Theses with co-authors", thesis_deduplicate_path) %></li>
+      <% end %>
+    </ul>
+  </nav>
+</div>

--- a/app/views/thesis/deduplicate.html.erb
+++ b/app/views/thesis/deduplicate.html.erb
@@ -6,40 +6,32 @@
 
 <link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
 
-<h3 class="title title-page">Theses with co-author(s)</h3>
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Theses with co-author(s)</h3>
 
-<%= render 'shared/you_are' %>
+    <%= render 'shared/defined_terms_filter' %>
 
-<%= form_tag(thesis_deduplicate_path, method: "get") do %>
-  <label>
-    Show only theses from: 
-    <select name="graduation">
-      <option value="all">All terms</option>
-      <% @terms.each do |term| %>
-        <option value="<%= term %>"<%= ' selected="selected"'.html_safe if params[:graduation].to_s == term.to_s %>>
-          <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
-        </option>
-      <% end %>
-    </select>    
-  </label>
+    <table class="table" id="thesisQueue" title="Thesis processing queue">
+      <thead>
+        <tr>
+          <th scope="col">Title</th>
+          <th scope="col">Author(s)</th>
+          <th scope="col">Coauthor(s)</th>
+          <th scope="col">Department(s)</th>
+          <th scope="col">Degree date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'thesis/duplicate_thesis', collection: @thesis) || render('select_empty') %>
+      </tbody>
+    </table>
+  </div>
 
-  <%= submit_tag('Apply filter', class: 'btn button-primary') %>
-<% end %>
-
-<table class="table" id="thesisQueue" title="Thesis processing queue">
-  <thead>
-    <tr>
-      <th scope="col">Title</th>
-      <th scope="col">Author(s)</th>
-      <th scope="col">Coauthor(s)</th>
-      <th scope="col">Department(s)</th>
-      <th scope="col">Degree date</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render(partial: 'thesis/duplicate_thesis', collection: @thesis) || render('select_empty') %>
-  </tbody>
-</table>
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>
 
 <script type="text/javascript">
 $(document).ready( function () {

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -10,21 +10,7 @@
 
 <%= render 'shared/you_are' %>
 
-<%= form_tag(thesis_select_path, method: "get") do %>
-  <label>
-    Show only theses from: 
-    <select name="graduation">
-      <option value="all">All terms</option>
-      <% @terms.each do |term| %>
-        <option value="<%= term %>"<%= ' selected="selected"'.html_safe if @graduation.to_s == term.to_s %>>
-          <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
-        </option>
-      <% end %>
-    </select>    
-  </label>
-
-  <%= submit_tag('Apply filter', class: 'btn button-primary') %>
-<% end %>
+<%= render 'shared/defined_terms_filter' %>
 
 <div id="status-list" class="filter-row">
   <button class="btn button-primary" data-filter="*">Show all</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     root to: "theses#index"
   end
 
+  get 'report', to: 'report#index', as: 'report_index'
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
   get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'
   get 'thesis/:id/process', to: 'thesis#process_theses', as: 'thesis_process'

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class ReportControllerTest < ActionDispatch::IntegrationTest
+  test 'summary report exists' do
+    sign_in users(:admin)
+    get report_index_path
+    assert_response :success
+  end
+
+  test 'anonymous users are prompted to log in by summary report' do
+    # Note that nobody is signed in.
+    get report_index_path
+    assert_response :redirect
+  end
+
+  test 'basic users cannot see summary report' do
+    sign_in users(:basic)
+    get report_index_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'submitters cannot see summary report' do
+    sign_in users(:transfer_submitter)
+    get report_index_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'processors can see summary report' do
+    sign_in users(:processor)
+    get report_index_path
+    assert_response :success
+  end
+
+  test 'thesis_admins can see summary report' do
+    sign_in users(:thesis_admin)
+    get report_index_path
+    assert_response :success
+  end
+
+  test 'admins can see summary report' do
+    sign_in users(:admin)
+    get report_index_path
+    assert_response :success
+  end
+
+  test 'summary report shows a few fields' do
+    sign_in users(:processor)
+    get report_index_path
+    assert_select '.card-overall .message', text: '20 thesis records', count: 1
+    assert_select '.card-files .message', text: '0 have files attached', count: 1
+    assert_select '.card-issues .message', text: '0 flagged with issues', count: 1
+    assert_response :success
+  end
+
+  test 'summary report allows filtering' do
+    sign_in users(:processor)
+    get report_index_path
+    assert_select '.card-overall .message', text: '20 thesis records', count: 1
+    get report_index_path, params: { graduation: '2018-09-01' }
+    assert_select '.card-overall .message', text: '2 thesis records', count: 1
+    assert_response :success
+  end
+end

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -17,4 +17,22 @@ class ThesisHelperTest < ActionView::TestCase
     @thesis = Thesis.new(title: 'yolo title!')
     assert_equal 'yolo title!', title_helper(@thesis)
   end
+
+  test 'filter_theses_by_term returns a filtered set of theses' do
+    @theses = Thesis.all
+    params[:graduation] = "2018-09-01"
+    assert_not_equal 2, @theses.count
+    assert_equal 2, filter_theses_by_term(@theses).count
+  end
+
+  test 'filter_theses_by_term does nothing when no graduation param is set' do
+    @theses = Thesis.all
+    assert_equal @theses.count, filter_theses_by_term(@theses).count
+  end
+
+  test 'filter_theses_by_term does nothing when graduation param is "all"' do
+    @theses = Thesis.all
+    params[:graduation] = "all"
+    assert_equal @theses.count, filter_theses_by_term(@theses).count
+  end
 end

--- a/test/integration/nav_test.rb
+++ b/test/integration/nav_test.rb
@@ -33,14 +33,6 @@ class NavTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'thesis deduplicate page nav' do
-    mock_auth(users(:admin))
-    get thesis_deduplicate_path
-    assert_select('.current') do |value|
-      assert(value.text.include?('Duplicate report'))
-    end
-  end
-
   test 'registrar page nav' do
     mock_auth(users(:admin))
     get new_registrar_path
@@ -76,6 +68,14 @@ class NavTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'report page nav' do
+    mock_auth(users(:admin))
+    get report_index_path
+    assert_select('.current') do |value|
+      assert(value.text.include?('Report'))
+    end
+  end
+
   # Basic user navigation
   test 'basic navigation' do
     mock_auth(users(:basic))
@@ -87,11 +87,11 @@ class NavTest < ActionDispatch::IntegrationTest
 
       # Navigation should not include:
       assert_select 'a[href=?]', thesis_select_path, count: 0
-      assert_select 'a[href=?]', thesis_deduplicate_path, count: 0
       assert_select 'a[href=?]', new_transfer_path, count: 0
       assert_select 'a[href=?]', transfer_select_path, count: 0
       assert_select 'a[href=?]', new_registrar_path, count: 0
       assert_select 'a[href=?]', harvest_path, count: 0
+      assert_select 'a[href=?]', report_index_path, count: 0
       assert_select 'a[href=?]', admin_root_path, count: 0
     end
   end
@@ -108,10 +108,10 @@ class NavTest < ActionDispatch::IntegrationTest
 
       # Navigation should not include:
       assert_select 'a[href=?]', thesis_select_path, count: 0
-      assert_select 'a[href=?]', thesis_deduplicate_path, count: 0
       assert_select 'a[href=?]', transfer_select_path, count: 0
       assert_select 'a[href=?]', new_registrar_path, count: 0
       assert_select 'a[href=?]', harvest_path, count: 0
+      assert_select 'a[href=?]', report_index_path, count: 0
       assert_select 'a[href=?]', admin_root_path, count: 0
     end
   end
@@ -125,11 +125,11 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', root_path
       assert_select 'a[href=?]', thesis_start_path
       assert_select 'a[href=?]', thesis_select_path
-      assert_select 'a[href=?]', thesis_deduplicate_path
       # assert_select "a[href=?]", new_transfer_path
       assert_select 'a[href=?]', transfer_select_path
       assert_select 'a[href=?]', new_registrar_path, count: 0
       assert_select 'a[href=?]', harvest_path, count: 0
+      assert_select 'a[href=?]', report_index_path
       # assert_select "a[href=?]", admin_root_path
     end
   end
@@ -143,11 +143,11 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', root_path
       assert_select 'a[href=?]', thesis_start_path
       assert_select 'a[href=?]', thesis_select_path
-      assert_select 'a[href=?]', thesis_deduplicate_path
       assert_select 'a[href=?]', new_transfer_path
       assert_select 'a[href=?]', transfer_select_path
       assert_select 'a[href=?]', new_registrar_path
       assert_select 'a[href=?]', harvest_path
+      assert_select 'a[href=?]', report_index_path
       assert_select 'a[href=?]', admin_root_path
     end
   end
@@ -161,11 +161,11 @@ class NavTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', root_path
       assert_select 'a[href=?]', thesis_start_path
       assert_select 'a[href=?]', thesis_select_path
-      assert_select 'a[href=?]', thesis_deduplicate_path
       assert_select 'a[href=?]', new_transfer_path
       assert_select 'a[href=?]', transfer_select_path
       assert_select 'a[href=?]', new_registrar_path
       assert_select 'a[href=?]', harvest_path
+      assert_select 'a[href=?]', report_index_path
       assert_select 'a[href=?]', admin_root_path
     end
   end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -552,6 +552,10 @@ class ThesisTest < ActiveSupport::TestCase
     assert_equal false, thesis.authors_graduated?
   end
 
+  test 'publication_statuses scope returns accepted status dictionary' do
+    assert_equal 4, Thesis.publication_statuses.length
+  end
+
   test 'publication status defaults to not ready for publication' do
     thesis = Thesis.new
     assert thesis.publication_status == 'Not ready for publication'


### PR DESCRIPTION
This creates the first summary dashboard for thesis records (for a given term). It contains the data points asked for in ETD-412, with links to see more information for various subsets of records.

1. The total number of thesis records (with a link to see them in the admin dashboard)
2. The number of theses which have attached files (and a link to see them in the processing queue)
3. The number of theses which have been flagged as having issues (there is no link for this box, because there's no easy web address to surface them - you would need to enter a filter value in the processing queue)

There are also two breakdown tables, showing how many thesis records are in each of two categories: publication status and copyright holder. The ticket only asks for publication status, but a separate ticket (413) is going to ask for copyright, and I needed to make sure that the engineering of the table code was at least somewhat abstracted.

As part of this work, the site navigation has also been restructured, removing the duplicate thesis report in favor of a "Report" item which links to this dashboard. Both the dashboard and the duplicate report have a reporting submenu. Further tickets will add more report options to this menu.

Beyond this initial implementation, the thesis controller has been refactored due to feedback from Codeclimate. Two helper methods have been defined in order to reduce the complexity of three methods which have _very_ similar logic. One method extracts a list of terms from a set of thesis (which is then used in a shared filtering partial). The other method filters a set of theses by the `graduation` parameter in the querystring.

I've tried to structure this PR as clearly as I can - but I've also spent longer on this than I intended, and I'm not sure more time will help. I fully expect that QA testing may surface requests for changes, and there are definitely tickets coming that will build upon this work.
 
#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-412

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
