### PR TITLE
Adds reporting cards for theses with multiple subrecords

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,11 +49,12 @@ class Report
   end
 
   def card_overall(collection, term)
+    searchterm = term if term != 'all'
     {
       'value' => collection.count,
       'verb' => 'thesis record',
       'link' => {
-        'url' => url_helpers.admin_theses_path(search: term),
+        'url' => url_helpers.admin_theses_path(search: searchterm),
         'text' => 'See all in admin dashboard'
       }
     }

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -5,7 +5,8 @@ class Report
     subset = collection.joins(:files_attachments)
     {
       'value' => subset.pluck(:id).uniq.count,
-      'label' => 'have files attached',
+      'verb' => 'has',
+      'label' => 'files attached',
       'note' => 'Only theses with a status of "Not ready for publication" and "Publication review" will be visible '\
                 'in the processing queue.',
       'link' => {
@@ -23,10 +24,34 @@ class Report
     }
   end
 
+  def card_multiple_authors(collection)
+    {
+      'value' => collection.joins(:authors).group('theses.id').having('COUNT(authors.id) > 1').length,
+      'verb' => 'has',
+      'label' => 'multiple authors'
+    }
+  end
+
+  def card_multiple_degrees(collection)
+    {
+      'value' => collection.joins(:degrees).group('theses.id').having('COUNT(degrees.id) > 1').length,
+      'verb' => 'has',
+      'label' => 'multiple degrees'
+    }
+  end
+
+  def card_multiple_departments(collection)
+    {
+      'value' => collection.joins(:departments).group('theses.id').having('COUNT(departments.id) > 1').length,
+      'verb' => 'has',
+      'label' => 'multiple departments'
+    }
+  end
+
   def card_overall(collection, term)
     {
       'value' => collection.count,
-      'label' => 'thesis records',
+      'verb' => 'thesis record',
       'link' => {
         'url' => url_helpers.admin_theses_path(search: term),
         'text' => 'See all in admin dashboard'
@@ -39,6 +64,9 @@ class Report
     result['overall'] = card_overall collection, term
     result['files'] = card_files collection, term
     result['issues'] = card_issues collection
+    result['multiple-authors'] = card_multiple_authors collection
+    result['multiple-degrees'] = card_multiple_degrees collection
+    result['multiple-departments'] = card_multiple_departments collection
     result
   end
 

--- a/app/views/report/_card.html.erb
+++ b/app/views/report/_card.html.erb
@@ -1,5 +1,11 @@
 <p class="box-content card-<%= card[0] %> inline-action">
-  <span class="message hero-text"><%= card[1]["value"] %> <%= card[1]["label"] %></span>
+  <span class="<% if card[1]["link"] %>message <% end %>hero-text">
+    <% if card[1]["verb"] %>
+      <%= pluralize(card[1]["value"].to_i, card[1]["verb"]) %> <%= card[1]["label"] %>
+    <% else %>
+      <%= card[1]["value"] %> <%= card[1]["label"] %>
+    <% end %>
+  </span>
   <% if card[1]["link"] %>
     <span class="actions"><%= link_to( card[1]["link"]["text"], card[1]["link"]["url"] ) %></span>
   <% end %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.irregular "has", "have"
+end

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -52,7 +52,10 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     get report_index_path
     assert_select '.card-overall .message', text: '20 thesis records', count: 1
     assert_select '.card-files .message', text: '0 have files attached', count: 1
-    assert_select '.card-issues .message', text: '0 flagged with issues', count: 1
+    assert_select '.card-issues span', text: '0 flagged with issues', count: 1
+    assert_select '.card-multiple-authors span', text: '2 have multiple authors', count: 1
+    assert_select '.card-multiple-degrees span', text: '1 has multiple degrees', count: 1
+    assert_select '.card-multiple-departments span', text: '1 has multiple departments', count: 1
     assert_response :success
   end
 

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class ReportTest < ActiveSupport::TestCase
+  test 'overall card uses search term if present' do
+    r = Report.new
+    result = r.card_overall Thesis.all, 'all'
+    assert_equal result['link']['url'], '/admin/theses'
+    result = r.card_overall Thesis.all, Thesis.first.grad_date
+    assert_match Thesis.first.grad_date.to_s, result['link']['url']
+  end
+end


### PR DESCRIPTION
This adds three new cards to the thesis dashboard, counting how many theses have multiple affiliated subrecords:

* Theses with multiple authors
* Theses with multiple degrees
* Theses with multiple departments

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-414

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
