### PR TITLE
ETD-394 Construct DSS SQS message

### DIFF
--- a/app/models/dspace_metadata.rb
+++ b/app/models/dspace_metadata.rb
@@ -1,3 +1,7 @@
+# Generates Dublin Core metadata require to publish a Thesis object to DSpace@MIT via the DSpace Submission System
+# DSS. This class assumes that the input Thesis is ready for publication and has all the requisite metadata and file
+# attachments. Validation of those requirements will occur in the Thesis model.
+
 class DspaceMetadata
   def initialize(thesis)
     @dc = {}

--- a/app/models/sqs_message.rb
+++ b/app/models/sqs_message.rb
@@ -1,0 +1,59 @@
+# Generates an SQS message containing the data needed for the DSpace Submission Service (DSS) to publish a Thesis object
+# to DSpace@MIT. This class assumes that the input Thesis is ready for publication and has an attached DspaceMetadata
+# object.
+
+class SqsMessage
+  def initialize(thesis)
+    @thesis = thesis
+    @package_id = "etd_#{@thesis.id}"
+    @metadata_uri = thesis.dspace_metadata.blob.url
+  end
+
+  def message_attributes
+    attributes = {}
+    attributes['PackageID'] = { 'DataType' => 'String', 'StringValue' => @package_id }
+    attributes['SubmissionSource'] = { 'DataType' => 'String', 'StringValue' => 'ETD' }
+    attributes['OutputQueue'] = { 'DataType' => 'String', 'StringValue' => ENV['OUTPUT_QUEUE_NAME'].to_s }
+    attributes
+  end
+
+  def message_body
+    body = {}
+    body['SubmissionSystem'] = 'DSpace@MIT'
+    body['CollectionHandle'] = collection_handle
+    body['MetadataLocation'] = @metadata_uri
+    body['Files'] = map_files
+
+    # SQS requires the MessageBody to be a string
+    body.to_json
+  end
+
+  def map_files
+    @thesis.files.map do |f|
+      {
+        'BitstreamName' => f.blob.filename.to_s,
+        'FileLocation' => f.blob.url,
+        'BitstreamDescription' => bitstream_description(f)
+      }
+    end
+  end
+
+  # There is a handle for all MIT theses, but there are also subcollections for doctoral, graduate, and undergraduate
+  # theses. Here we're trying to get the most specific handle possible.
+  def collection_handle
+    if @thesis.degrees.any? { |d| d.degree_type.name == 'Doctoral' }
+      '1721.1/131022'
+    elsif @thesis.degrees.any? { |d| d.degree_type.name == 'Master' }
+      '1721.1/131023'
+    else
+      '1721.1/131024'
+    end
+  end
+
+  def bitstream_description(file)
+    file_purposes = { 'thesis_pdf' => 'Thesis PDF', 'thesis_source' => 'Thesis source', 'thesis_supplementary_file' =>
+                      'Supplementary file', 'proquest_form' => 'Proquest form', 'signature_page' => 'Signature page' }
+    translated_purpose = file_purposes[file.purpose]
+    "#{translated_purpose} #{file.description}".strip
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
   ENV['SP_PRIVATE_KEY'] = ''
   ENV['SP_CERTIFICATE'] = ''
   ENV['THESIS_ADMIN_EMAIL'] = 'test@example.com'
+  ENV['OUTPUT_QUEUE_NAME'] = 'test_queue'
 
   config.cache_classes = true
 

--- a/test/fixtures/degrees.yml
+++ b/test/fixtures/degrees.yml
@@ -26,3 +26,11 @@ two:
   code_dw: JD123
   abbreviation: JD
   name_dspace: Master of Fine Arts 
+  degree_type: doctoral
+
+three:
+  name_dw: Master of Puppets
+  code_dw: MP123
+  abbreviation: MP
+  name_dspace: MP
+  degree_type: master

