### PR TITLE
Prevents student editing of thesis metadata when issues have been flagged

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,12 +108,12 @@ class User < ApplicationRecord
     end
   end
 
-  # This convenience method returns the list of the user's theses for which
-  # the user can submit metadata. The logic regarding which theses qualify for
-  # this list may be subject to change; initially this is all theses for which
-  # the "metadata_complete" flag is not set.
+  # This convenience method returns the list of the user's theses for which the user can submit metadata. The current
+  # logic is to return only theses for which two conditions are true:
+  # 1. The metadata_complete flag is set to false
+  # 2. The issues_flag false is set to false
   def editable_theses
-    theses.where(metadata_complete: false)
+    theses.where(metadata_complete: false).where(issues_found: false)
   end
 
   # Definitely for sure wrong for some people. But staff want to be able to

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -351,6 +351,55 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 3, u.editable_theses.count
   end
 
+  test 'editable_theses returns a thesis with neither metadata nor issues flags set' do
+    u = users(:yo)
+    t = theses(:one)
+    assert_equal false, t.metadata_complete
+    assert_equal false, t.issues_found
+    assert u.editable_theses.include?(t)
+  end
+
+  test 'setting thesis.metadata_complete to true removes it from editable_theses' do
+    u = users(:yo)
+    t = theses(:one)
+    assert u.editable_theses.include?(t)
+    baseline = u.editable_theses.count
+    assert_equal false, t.metadata_complete
+    t.metadata_complete = true
+    t.save
+    u.reload
+    assert_equal baseline - 1, u.editable_theses.count
+    assert_not u.editable_theses.include?(t)
+  end
+
+  test 'setting thesis.issues_found to true removes it from editable_theses' do
+    u = users(:yo)
+    t = theses(:one)
+    assert u.editable_theses.include?(t)
+    baseline = u.editable_theses.count
+    assert_equal false, t.issues_found
+    t.issues_found = true
+    t.save
+    u.reload
+    assert_equal baseline - 1, u.editable_theses.count
+    assert_not u.editable_theses.include?(t)
+  end
+
+  test 'editable_theses returns no thesis with both metadata and issues flags set' do
+    u = users(:yo)
+    t = theses(:one)
+    assert u.editable_theses.include?(t)
+    baseline = u.editable_theses.count
+    assert_equal false, t.issues_found
+    assert_equal false, t.metadata_complete
+    t.issues_found = true
+    t.metadata_complete = true
+    t.save
+    u.reload
+    assert_equal baseline - 1, u.editable_theses.count
+    assert_not u.editable_theses.include?(t)
+  end
+
   test 'users with no theses have no editable_theses' do
     u = users(:admin)
     assert_equal 0, u.editable_theses.count


### PR DESCRIPTION
This extends the (existing) `editable_theses` helper method on the user model, adding a second condition - that theses are only editable if _both_ the `metadata_confirmed` and `issues_found` flags are both set to `FALSE` (which is the default condition.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-305

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO*
(An earlier version of this PR had added Timecop, but that has now been removed)
