### PR TITLE
Update thesis fixtures to have files attached automatically

### DIFF
--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -135,7 +135,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'empty theses report shows a card' do
     sign_in users(:processor)
     get report_empty_theses_path
-    assert_select '.card-empty-theses span', text: '24 have no attached files', count: 1
+    assert_select '.card-empty-theses span', text: '17 have no attached files', count: 1
   end
 
   test 'empty theses report has links to processing pages' do
@@ -147,7 +147,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'empty theses report allows filtering by term' do
     sign_in users(:processor)
     get report_empty_theses_path
-    assert_select '.card-empty-theses span', text: '24 have no attached files', count: 1
+    assert_select '.card-empty-theses span', text: '17 have no attached files', count: 1
     get report_empty_theses_path, params: { graduation: '2018-09-01' }
     assert_select '.card-empty-theses span', text: '2 have no attached files', count: 1
   end
@@ -205,7 +205,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:processor)
     get report_term_path
     assert_select '.card-overall .message', text: '24 thesis records', count: 1
-    assert_select '.card-files .message', text: '0 have files attached', count: 1
+    assert_select '.card-files .message', text: '7 have files attached', count: 1
     assert_select '.card-issues span', text: '1 flagged with issues', count: 1
     assert_select '.card-multiple-authors span', text: '2 have multiple authors', count: 1
     assert_select '.card-multiple-degrees span', text: '1 has multiple degrees', count: 1

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -231,6 +231,13 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'processing queue shows nothing without files attached' do
+    sign_in users(:processor)
+    Thesis.all.map { |t| t.files.delete_all }
+    get thesis_select_path
+    assert @response.body.include? 'No theses found'
+  end
+
   test 'processing queue shows records with files attached' do
     sign_in users(:processor)
     get thesis_select_path

--- a/test/controllers/thesis_controller_test.rb
+++ b/test/controllers/thesis_controller_test.rb
@@ -231,19 +231,7 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'processing queue shows nothing without work done' do
-    sign_in users(:processor)
-    get thesis_select_path
-    assert @response.body.include? 'No theses found'
-  end
-
-  test 'processing queue shows a record with file attached' do
-    # Attach a file to the thesis
-    t = theses(:with_hold)
-    f = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    t.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
-
-    # Make sure the url for each thesis processing form is included
+  test 'processing queue shows records with files attached' do
     sign_in users(:processor)
     get thesis_select_path
     expected_theses = Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', 'Published')
@@ -253,22 +241,18 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'processing queue allows filtering by term' do
-    # Attach files to two theses
-    t1 = theses(:with_hold)
-    t2 = theses(:active)
-    f = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    t1.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
-    t2.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
-
-    # Request the processing queue and note two records, with three filter
+    # Request the processing queue and note six records, with three filter
     # options (two specific terms, and the "all terms" option)
     sign_in users(:processor)
     get thesis_select_path
-    assert_select 'table#thesisQueue tbody tr', count: 2
+    assert_select 'table#thesisQueue tbody tr', count: 6
     assert_select 'select[name="graduation"] option', count: 3
-    # Now request the queue with a filter applied, and see only one record
+    # Now request the queue with a term filter applied, and see three records
+    get thesis_select_path, params: { graduation: '2018-06-01' }
+    assert_select 'table#thesisQueue tbody tr', count: 3
+    # Now request the queue with an invalid filter applied, and see the no records message
     get thesis_select_path, params: { graduation: '2018-09-01' }
-    assert_select 'table#thesisQueue tbody tr', count: 1
+    assert @response.body.include? 'No theses found'
   end
 
   # ~~~~~~~~~~~~~~~ duplicate theses / multiple authors report ~~~~~~~~~~~~~~~~
@@ -471,7 +455,6 @@ class ThesisControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:processor)
     tr = transfers(:valid)
     th = theses(:publication_review_except_hold)
