### PR TITLE
Adds color to final banner of publication UI

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -19,7 +19,20 @@ label.error {
   color: $error;
 }
 
-
+.well {
+  &.error {
+    background-color: rgba($error, 0.1);
+    box-shadow: inset 0 0 5px rgba($error, 0.5);
+  }
+  &.success {
+    background-color: rgba($success, 0.1);
+    box-shadow: inset 0 0 5px rgba($success, 0.5);
+  }
+  &.warning {
+    background-color: rgba($warning, 0.1);
+    box-shadow: inset 0 0 5px rgba($warning, 0.5);
+  }
+}
 // admin processing
 .downloaded, .withdrawn {
   @extend .field-wrap;

--- a/app/views/thesis/publish_preview.html.erb
+++ b/app/views/thesis/publish_preview.html.erb
@@ -24,7 +24,7 @@
 </table>
 
 <div id="publish-to-dspace" class="gridband" aria-live="polite" role="region">
-  <div class="inline-action well">
+  <div class="inline-action well warning">
     <% if params[:graduation] == 'all' || params[:graduation].nil? %>
       <div class="message">
         <h4 class="title">Select a term to publish to DSpace@MIT</h4>


### PR DESCRIPTION
#### Why are these changes being introduced:

* During QA testing for ETD-477, Jess asked that the final banner and
  button that will initiate the publication process be rendered with a
  color, to call out that this is something different than normal
  processing. The goal is to prevent accidental clicking.
* Our current theme gem does not implement a coloring option for this
  "well" element, although elsewhere it does define semantic colors for
  "warning", "error", and "success".

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/etd-477

#### How does this address that need:

* This extends our application of the warning, error, and success colors
  to the styles for the "well" elements, so that .well.success will, for
  example, produce a well box that is shaded green. .well.warning will
  render with a yellow treatment, and .well.error will render with a red
  treatment.
* Given these new options, the final publication well is now rendered as
  yellow, or Warning.

#### Document any side effects to this change:

* Adding the two color treatments that aren't implemented here - this
  is a hedge against future requests, and the memory that this isn't
  the first time I've wondered about a color option for these elements.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
