### PR TITLE
Adds count of student contributions to dashboard and term report

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -35,6 +35,9 @@ class ReportController < ApplicationController
   end
 
   def student_submitted_theses
+    term = params[:graduation] ? params[:graduation].to_s : 'all'
+    @this_term = 'all terms'
+    @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
     report = Report.new
     theses = Thesis.all
     @terms = report.extract_terms theses

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -68,6 +68,14 @@ class Report
     }
   end
 
+  def card_student_contributions(collection)
+    {
+      'value' => collection.map(&:student_contributed?).count(true),
+      'verb' => 'has',
+      'label' => 'had metadata contributed by students'
+    }
+  end
+
   def data_category_copyright_holder
     category = []
     rows = populate_category(Copyright.pluck(:holder))
@@ -211,6 +219,18 @@ class Report
     }
   end
 
+  def data_student_contributions
+    row_data = {}
+    terms = Thesis.all.pluck(:grad_date).uniq.sort
+    terms.each do |term|
+      row_data[term] = Thesis.where('grad_date = ?', term).map(&:student_contributed?).count(true)
+    end
+    {
+      label: 'Students contributing',
+      data: pad_terms(row_data)
+    }
+  end
+
   def data_thesis_records
     {
       label: 'Thesis records',
@@ -243,6 +263,7 @@ class Report
     output['summary'].push data_theses_with_files
     output['summary'].push data_files_attached_to_theses
     output['summary'].push data_issues
+    output['summary'].push data_student_contributions
     output['summary'].push data_multiple_authors
     output['summary'].push data_multiple_degrees
     output['summary'].push data_multiple_departments
@@ -399,6 +420,7 @@ class Report
     result['overall'] = card_overall collection, term
     result['files'] = card_files collection, term
     result['issues'] = card_issues collection
+    result['students-contributing'] = card_student_contributions collection
     result['multiple-authors'] = card_multiple_authors collection
     result['multiple-degrees'] = card_multiple_degrees collection
     result['multiple-departments'] = card_multiple_departments collection

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -122,6 +122,11 @@ class Thesis < ApplicationRecord
     authors.map(&:graduation_confirmed?).reduce(:&)
   end
 
+  # Returns an array of user IDs from whodunnit who have saved a version of the thesis.
+  def contributors
+    versions.pluck(:whodunnit).uniq.map(&:to_i)
+  end
+
   # Returns a true/false value if there are any affiliated degrees.
   def degrees?
     !degrees.count.zero?
@@ -236,6 +241,11 @@ class Thesis < ApplicationRecord
     end
 
     false
+  end
+
+  # This method returns true if any of its versions have been contributed by someone with a student status.
+  def student_contributed?
+    User.where(id: contributors).map(&:student?).any?
   end
 
   # This contains the logic for a thesis to have its status set to either

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -9,10 +9,7 @@
       <p>Click on a column heading to see more detailed information about the theses from that term.</p>
     </div>
 
-    <div class="alert alert-banner">
-      <p><i class="fa fa-info-circle fa-lg"></i> Note: Counts of students contributing may not be accurate prior to the
-      February 2022 degree period.</p>
-    </div>
+    <%= render 'shared/whodunnit_accuracy_statement' %>
 
     <% @data.each do |table| %>
       <table class="table table-simplified table-<%= table[0].gsub(" ", "-").downcase %>" style="margin-top: 4em;">

--- a/app/views/report/index.html.erb
+++ b/app/views/report/index.html.erb
@@ -9,6 +9,11 @@
       <p>Click on a column heading to see more detailed information about the theses from that term.</p>
     </div>
 
+    <div class="alert alert-banner">
+      <p><i class="fa fa-info-circle fa-lg"></i> Note: Counts of students contributing may not be accurate prior to the
+      February 2022 degree period.</p>
+    </div>
+
     <% @data.each do |table| %>
       <table class="table table-simplified table-<%= table[0].gsub(" ", "-").downcase %>" style="margin-top: 4em;">
         <caption class="hd-4"><%= table[0].gsub("-", " ").capitalize %></caption>

--- a/app/views/report/student_submitted_theses.html.erb
+++ b/app/views/report/student_submitted_theses.html.erb
@@ -2,12 +2,11 @@
 
 <div class="layout-3q1q layout-band">
   <div class="col3q">
-    <h3 class="title title-page">Theses submitted by students</h3>
+    <h3 class="title title-page">Theses submitted by students for <%= @this_term %></h3>
 
-    <div class="alert alert-banner">
-      <p><i class="fa fa-info-circle fa-lg"></i> Note: this report may not be accurate for theses submitted before the
-      February 2022 degree period.</p>
-    </div>
+    <% if @this_term == "all terms" || Date.parse(@this_term).year < 2022 %>
+      <%= render 'shared/whodunnit_accuracy_statement' %>
+    <% end %>
 
     <%= render 'shared/defined_terms_filter' %>
 

--- a/app/views/report/term.html.erb
+++ b/app/views/report/term.html.erb
@@ -9,10 +9,7 @@
     <%= render 'shared/defined_terms_filter' %>
 
     <% if @this_term == "all terms" || Date.parse(@this_term).year < 2022 %>
-      <div class="alert alert-banner">
-        <p><i class="fa fa-info-circle fa-lg"></i> Note: Counts of students contributing may not be accurate prior to the
-        February 2022 degree period.</p>
-      </div>
+      <%= render 'shared/whodunnit_accuracy_statement' %>
     <% end %>
 
     <%= render(partial: 'card', collection: @data) %>

--- a/app/views/report/term.html.erb
+++ b/app/views/report/term.html.erb
@@ -8,6 +8,13 @@
 
     <%= render 'shared/defined_terms_filter' %>
 
+    <% if @this_term == "all terms" || Date.parse(@this_term).year < 2022 %>
+      <div class="alert alert-banner">
+        <p><i class="fa fa-info-circle fa-lg"></i> Note: Counts of students contributing may not be accurate prior to the
+        February 2022 degree period.</p>
+      </div>
+    <% end %>
+
     <%= render(partial: 'card', collection: @data) %>
 
     <hr>

--- a/app/views/shared/_whodunnit_accuracy_statement.html.erb
+++ b/app/views/shared/_whodunnit_accuracy_statement.html.erb
@@ -1,0 +1,4 @@
+<div class="alert alert-banner">
+  <p><i class="fa fa-info-circle fa-lg"></i> Note: Counts of students contributing may not be accurate prior to the
+  February 2022 degree period.</p>
+</div>

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -227,6 +227,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     assert_select '.card-overall .message', text: '24 thesis records', count: 1
     assert_select '.card-files .message', text: '7 have files attached', count: 1
     assert_select '.card-issues span', text: '1 flagged with issues', count: 1
+    assert_select '.card-students-contributing span', text: '0 have had metadata contributed by students', count: 1
     assert_select '.card-multiple-authors span', text: '2 have multiple authors', count: 1
     assert_select '.card-multiple-degrees span', text: '1 has multiple degrees', count: 1
     assert_select '.card-multiple-departments span', text: '1 has multiple departments', count: 1

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -184,54 +184,6 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_no_match note_text, response.body
   end
 
-  test 'contributors returns array of contributors' do
-    yo = users(:yo)
-    admin = users(:admin)
-
-    sign_in yo
-    thesis = yo.theses.first
-    assert_equal [], thesis.contributors
-    assert_equal 0, thesis.versions.count
-
-    patch thesis_path(thesis),
-         params: { thesis: { title: 'A student-contributed update' } }
-    assert_equal [yo.id], thesis.contributors
-    assert_equal 1, thesis.versions.count
-    sign_out yo
-
-    sign_in admin
-    patch thesis_path(thesis),
-         params: { thesis: { title: 'An admin-contributed update' } }
-    assert_equal [yo.id, admin.id], thesis.contributors
-    assert_equal 2, thesis.versions.count
-
-    # Make sure contributors returns unique values, not all values
-    patch thesis_path(thesis),
-         params: { thesis: { title: 'Another admin-contributed update' } }
-    assert_equal [yo.id, admin.id], thesis.contributors
-    assert_equal 3, thesis.versions.count
-  end
-
-  test 'students_contributed? returns true when students have contributed' do
-    yo = users(:yo)
-    thesis_admin = users(:thesis_admin)
-
-    sign_in thesis_admin
-    thesis = yo.theses.first
-    assert_not thesis.student_contributed?
-
-    sign_in thesis_admin
-    patch thesis_path(thesis),
-         params: { thesis: { title: 'An admin-contributed update' } }
-    assert_not thesis.student_contributed?
-    sign_out thesis_admin
-
-    sign_in yo
-    patch thesis_path(thesis),
-         params: { thesis: { title: 'A student-contributed update' } }
-    assert thesis.student_contributed?
-  end
-
   # ~~~~~~~~~~~~~~~~~~~~~~~~~ thesis processing queue ~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'thesis processing queue exists' do
     sign_in users(:admin)

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -184,6 +184,54 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_no_match note_text, response.body
   end
 
+  test 'contributors returns array of contributors' do
+    yo = users(:yo)
+    admin = users(:admin)
+
+    sign_in yo
+    thesis = yo.theses.first
+    assert_equal [], thesis.contributors
+    assert_equal 0, thesis.versions.count
+
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'A student-contributed update' } }
+    assert_equal [yo.id], thesis.contributors
+    assert_equal 1, thesis.versions.count
+    sign_out yo
+
+    sign_in admin
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'An admin-contributed update' } }
+    assert_equal [yo.id, admin.id], thesis.contributors
+    assert_equal 2, thesis.versions.count
+
+    # Make sure contributors returns unique values, not all values
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'Another admin-contributed update' } }
+    assert_equal [yo.id, admin.id], thesis.contributors
+    assert_equal 3, thesis.versions.count
+  end
+
+  test 'students_contributed? returns true when students have contributed' do
+    yo = users(:yo)
+    thesis_admin = users(:thesis_admin)
+
+    sign_in thesis_admin
+    thesis = yo.theses.first
+    assert_not thesis.student_contributed?
+
+    sign_in thesis_admin
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'An admin-contributed update' } }
+    assert_not thesis.student_contributed?
+    sign_out thesis_admin
+
+    sign_in yo
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'A student-contributed update' } }
+    assert thesis.student_contributed?
+  end
+
   # ~~~~~~~~~~~~~~~~~~~~~~~~~ thesis processing queue ~~~~~~~~~~~~~~~~~~~~~~~~~
   test 'thesis processing queue exists' do
     sign_in users(:admin)

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -272,4 +272,53 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
     msg = 'Select the thesis record you wish to review and edit'
     assert @response.body.include? msg
   end