-    attach_files_to_records(tr, th)
     transfer_file_count = tr.files.count
     thesis_file_count = th.files.count
     attachment_count = ActiveStorage::Attachment.count

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -1,0 +1,47 @@
+valid_files_attachment:
+  name: files
+  record: valid (Transfer)
+  blob: publication_review_except_hold_files_blob
+
+publication_review_files_attachment:
+  name: files
+  record: publication_review (Thesis)
+  purpose: thesis_pdf
+  description: "This is a description of the attachment."
+  blob: publication_review_files_blob
+
+publication_review_except_hold_files_attachment:
+  name: files
+  record: publication_review_except_hold (Thesis)
+  purpose: thesis_pdf
+  blob: publication_review_except_hold_files_blob
+
+pending_publication_files_attachment:
+  name: files
+  record: pending_publication (Thesis)
+  purpose: thesis_pdf
+  blob: pending_publication_files_blob
+
+published_files_attachment:
+  name: files
+  record: published (Thesis)
+  purpose: thesis_pdf
+  blob: published_files_blob
+
+bachelor_files_attachment:
+  name: files
+  record: bachelor (Thesis)
+  purpose: thesis_pdf
+  blob: bachelor_files_blob
+
+master_files_attachment:
+  name: files
+  record: master (Thesis)
+  purpose: thesis_pdf
+  blob: master_files_blob
+
+doctor_files_attachment:
+  name: files
+  record: doctor (Thesis)
+  purpose: thesis_pdf
+  blob: doctor_files_blob

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -1,0 +1,62 @@
+publication_review_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+publication_review_except_hold_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+pending_publication_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+published_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+bachelor_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+master_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test
+
+doctor_files_blob:
+  key: <%= ActiveStorage::Blob.generate_unique_secure_token %>
+  filename: a_pdf.pdf
+  content_type: application/pdf
+  metadata: '{"identified":true,"analyzed":true}'
+  byte_size: 19333
+  checksum: 2800ec8c99c60f5b15520beac9939a46
+  service_name: test

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -44,34 +44,20 @@ class ReportTest < ActiveSupport::TestCase
 
   # ~~~~ Dashboard report
   test 'dashboard includes a table of departments' do
-    # Because our fixtures don't have files attached all the returned values will be zero unless we
-    # manually attach files here.
-    f = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    t = theses(:one)
-    t.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
-    t.save
-
     r = Report.new
     result = r.index_data
     assert_equal Department.count, result['departments'].pluck(:label).length
     assert_includes result['departments'].pluck(:label), Department.first.name_dw
-    assert_equal result['departments'][0][:data].values, [1, 0, 0, 0, 0, 0, 0, 0]
+    assert_equal result['departments'][0][:data].values, [0, 3, 0, 0, 0, 0, 0, 4]
   end
 
   # ~~~~ Term detail report
   test 'term detail includes a breakdown of departments' do
-    # Because our fixtures don't have files attached all the returned values will be zero unless we
-    # manually attach files here.
-    f = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    t = theses(:one)
-    t.files.attach(io: File.open(f), filename: 'a_pdf.pdf')
-    t.save
-
     r = Report.new
-    subset = Thesis.where('grad_date = ?', '2017-09-01')
+    subset = Thesis.where('grad_date = ?', '2018-06-01')
     result = r.term_tables subset
     assert_equal Department.count, result['departments']['data'].length
     assert_includes result['departments']['data'].keys, Department.first.name_dw
-    assert_equal [1, 0, 0], result['departments']['data'].values
+    assert_equal [3, 0, 0], result['departments']['data'].values
   end
 end

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -15,12 +15,12 @@ require 'test_helper'
 class TransferTest < ActiveSupport::TestCase
   setup do
     @transfer = transfers(:valid)
-    file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    @transfer.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
+    # file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    # @transfer.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
   end
 
   teardown do
-    @transfer.files.purge
+    # @transfer.files.purge
   end
 
   test 'valid transfer' do
@@ -144,14 +144,14 @@ class TransferTest < ActiveSupport::TestCase
   end
 
   test 'unassigned_files updates as needed' do
-    assert_equal @transfer.unassigned_files, 1
+    assert_equal 0, @transfer.unassigned_files
 
     @newfile = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
     @transfer.files.attach(io: File.open(@newfile), filename: 'a_pdf.pdf')
-    assert_equal @transfer.unassigned_files, 2
+    assert_equal 1, @transfer.unassigned_files
 
     @thesis = theses(:one)
-    @thesis.files.attach(@transfer.files.blobs.first)
-    assert_equal @transfer.unassigned_files, 1
+    @thesis.files.attach(@transfer.files.blobs.last)
+    assert_equal 0, @transfer.unassigned_files
   end
 end

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -15,12 +15,6 @@ require 'test_helper'
 class TransferTest < ActiveSupport::TestCase
   setup do
     @transfer = transfers(:valid)
-    # file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
-    # @transfer.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
-  end
-
-  teardown do
-    # @transfer.files.purge
   end
 
   test 'valid transfer' do


### PR DESCRIPTION
This updates our thesis fixtures - as well as one transfer fixture - to have files attached without needing to rely on a `setup` method, or a helper function to do during a test. The work was motivated by some work on ETD-415 and ETD-477, where I realized that having test fixtures with files already attached could be helpful.

Some tests will need files to be attached _during_ the test, so some of these helper functions still remain (and are called).

Additionally, because this work has so far been focused on thesis testing, I've not yet extended this work to update other fixtures - for example, the Registrar fixtures, department tests, and a few others. Searching the test directory for the `.attach` method gives a sense of how much is still being done that way.

I welcome feedback from the reviewer about whether this PR should be extended, and _all_ fixtures updated. At the moment, however, I'm concerned about how much work that would take for something that has not gone through our projects usual ticket triage.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
