### PR TITLE
Publish only PDF and supplementary files via SQS

### DIFF
--- a/app/models/sqs_message.rb
+++ b/app/models/sqs_message.rb
@@ -29,7 +29,7 @@ class SqsMessage
   end
 
   def map_files
-    @thesis.files.map do |f|
+    @thesis.files.select { |f| %w[thesis_pdf thesis_supplementary_file].include? f.purpose }.map do |f|
       {
         'BitstreamName' => f.blob.filename.to_s,
         'FileLocation' => f.blob.url(expires_in: 604800),


### PR DESCRIPTION
#### Why are these changes being introduced:

* Only the thesis PDF and any supplementary files should be sent to
  DSpace - the source files, signature pages, and proquest forms should
  not.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/etd-500

#### How does this address that need:

* This adds a small select() clause to the SQS Message model's map_files
  method, such that only those two types of files are added to the
  package.

#### Document any side effects to this change:

* None, that I'm aware of. I worry slightly about what changes may be
  needed when we start publishing to more than just DSpace, but the
  map_files method can probably be split to a filter_for_dspace()
  and filter_for_archivespeace() or something.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