--- a/test/models/sqs_message_test.rb
+++ b/test/models/sqs_message_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+
+class SqsMessageTest < ActiveSupport::TestCase
+  def setup
+    ActiveStorage::Current.host = 'https://example.com'
+    @thesis = theses(:one)
+    dss_friendly_thesis(@thesis)
+  end
+
+  def teardown
+    @thesis.files.purge
+    @thesis.dspace_metadata.purge
+  end
+
+  # Attaching thesis file and dspace_metadata so tests will pass.
+  def dss_friendly_thesis(thesis)
+    file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    thesis.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
+    thesis.files.first.description = 'My thesis'
+    thesis.files.first.purpose = 'thesis_pdf'
+    metadata_json = DspaceMetadata.new(thesis).serialize_dss_metadata
+    thesis.dspace_metadata.attach(io: StringIO.new(metadata_json),
+                                  filename: 'some_file.json')
+    thesis.save
+  end
+
+  test 'files are mapped as expected' do
+    files = SqsMessage.new(@thesis).map_files
+    assert_equal Array, files.class
+    assert_equal 1, files.length
+    assert_equal %w[BitstreamName FileLocation BitstreamDescription], files.first.keys
+    assert_equal 'a_pdf.pdf', files.first['BitstreamName']
+
+    # Not checking the full URI here because ActiveStorage::SetCurrent doesn't generate URIs consistently.
+    assert files.first['FileLocation'].ends_with?('a_pdf.pdf')
+
+    # More thorough testing of bitstream description below.
+    assert_equal 'Thesis PDF My thesis', files.first['BitstreamDescription']
+  end
+
+  test 'returns correct bitstream description' do
+    # File without description.
+    @thesis.files.first.description = nil
+    files = SqsMessage.new(@thesis).map_files
+    assert_equal 'Thesis PDF', files.first['BitstreamDescription']
+
+    # Different file purposes.
+    f = @thesis.files.first
+    f.purpose = 'thesis_source'
+    assert_equal 'Thesis source', SqsMessage.new(@thesis).bitstream_description(f)
+
+    @thesis.files.first.purpose = 'thesis_supplementary_file'
+    assert_equal 'Supplementary file', SqsMessage.new(@thesis).bitstream_description(f)
+
+    @thesis.files.first.purpose = 'proquest_form'
+    assert_equal 'Proquest form', SqsMessage.new(@thesis).bitstream_description(f)
+
+    @thesis.files.first.purpose = 'signature_page'
+    assert_equal 'Signature page', SqsMessage.new(@thesis).bitstream_description(f)
+  end
+
+  test 'returns correct collection handle' do
+    assert_equal 'Bachelor', @thesis.degrees.first.degree_type.name
+    assert_equal '1721.1/131024', SqsMessage.new(@thesis).collection_handle
+
+    masters_degree = degrees(:three)
+    @thesis.degrees << masters_degree
+    assert_equal 'Master', @thesis.degrees.second.degree_type.name
+    assert_equal '1721.1/131023', SqsMessage.new(@thesis).collection_handle
+
+    doctoral_degree = degrees(:two)
+    @thesis.degrees << doctoral_degree
+    assert_equal 'Doctoral', @thesis.degrees.third.degree_type.name
+    assert_equal '1721.1/131022', SqsMessage.new(@thesis).collection_handle
+  end
+
+  test 'message_attributes is valid' do
+    attributes = SqsMessage.new(@thesis).message_attributes
+    package_id = { 'DataType' => 'String', 'StringValue' => "etd_#{@thesis.id}" }
+    output_queue = { 'DataType' => 'String', 'StringValue' => 'test_queue' }
+    submission_source = { 'DataType' => 'String', 'StringValue' => 'ETD' }
+    assert_equal %w[PackageID SubmissionSource OutputQueue], attributes.keys
+    assert_equal package_id, attributes['PackageID']
+    assert_equal submission_source, attributes['SubmissionSource']
+    assert_equal output_queue, attributes['OutputQueue']
+  end
+
+  test 'message_body is valid' do
+    body = SqsMessage.new(@thesis).message_body
+
+    # Should be serialized.
+    assert_equal String, body.class
+
+    body_json = JSON.parse(body)
+
+    # Checking for the presence of the Files key, but not checking the value here as we have a separate test for that.
+    assert_equal %w[SubmissionSystem CollectionHandle MetadataLocation Files], body_json.keys
+    assert_equal 'DSpace@MIT', body_json['SubmissionSystem']
+    assert_equal '1721.1/131024', body_json['CollectionHandle']
+
+    # Not checking the full URI here because ActiveStorage::SetCurrent doesn't generate URIs consistently.
+    assert body_json['MetadataLocation'].ends_with?('some_file.json')
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

This is the third part of ETD-394, supporting publication to
DSpace@MIT via the DSpace Submission Service.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-394

#### How this addresses that need:

This constructs the SQS message attributes and body, as per the
DSS spec. Submitting the message to the queue will come in a
subsequent PR.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
