### PR TITLE
ETD-468 Publish Engineer degrees to graduate collection in DSpace

### DIFF
--- a/app/models/sqs_message.rb
+++ b/app/models/sqs_message.rb
@@ -43,7 +43,7 @@ class SqsMessage
   def collection_handle
     if @thesis.degrees.any? { |d| d.degree_type.name == 'Doctoral' }
       ENV.fetch('DSPACE_DOCTORAL_HANDLE')
-    elsif @thesis.degrees.any? { |d| d.degree_type.name == 'Master' }
+    elsif @thesis.degrees.any? { |d| d.degree_type.name == 'Master' || d.degree_type.name == 'Engineer' }
       ENV.fetch('DSPACE_GRADUATE_HANDLE')
     else
       ENV.fetch('DSPACE_UNDERGRADUATE_HANDLE')

--- a/test/fixtures/degrees.yml
+++ b/test/fixtures/degrees.yml
@@ -34,3 +34,10 @@ three:
   abbreviation: MP
   name_dspace: MP
   degree_type: master
+
+four:
+  name_dw: Theoretical Engineer
+  code_dw: TE123
+  abbreviation: TE
+  name_dspace: TE
+  degree_type: engineer  

--- a/test/models/sqs_message_test.rb
+++ b/test/models/sqs_message_test.rb
@@ -62,7 +62,13 @@ class SqsMessageTest < ActiveSupport::TestCase
     assert_equal 'Bachelor', @thesis.degrees.first.degree_type.name
     assert_equal '1721.1/777777', SqsMessage.new(@thesis).collection_handle
 
+    engineer_degree = degrees(:four)
+    @thesis.degrees << engineer_degree
+    assert_equal 'Engineer', @thesis.degrees.second.degree_type.name
+    assert_equal '1721.1/888888', SqsMessage.new(@thesis).collection_handle
+
     masters_degree = degrees(:three)
+    @thesis.degrees.delete(engineer_degree)
     @thesis.degrees << masters_degree
     assert_equal 'Master', @thesis.degrees.second.degree_type.name
     assert_equal '1721.1/888888', SqsMessage.new(@thesis).collection_handle


### PR DESCRIPTION
#### Why these changes are being introduced:

In the SqsMessage model, Engineer degrees are incorrectly assigned
the handle for the DSpace undergrad theses collection.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-468

#### How this addresses that need:

This updates the collection handle for Engineer degrees to the
graduate theses collection.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
