### PR TITLE
Enable state saving on Thesis and Transfer processing queues

### DIFF
--- a/app/views/thesis/deduplicate.html.erb
+++ b/app/views/thesis/deduplicate.html.erb
@@ -1,10 +1,10 @@
 <%= content_for(:title, "Duplicate Theses Report | MIT Libraries") %>
 
 <% content_for :additional_js do %>
-  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
 <% end %>
 
-<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
 
 <div class="layout-3q1q layout-band">
   <div class="col3q">
@@ -37,7 +37,7 @@
 $(document).ready( function () {
   if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
     var table = $('#thesisQueue').DataTable({
-      "order": [[ 1, "asc" ]]
+      stateSave: true
     });
   };
 });

--- a/app/views/thesis/select.html.erb
+++ b/app/views/thesis/select.html.erb
@@ -1,10 +1,10 @@
 <%= content_for(:title, "Thesis Processing | MIT Libraries") %>
 
 <% content_for :additional_js do %>
-  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
 <% end %>
 
-<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
 
 <h3 class="title title-page">Thesis Processing Queue</h3>
 
@@ -53,17 +53,43 @@
 </div>
 
 <script type="text/javascript">
+function applyFilter(table, _status) {
+  // Update UI
+  $("#status-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
+  $('#status-list button[data-filter="' + _status + '"]').removeClass("button-secondary").addClass("button-primary");
+
+  // Filter the data table
+  table.draw();
+
+  // Reveal the "Publish to DSpace@MIT panel if warranted"
+  if( 'Publication review' === _status ) {
+    $("#publish-to-dspace").attr('style', '');
+  } else {
+    $("#publish-to-dspace").attr('style', 'display: none;');
+  }
+}
+
 $(document).ready( function () {
   if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
+    // _status is the variable which the custom filter behavior looks for.
+    var _status = "*";
+
     // Initialize DataTable, sorting by default on degree column (columns are zero-based)
     var table = $('#thesisQueue').DataTable({
-      "order": [[ 1, "asc" ]]
+      stateSave: true,
+      stateSaveParams: function( settings, data ) {
+        data.filter = _status;
+      },
+      stateLoadParams: function( settings, data ) {
+        if ( data.filter ) {
+          _status = data.filter;
+        }
+      }
     });
-
-    var _status = "*";
 
     // Add filter for "Status" column to standard table behavior
     // From: https://datatables.net/blog/2014-08-26#Complete-code
+    // Note that this new behavior is invoked on calling table.draw()
     $.fn.dataTable.ext.search.push(
       function( settings, data, dataIndex ) {
         return ( data[5] === _status || _status === "*" )
@@ -82,19 +108,13 @@ $(document).ready( function () {
       `);
     });
 
+    // Apply initial filter
+    applyFilter(table, _status);
+
     // Change highlighting and perform filtering when buttons are clicked
     $("#status-list button").click(function() {
-      $("#status-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
-      $(this).removeClass("button-secondary").addClass("button-primary");
-
       _status = $(this).data("filter");
-      table.draw();
-
-      if( 'Publication review' === _status ) {
-        $("#publish-to-dspace").attr('style', '');
-      } else {
-        $("#publish-to-dspace").attr('style', 'display: none;');
-      }
+      applyFilter(table, _status);
     });
   };
 });

--- a/app/views/transfer/select.html.erb
+++ b/app/views/transfer/select.html.erb
@@ -1,10 +1,10 @@
 <%= content_for(:title, "Transfer Processing | MIT Libraries") %>
 
 <% content_for :additional_js do %>
-  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
 <% end %>
 
-<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
 
 <h3 class="title title-page">Transfer Processing Queue</h3>
 
@@ -29,17 +29,36 @@
 </table>
 
 <script type="text/javascript">
+function applyFilter(table, _degreeDate) {
+  // Update UI
+  $("#term-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
+  $('#term-list button[data-filter="' + _degreeDate + '"]').removeClass("button-secondary").addClass("button-primary");
+
+  // Filter the data table
+  table.draw();
+}
+
 $(document).ready( function () {
   if( document.getElementById('transferQueue').getElementsByClassName('empty').length === 0 ) {
+    // _degreeDate is the variable which the custom filter behavior looks for.
+    var _degreeDate = '*';
+
     // Initialize DataTable, sorting by default on the degree column (columns are zero-based)
     var table = $('#transferQueue').DataTable({
-      "order": [[ 1, "asc" ]]
+      stateSave: true,
+      stateSaveParams: function( settings, data ) {
+        data.filter = _degreeDate;
+      },
+      stateLoadParams: function( settings, data ) {
+        if ( data.filter ) {
+          _degreeDate = data.filter;
+        }
+      }
     });
-
-    var _degreeDate = "*";
 
     // Add filter for "Degree date" column to standard table behavior
     // From: https://datatables.net/blog/2014-08-26#Complete-code
+    // Note that this new behavior is invoked on calling table.draw()
     $.fn.dataTable.ext.search.push(
       function( settings, data, dataIndex ) {
         return ( data[1] === _degreeDate || _degreeDate === "*" )
@@ -58,13 +77,16 @@ $(document).ready( function () {
       `);
     });
 
-    // Change highlighting and perform filtering when buttons are clicked
-    $("#term-list button").click(function() {
-      $("#term-list").find(".button-primary").removeClass("button-primary").addClass("button-secondary");
-      $(this).removeClass("button-secondary").addClass("button-primary");
+    // Apply initial filter
+    applyFilter(table, _degreeDate);
 
+    // Assign event listeners to filter buttons which call applyFilter
+    // Yes, we are taking "this" and looking up its data attribute, only to look the button up again by its data
+    // attribute again inside applyFilter. It is less efficient, but we do this to match the behavior on page load, when
+    // the table state is read from storage and we only have a string, not a "this", and need to find the button.
+    $("#term-list button").click(function() {
       _degreeDate = $(this).data("filter");
-      table.draw();
+      applyFilter(table, _degreeDate);
     });
   }
 });

--- a/app/views/transfer/show.html.erb
+++ b/app/views/transfer/show.html.erb
@@ -1,11 +1,11 @@
 <%= content_for(:title, "Transfer Processing | MIT Libraries") %>
 
 <% content_for :additional_js do %>
-  <script src="https://cdn.datatables.net/1.10.24/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"></script>
 <% end %>
 
-<link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.min.css" rel="stylesheet">
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
 
 <p><%= link_to "Back to Transfer queue", transfer_select_path %></p>
 
@@ -107,7 +107,9 @@
 <script>
   $(document).ready( function() {
     if( document.getElementById('thesisTargets').getElementsByClassName('empty').length === 0) {
-      var table = $('#thesisTargets').DataTable({});
+      var table = $('#thesisTargets').DataTable({
+        stateSave: true
+      });
     }
     $(".checkbox-trigger-filter").change(function() {
       if(this.checked) {


### PR DESCRIPTION
This enables the `stateSave` parameter on all four implementations of the DataTable library across the app:

* Thesis processing queue
* Transfer processing queue
* Transfer processing form
* Deduplication report

It further integrates the custom filter buttons which have been added to the two processing queues.

Along the way, this PR also updates DataTables to the current release (1.11.3, from 1.10.24). I debated making the implementation itself more robust by looking for a Rails gem that might include it, or doing more with WebPacker, but elected against this for now.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-440

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
