### PR TITLE
Adds list of theses to admin copyright page

### DIFF
--- a/app/dashboards/copyright_dashboard.rb
+++ b/app/dashboards/copyright_dashboard.rb
@@ -39,6 +39,7 @@ class CopyrightDashboard < Administrate::BaseDashboard
     display_description
     statement_dspace
     url
+    theses
     id
     created_at
     updated_at


### PR DESCRIPTION
#### Why are these changes being introduced:

* The administrate page for License currently displays a panel of theses
  which have that license, but the admin page for Copyright does not.
  Stakeholders have requested that the Copyright page be made to match
  the License page.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/etd-411

#### How does this address that need:

* This adds "theses" to the list of information displayed on the admin
  Copyright page

#### Document any side effects to this change:

* None

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
