### PR TITLE
Adds report for thesis files with no defined purpose

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -6,6 +6,14 @@ class ReportController < ApplicationController
 
   include ThesisHelper
 
+  def files
+    report = Report.new
+    theses = Thesis.all
+    @terms = report.extract_terms theses
+    subset = filter_theses_by_term theses
+    @list = report.list_unattached_files subset
+  end
+
   def index
     report = Report.new
     @terms = Thesis.pluck(:grad_date).uniq.sort

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -53,6 +53,7 @@ class Ability
 
     can :manage, :submitter
 
+    can :files, Report
     can :index, Report
     can :term, Report
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -252,6 +252,16 @@ class Report
     collection.pluck(:grad_date).uniq.sort
   end
 
+  def list_unattached_files(collection)
+    result = []
+    collection.joins(:files_attachments).order(:grad_date).uniq.each do |record|
+      record.files.where(purpose: nil).each do |file|
+        result.push(file)
+      end
+    end
+    result
+  end
+
   def table_copyright(collection)
     result = {}
     collection.group(:copyright).count.each do |record|

--- a/app/views/report/_files_empty.html.erb
+++ b/app/views/report/_files_empty.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan="4">There are no files without an assigned purpose within the selected term.</td>
+</tr>

--- a/app/views/report/_files_without_purpose.html.erb
+++ b/app/views/report/_files_without_purpose.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= link_to(files_without_purpose.blob[:filename],thesis_process_path(files_without_purpose[:record_id])) %></td>
+  <td>
+    <% files_without_purpose.record.authors.each do |author| %>
+      <%= author.user.display_name %><br>
+    <% end %>
+  </td>
+  <td>
+    <% files_without_purpose.record.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td><%= files_without_purpose[:description] %></td>
+</tr>

--- a/app/views/report/files.html.erb
+++ b/app/views/report/files.html.erb
@@ -1,0 +1,30 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Files without a defined purpose</h3>
+
+    <%= render 'shared/defined_terms_filter' %>
+
+    <table class="table" summary="This table presents a list of files which are attached to theses but which have no purpose defined.
+        Clicking the link in the left column will take you to the processing form for that thesis, where a purpose can
+        be declared." title="Files without a defined purpose">
+      <thead>
+        <tr>
+          <th scope="col">File</th>
+          <th scope="col">Authors</th>
+          <th scope="col">Departments</th>
+          <th scope="col">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'report/files_without_purpose', collection: @list) || render('files_empty') %>
+      </tbody>
+    </table>
+
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -8,6 +8,9 @@
       <% if can?(:select, Thesis) %>
         <li><%= link_to("Theses with co-authors", thesis_deduplicate_path) %></li>
       <% end %>
+      <% if can?(:files, Report) %>
+        <li><%= link_to("Files without purpose", report_files_path) %></li>
+      <% end %>
     </ul>
   </nav>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   end
 
   get 'report', to: 'report#index', as: 'report_index'
+  get 'report/files', to: 'report#files', as: 'report_files'
   get 'report/term', to: 'report#term', as: 'report_term'
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
   get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -1,6 +1,23 @@
 require 'test_helper'
 
 class ReportControllerTest < ActionDispatch::IntegrationTest
+  def attach_files(tr, th)
+    # Ideally our fixtures would have already-attached files, but they do not
+    # yet. So we attach two files to a transfer and thesis record, to prepare
+    # for tests with an accurate set of file attachments.
+    f1 = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    f2 = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    tr.files.attach(io: File.open(f1), filename: 'a_pdf.pdf')
+    tr.files.attach(io: File.open(f2), filename: 'a_pdf.pdf')
+    tr.save
+    tr.reload
+    th.files.attach(tr.files.first.blob)
+    th.files.attach(tr.files.second.blob)
+    th.save
+    th.reload
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~~ Report dashboard ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'summary report exists' do
     sign_in users(:admin)
     get report_index_path
@@ -119,5 +136,92 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     get report_term_path, params: { graduation: '2018-09-01' }
     assert_select '.card-overall .message', text: '2 thesis records', count: 1
     assert_response :success
+  end
+
+  # ~~~~~~~~~~~~~~~~~~~~ Files without purpose report ~~~~~~~~~~~~~~~~~~~~~~~~
+  test 'files report exists' do
+    sign_in users(:admin)
+    get report_files_path
+    assert_response :success
+  end
+
+  test 'anonymous users are prompted to log in by files report' do
+    # Note that nobody is signed in.
+    get report_files_path
+    assert_response :redirect
+  end
+
+  test 'basic users cannot see files report' do
+    sign_in users(:basic)
+    get report_files_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'submitters cannot see files report' do
+    sign_in users(:transfer_submitter)
+    get report_files_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'processors can see files report' do
+    sign_in users(:processor)
+    get report_files_path
+    assert_response :success
+  end
+
+  test 'thesis_admins can see files report' do
+    sign_in users(:thesis_admin)
+    get report_files_path
+    assert_response :success
+  end
+
+  test 'admins can see files report' do
+    sign_in users(:admin)
+    get report_files_path
+    assert_response :success
+  end
+
+  test 'default files report is empty' do
+    sign_in users(:processor)
+    get report_files_path
+    assert_select 'table tbody td', text: 'There are no files without an assigned purpose within the selected term.', count: 1
+  end
+
+  test 'files have no default purpose, and appear on the files report' do
+    sign_in users(:processor)
+    xfer = transfers(:valid)
+    thesis = theses(:one)
+    attach_files(xfer, thesis)
+    get report_files_path
+    assert_select 'table tbody td', text: 'a_pdf.pdf', count: 2
+  end
+
+  test 'files report can be filtered by term' do
+    sign_in users(:processor)
+    xfer = transfers(:valid)
+    thesis = theses(:one)
+    attach_files(xfer, thesis)
+    get report_files_path
+    assert_select 'table tbody td', text: 'a_pdf.pdf', count: 2
+    get report_files_path, params: { graduation: '2018-09-01' }
+    assert_select 'table tbody td', text: 'There are no files without an assigned purpose within the selected term.', count: 1
+  end
+
+  test 'files disappear from files report when a purpose is set' do
+    sign_in users(:processor)
+    xfer = transfers(:valid)
+    thesis = theses(:one)
+    attach_files(xfer, thesis)
+    get report_files_path
+    assert_select 'table tbody td', text: 'a_pdf.pdf', count: 2
+    file = thesis.files.first
+    file.purpose = 0
+    file.save
+    get report_files_path
+    assert_select 'table tbody td', text: 'a_pdf.pdf', count: 1
   end
 end


### PR DESCRIPTION
This adds a new report page for files with no defined purpose. The table includes links to the processing form for that thesis, so staff can assign a purpose.

More details in the commit message...

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-418

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
