### PR TITLE
ETD-481 Add report for thesis with ProQuest forms

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -26,6 +26,14 @@ class ReportController < ApplicationController
     @list = report.list_unattached_files subset
   end
 
+  def proquest_files
+    report = Report.new
+    theses = Thesis.all
+    @terms = report.extract_terms theses
+    subset = filter_theses_by_term theses
+    @list = report.list_proquest_files subset
+  end
+
   def index
     report = Report.new
     @terms = Thesis.pluck(:grad_date).uniq.sort

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -54,6 +54,7 @@ class Ability
     can :manage, :submitter
 
     can :files, Report
+    can :proquest_files, Report
     can :index, Report
     can :term, Report
     can :empty_theses, Report

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -289,6 +289,16 @@ class Report
     result
   end
 
+  def list_proquest_files(collection)
+    result = []
+    collection.joins(:files_attachments).order(:grad_date).uniq.each do |record|
+      record.files.where(purpose: 'proquest_form').each do |file|
+        result.push(file)
+      end
+    end
+    result
+  end
+
   def table_copyright(collection)
     result = {}
     collection.group(:copyright).count.each do |record|

--- a/app/views/report/_files_empty_proquest.html.erb
+++ b/app/views/report/_files_empty_proquest.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan="4">There are no ProQuest forms within the selected term.</td>
+</tr>

--- a/app/views/report/_files_proquest_form.html.erb
+++ b/app/views/report/_files_proquest_form.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= link_to(files_proquest_form.blob[:filename], files_proquest_form.blob) %></td>
+  <td>
+    <% files_proquest_form.record.authors.each do |author| %>
+      <%= author.user.display_name %><br>
+    <% end %>
+  </td>
+  <td>
+    <% files_proquest_form.record.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td><%= files_proquest_form[:description] %></td>
+</tr>

--- a/app/views/report/proquest_files.html.erb
+++ b/app/views/report/proquest_files.html.erb
@@ -1,0 +1,29 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">ProQuest forms</h3>
+
+    <%= render 'shared/defined_terms_filter' %>
+
+    <table class="table" summary="This table presents a list of files that are tagged as ProQuest forms.
+        Clicking the link in the left column will download the form." title="ProQuest forms">
+      <thead>
+        <tr>
+          <th scope="col">File</th>
+          <th scope="col">Authors</th>
+          <th scope="col">Departments</th>
+          <th scope="col">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'files_proquest_form', collection: @list) || render('files_empty_proquest') %>
+      </tbody>
+    </table>
+
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -14,6 +14,9 @@
       <% if can?(:files, Report) %>
         <li><%= link_to("Files without purpose", report_files_path) %></li>
       <% end %>
+      <% if can?(:proquest_files, Report) %>
+        <li><%= link_to("ProQuest forms", report_proquest_files_path) %></li>
+      <% end %>
     </ul>
   </nav>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   get 'report', to: 'report#index', as: 'report_index'
   get 'report/empty_theses', to: 'report#empty_theses', as: 'report_empty_theses'
   get 'report/files', to: 'report#files', as: 'report_files'
+  get 'report/proquest_files', to: 'report#proquest_files', as: 'report_proquest_files'
   get 'report/term', to: 'report#term', as: 'report_term'
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
   get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'


### PR DESCRIPTION
#### Why these changes are being introduced:

Thesis processors need to be able to download ProQuest forms.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-481

#### How this addresses that need:

This creates a report that lists the theses with ProQuest forms.
Each row includes a clickable link of the ProQuest form for processors
to download.

#### Side effects of this change:

Adds a new route and modifies the ability model to account for the
new controller action.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
