### PR TITLE
Adds "Publish to DSpace@MIT" button to processing queue

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -44,6 +44,23 @@ class ThesisController < ApplicationController
     @thesis.association(:advisors).add_to_target(Advisor.new) if @thesis.advisors.count.zero?
   end
 
+  def publish_to_dspace
+    # This will be where the publication job gets invoked.
+    # subset = filter_theses_by_term Thesis.in_review
+    # result = subset.map(&:some_async_method)
+    # if result.map { |val| val == true }.reduce(:&)
+    #   flash[:success] = 'This would have published theses to DSpace@MIT.'
+    # else
+    #   flash[:warning] = 'Not all selected theses are ready for publication.<br>'.html_safe + ready.to_s
+    # end
+    if params[:graduation] == 'all' || params[:graduation].nil?
+      flash[:warning] = 'Please select a term before attempting to publish theses to DSpace@MIT.'
+    else
+      flash[:success] = 'If publishing to DSpace@MIT worked, this would be a meaningful update message.'
+    end
+    redirect_to thesis_select_path
+  end
+
   def select
     # Get array of defined terms where unpublished theses have files attached
     @terms = defined_terms Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', 'Published')

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,6 +65,7 @@ class Ability
     can :mark_withdrawn, Thesis
     can :process_theses, Thesis
     can :process_theses_update, Thesis
+    can :publish_to_dspace, Thesis
     can :select, Thesis
 
     can :read, Transfer

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -96,6 +96,7 @@ class Thesis < ApplicationRecord
   #  includes(:user).order('users.surname, users.given_name')
   # }
   scope :date_asc, -> { order('grad_date') }
+  scope :in_review, -> { where('publication_status == ?', 'Publication review') }
   scope :without_files, -> { where.missing(:files_attachments) }
   scope :valid_months_only, lambda {
     select { |t| VALID_MONTHS.include? t.grad_date.strftime('%B') }

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -33,6 +33,25 @@
   </tbody>
 </table>
 
+<div id="publish-to-dspace" class="gridband" style="display: none;" aria-live="polite" role="region">
+  <div class="inline-action well">
+    <% if params[:graduation] == 'all' || params[:graduation].nil? %>
+      <div class="message">
+        <h4 class="title">Select a term to publish to DSpace@MIT</h4>
+        <p>Batches of theses can be sent to DSpace@MIT only when a term is specified.</p>
+      </div>
+    <% else %>
+      <div class="message">
+        <h4 class="title">Ready to publish to DSpace@MIT?</h4>
+        <p>When this set of thesis records looks correct, click the button at right to publish them.</p>
+      </div>
+      <div class="actions">
+        <%= link_to "Publish theses to DSpace@MIT", thesis_publish_to_dspace_path(:graduation => params[:graduation]), class: 'button button-primary' %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
 <script type="text/javascript">
 $(document).ready( function () {
   if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
@@ -70,6 +89,12 @@ $(document).ready( function () {
 
       _status = $(this).data("filter");
       table.draw();
+
+      if( 'Publication review' === _status ) {
+        $("#publish-to-dspace").attr('style', '');
+      } else {
+        $("#publish-to-dspace").attr('style', 'display: none;');
+      }
     });
   };
 });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'
   get 'thesis/:id/process', to: 'thesis#process_theses', as: 'thesis_process'
   patch 'thesis/:id/process', to: 'thesis#process_theses_update', as: 'thesis_process_update'
+  get 'thesis/publish', to: 'thesis#publish_to_dspace', as: 'thesis_publish_to_dspace'
   get 'thesis/select', to: 'thesis#select', as: 'thesis_select'
   get 'thesis/start', to: 'thesis#start', as: 'thesis_start'
   resources :registrar, only: [:new, :create, :show]

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -552,6 +552,12 @@ class ThesisTest < ActiveSupport::TestCase
     assert_equal false, thesis.authors_graduated?
   end
 
+  test 'in_review scope returns theses in that publication status' do
+    assert_equal 'Publication review', Thesis.in_review.first.publication_status
+    assert_includes Thesis.in_review, theses(:publication_review)
+    assert_not_includes Thesis.in_review, theses(:issues_found)
+  end
+
   test 'without_files scope returns list of records with no attached files' do
     thesis = theses(:one)
     all_theses = Thesis.count


### PR DESCRIPTION
This augments the Thesis Processing Queue, adding a button that will publish records in the `Publication Review` status to our repository via the coming DSpace Submission Service.

As yet, this button does not do anything - but it will. Clicking the button with this PR will generate a flash message that is a placeholder.

I've populated a sample record in the review app, in case you want to see how the button appears / disappears.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-310

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
