### PR TITLE
ETD-482 Allow thesis_admin role to delete theses

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -87,6 +87,5 @@ class Ability
     cannot 'destroy', :department
     cannot 'destroy', :hold_source
     cannot 'destroy', :license
-    cannot 'destroy', :thesis
   end
 end

--- a/test/integration/admin/admin_thesis_test.rb
+++ b/test/integration/admin/admin_thesis_test.rb
@@ -87,7 +87,7 @@ class AdminThesisTest < ActionDispatch::IntegrationTest
     assert_equal 'We discovered it with science', Thesis.last.abstract
   end
 
-  test 'thesis admins cannot destroy theses through admin panel' do
+  test 'thesis admins can destroy theses through admin panel' do
     mock_auth(users(:thesis_admin))
 
     thesis = Thesis.first
@@ -97,7 +97,7 @@ class AdminThesisTest < ActionDispatch::IntegrationTest
     assert Thesis.exists?(thesis_id)
 
     delete admin_thesis_path(thesis)
-    assert Thesis.exists?(thesis_id)
+    assert_not Thesis.exists?(thesis_id)
   end
 
   test 'admins can destroy theses through admin panel' do


### PR DESCRIPTION
#### Why these changes are being introduced:

Originally, thesis admins were not allowed to delete theses, but
there are certain situations in which they need to (e.g., duplicate
thesis records).

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-482

#### How this addresses that need:

This updates the abilty model to allow thesis admins to delete theses.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
