### PR TITLE
ETD-394 Upload DSS metadata JSON files to S3

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -43,6 +43,7 @@ class Thesis < ApplicationRecord
   has_many :users, through: :authors
 
   has_many_attached :files
+  has_one_attached :dspace_metadata
 
   accepts_nested_attributes_for :users
   accepts_nested_attributes_for :advisors, allow_destroy: true

--- a/test/fixtures/degrees.yml
+++ b/test/fixtures/degrees.yml
@@ -19,10 +19,10 @@ one:
   code_dw: MFA123
   abbreviation: MFA
   name_dspace: Master of Fine Arts
-  degree_type_id: 
+  degree_type: bachelor
 
 two:
   name_dw: Juris Doctor
   code_dw: JD123
   abbreviation: JD
-  name_dspace: Master of Fine Arts
+  name_dspace: Master of Fine Arts 

--- a/test/models/dspace_metadata_test.rb
+++ b/test/models/dspace_metadata_test.rb
@@ -1,11 +1,8 @@
 require 'test_helper'
 
 class DspaceMetadataTest < ActiveSupport::TestCase
-  # Adding some properties that are not included in our fixtures
+  # Attaching thesis file so tests will pass
   def dss_friendly_thesis(thesis)
-    degree = thesis.degrees.first
-    degree.degree_type_id = degree_types(:bachelor).id
-    degree.save
     file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
     thesis.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
     thesis.files.first.description = 'My thesis'


### PR DESCRIPTION
#### Why these changes are being introduced:

This is additional work toward ETD-394, which involves creating
a DSS-compliant JSON package and submitting a message to the SQS
queue. This particular commit associates metadata JSON objects
with Thesis records, and puts the metadata files in place in S3.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-394

#### How this addresses that need:

This uses Active Storage to attach metadata JSON (i.e., DspaceMetadata
objects) to their Thesis records and upload them to S3. The next
step is to build the SQS message and the job that puts it all together
and submits it to the SQS queue.

#### Side effects of this change:

We're using StringIO to simulate IO on the serialized JSON string, so
Active Storage will attach it as a file. This doesn't affect the
outcome, but it's worth noting as a fairly unusual approach.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
