### PR TITLE
ETD-502 Fix mailer bug in DSpace Publication Results Job

### DIFF
--- a/app/jobs/dspace_publication_job.rb
+++ b/app/jobs/dspace_publication_job.rb
@@ -31,7 +31,8 @@ class DspacePublicationJob < ActiveJob::Base
     rescue StandardError, Aws::Errors, Aws::SQS::Errors => e
       Rails.logger.error("Message not sent: #{e}")
       Sentry.capture_exception(e)
-      # Update thesis record with error status once ETD-399 merges
+      thesis.publication_status = 'Publication error'
+      thesis.save
     end
   end
 

--- a/app/jobs/dspace_publication_results_job.rb
+++ b/app/jobs/dspace_publication_results_job.rb
@@ -17,7 +17,8 @@ class DspacePublicationResultsJob < ActiveJob::Base
       results[:errors] << "Error reading from SQS queue: #{e}"
     end
 
-    ReportMailer.publication_results_email(results).deliver_now if results[:processed].positive?
+    ReportMailer.publication_results_email(results).deliver_now if results[:total].positive? ||
+                                                                   results[:errors].any?
     results
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

In its current state, the app does not send mail if the DSpace
Publication Results Job is run and the results include errors only.
This is because mail is sent when results[:processed] is positive,
and this condition will never be met if the job returns no successes.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-502

#### How this addresses that need:

This changes the condition for the DSpace Publication Results Job
to send mail. Mail will now be sent either if results[:total] is
positive, or if results[:errors] has any items. The results[:errors]
piece of this is necessary because the job can fail before it starts
polling, in which case results[:total] will not increment.

#### Side effects of this change:

I noticed some TODOs in the DSpace Publication Job around setting
the publication status to 'Publication error'. It seems we didn't
have that status in the app when we enabled that job. We do now,
so I updated the job and corresponding tests accordingly.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