+
+  # Thesis contributors, and students_contributed?
+  test 'contributors returns array of contributors' do
+    yo = users(:yo)
+    admin = users(:admin)
+
+    sign_in yo
+    thesis = yo.theses.first
+    assert_equal [], thesis.contributors
+    assert_equal 0, thesis.versions.count
+
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'A student-contributed update' } }
+    assert_equal [yo.id], thesis.contributors
+    assert_equal 1, thesis.versions.count
+    sign_out yo
+
+    sign_in admin
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'An admin-contributed update' } }
+    assert_equal [yo.id, admin.id], thesis.contributors
+    assert_equal 2, thesis.versions.count
+
+    # Make sure contributors returns unique values, not all values
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'Another admin-contributed update' } }
+    assert_equal [yo.id, admin.id], thesis.contributors
+    assert_equal 3, thesis.versions.count
+  end
+
+  test 'students_contributed? returns true when students have contributed' do
+    yo = users(:yo)
+    thesis_admin = users(:thesis_admin)
+
+    sign_in thesis_admin
+    thesis = yo.theses.first
+    assert_not thesis.student_contributed?
+
+    sign_in thesis_admin
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'An admin-contributed update' } }
+    assert_not thesis.student_contributed?
+    sign_out thesis_admin
+
+    sign_in yo
+    patch thesis_path(thesis),
+         params: { thesis: { title: 'A student-contributed update' } }
+    assert thesis.student_contributed?
+  end  
 end

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -561,6 +561,13 @@ class ThesisTest < ActiveSupport::TestCase
     assert_equal false, thesis.authors_graduated?
   end
 
+  test 'contributors method does not error without whodunnit values' do
+    thesis = theses(:one)
+    assert_equal Array, thesis.contributors.class
+    assert_equal [], thesis.contributors # Fixtures don't trigger whodunnit
+    # Not sure whether more tests are possible at the model level - see thesis controller tests for more
+  end
+
   test 'in_review scope returns theses in that publication status' do
     assert_equal 'Publication review', Thesis.in_review.first.publication_status
     assert_includes Thesis.in_review, theses(:publication_review)


### PR DESCRIPTION
This adds information about how many theses have had contributions from students to the reporting dashboard, as well as to the term detail report.

#### Caveats

See the commit message for a list of concerns that I'm having trouble shaking out of my head.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-415

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
