### PR TITLE
Report on expired holds

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -32,6 +32,10 @@ label.error {
     background-color: rgba($warning, 0.1);
     box-shadow: inset 0 0 5px rgba($warning, 0.5);
   }
+
+  :last-child {
+    margin-bottom: 0;
+  }
 }
 // admin processing
 .downloaded, .withdrawn {

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -19,9 +19,7 @@ class ReportController < ApplicationController
   end
 
   def expired_holds
-    report = Report.new
-    holds = Hold.all
-    @list = report.list_expired_holds holds
+    @list = Hold.active_or_expired.ends_today_or_before.order(:date_end)
   end
 
   def files

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -18,6 +18,12 @@ class ReportController < ApplicationController
     @record = report.empty_theses_record subset
   end
 
+  def expired_holds
+    report = Report.new
+    holds = Hold.all
+    @list = report.list_expired_holds holds
+  end
+
   def files
     report = Report.new
     theses = Thesis.all

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,6 +58,7 @@ class Ability
     can :index, Report
     can :term, Report
     can :empty_theses, Report
+    can :expired_holds, Report
     can :student_submitted_theses, Report
 
     can %i[read update], Thesis

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -30,6 +30,9 @@ class Hold < ApplicationRecord
 
   after_save :update_thesis_status
 
+  scope :active_or_expired, -> { Hold.active.or(Hold.expired) }
+  scope :ends_today_or_before, -> { where('date_end <= ?', Date.current) }
+
   def degrees
     thesis.degrees.map(&:name_dw).join("\n")
   end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -301,10 +301,6 @@ class Report
     }
   end
 
-  def list_expired_holds(collection)
-    collection.active_or_expired.ends_today_or_before.order(:date_end)
-  end
-
   def list_unattached_files(collection)
     result = []
     collection.joins(:files_attachments).order(:grad_date).uniq.each do |record|

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -301,6 +301,10 @@ class Report
     }
   end
 
+  def list_expired_holds(collection)
+    collection.active_or_expired.ends_today_or_before.order(:date_end)
+  end
+
   def list_unattached_files(collection)
     result = []
     collection.joins(:files_attachments).order(:grad_date).uniq.each do |record|

--- a/app/views/report/_expired_holds_empty.html.erb
+++ b/app/views/report/_expired_holds_empty.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan="5">There are no holds which have expired.</td>
+</tr>

--- a/app/views/report/_expired_holds_row.html.erb
+++ b/app/views/report/_expired_holds_row.html.erb
@@ -1,0 +1,17 @@
+<tr>
+  <td>
+    <% expired_holds_row.thesis.authors.each do |author| %>
+      <%= author.user.display_name %><br>
+    <% end %>
+  </td>
+  <td>
+    <% expired_holds_row.thesis.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td>
+    <%= expired_holds_row.thesis.graduation_month[...3] %> <%= expired_holds_row.thesis.graduation_year %>
+  </td>
+  <td><%= expired_holds_row[:status].capitalize %></td>
+  <td><%= link_to( expired_holds_row[:date_end].in_time_zone('Eastern Time (US & Canada)').strftime('%b %-d, %Y'), admin_hold_url(expired_holds_row[:id]) ) %></td>
+</tr>

--- a/app/views/report/expired_holds.html.erb
+++ b/app/views/report/expired_holds.html.erb
@@ -1,0 +1,36 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Unreleased holds which end today or in the past</h3>
+
+    <div class="well">
+      <p>This list displays holds which meet all of the following criteria:</p>
+      <ul>
+        <li>The hold status is either "active" or "expired".</li>
+        <li>The hold either ends today or ended in the past.</li>
+      </ul>
+      <p>Update these holds in the administrative interface by clicking the link in the "Expired on" column.</p>
+    </div>
+
+    <table class="table" summary="This table presents a list of holds which have an end date of today, or an end date which has already passed, which have a status of either 'active' or 'expired'. Clicking on the link in the right column will open the administrative form for this hold." title="Unreleased holds with an end date of today or in the past">
+      <thead>
+        <tr>
+          <th scope="col">Thesis authors</th>
+          <th scope="col">Thesis departments</th>
+          <th scope="col">Thesis term</th>
+          <th scope="col">Status</th>
+          <th scope="col">Expired on</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'report/expired_holds_row', collection: @list) || render('expired_holds_empty') %>
+      </tbody>
+    </table>
+
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -20,6 +20,9 @@
       <% if can?(:files, Report) %>
         <li><%= link_to("Files without purpose", report_files_path) %></li>
       <% end %>
+      <% if can?(:expired_holds, Report) %>
+        <li><%= link_to("Unreleased holds which have ended", report_expired_holds_path) %></li>
+      <% end %>
       <% if can?(:proquest_files, Report) %>
         <li><%= link_to("ProQuest forms", report_proquest_files_path) %></li>
       <% end %>

--- a/app/views/transfer/_welcome.html.erb
+++ b/app/views/transfer/_welcome.html.erb
@@ -41,7 +41,7 @@
     </li>
   </ul>
 
-  <p class="last">Please let us know if you or your students have any feedback or questions about this process by
+  <p class="pseudo-heading">Please let us know if you or your students have any feedback or questions about this process by
     emailing us at <a href="mailto:mit-theses@mit.edu?Subject=Transfer%20submission%20help" target="_blank">
     mit-theses@mit.edu</a>.</p>
 </div>
@@ -59,8 +59,7 @@
   .well ul {
     margin-bottom: 5px;
   }
-  .well p.last {
+  .well p.pseudo-heading {
     margin-top: 15px;
-    margin-bottom: 0;
   }
 </style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   get 'report', to: 'report#index', as: 'report_index'
   get 'report/empty_theses', to: 'report#empty_theses', as: 'report_empty_theses'
+  get 'report/expired_holds', to: 'report#expired_holds', as: 'report_expired_holds'
   get 'report/files', to: 'report#files', as: 'report_files'
   get 'report/proquest_files', to: 'report#proquest_files', as: 'report_proquest_files'
   get 'report/student_submitted_theses', to: 'report#student_submitted_theses', as: 'report_student_submitted_theses'

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -243,6 +243,53 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # ~~~~~~~~~~~~~~~~~~~~ Expired holds report ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  test 'expired holds report exists' do
+    sign_in users(:admin)
+    get report_expired_holds_path
+    assert_response :success
+  end
+
+  test 'anonymous users are prompted to log in by expired holds report' do
+    # Note that nobody is signed in.
+    get report_expired_holds_path
+    assert_response :redirect
+  end
+
+  test 'basic users cannot see expired holds report' do
+    sign_in users(:basic)
+    get report_expired_holds_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'submitters cannot see expired holds report' do
+    sign_in users(:transfer_submitter)
+    get report_expired_holds_path
+    assert_redirected_to '/'
+    follow_redirect!
+    assert_select 'div.alert', text: 'Not authorized.', count: 1
+  end
+
+  test 'processors can see expired holds report' do
+    sign_in users(:processor)
+    get report_expired_holds_path
+    assert_response :success
+  end
+
+  test 'thesis_admins can see expired holds report' do
+    sign_in users(:thesis_admin)
+    get report_expired_holds_path
+    assert_response :success
+  end
+
+  test 'admins can see expired holds report' do
+    sign_in users(:admin)
+    get report_expired_holds_path
+    assert_response :success
+  end
+
   # ~~~~~~~~~~~~~~~~~~~~ Files without purpose report ~~~~~~~~~~~~~~~~~~~~~~~~
   test 'files report exists' do
     sign_in users(:admin)

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -70,28 +70,47 @@ class HoldTest < ActiveSupport::TestCase
     assert(hold.invalid?)
   end
 
-  test 'active_or_expired scope shows expected records' do
+  test 'active_or_expired scope returns both statuses together' do
     assert_equal ["active", "expired"], Hold.active_or_expired.map(&:status).uniq.sort
+  end
+
+  test 'active_or_expired scope returns an active hold' do
     hold = holds(:valid)
     hold.status = :active
     hold.save
     assert Hold.active_or_expired.pluck(:id).include?(hold.id)
+  end
+
+  test 'active_or_expired scope returns an expired hold' do
+    hold = holds(:valid)
     hold.status = :expired
     hold.save
     assert Hold.active_or_expired.pluck(:id).include?(hold.id)
+  end
+
+  test 'active_or_expired scope does not return a released hold' do
+    hold = holds(:valid)
     hold.status = :released
     hold.save
     assert_not Hold.active_or_expired.pluck(:id).include?(hold.id)
   end
 
-  test 'ends_today_or_before scope shows expected records' do
+  test 'ends_today_or_before scope returns a hold which ends today' do
     hold = holds(:valid)
     hold.date_end = Date.today
     hold.save
     assert Hold.ends_today_or_before.pluck(:id).include?(hold.id)
+  end
+
+  test 'ends_today_or_before scope returns a hold which ends in the past' do
+    hold = holds(:valid)
     hold.date_end = Date.today - 1
     hold.save
     assert Hold.ends_today_or_before.pluck(:id).include?(hold.id)
+  end
+
+  test 'ends_today_or_before scope does not return a hold which ends in the future' do
+    hold = holds(:valid)
     hold.date_end = Date.today + 1
     hold.save
     assert_not Hold.ends_today_or_before.pluck(:id).include?(hold.id)

--- a/test/models/hold_test.rb
+++ b/test/models/hold_test.rb
@@ -70,6 +70,33 @@ class HoldTest < ActiveSupport::TestCase
     assert(hold.invalid?)
   end
 
+  test 'active_or_expired scope shows expected records' do
+    assert_equal ["active", "expired"], Hold.active_or_expired.map(&:status).uniq.sort
+    hold = holds(:valid)
+    hold.status = :active
+    hold.save
+    assert Hold.active_or_expired.pluck(:id).include?(hold.id)
+    hold.status = :expired
+    hold.save
+    assert Hold.active_or_expired.pluck(:id).include?(hold.id)
+    hold.status = :released
+    hold.save
+    assert_not Hold.active_or_expired.pluck(:id).include?(hold.id)
+  end
+
+  test 'ends_today_or_before scope shows expected records' do
+    hold = holds(:valid)
+    hold.date_end = Date.today
+    hold.save
+    assert Hold.ends_today_or_before.pluck(:id).include?(hold.id)
+    hold.date_end = Date.today - 1
+    hold.save
+    assert Hold.ends_today_or_before.pluck(:id).include?(hold.id)
+    hold.date_end = Date.today + 1
+    hold.save
+    assert_not Hold.ends_today_or_before.pluck(:id).include?(hold.id)
+  end
+
   test 'editing hold generates an audit trail' do
     hold = holds(:valid)
     hold.save


### PR DESCRIPTION
This creates a report of holds which should be reviewed for a status change: holds with an end date of today or before, and which have not yet been marked as "released" (i.e. either "active" or "expired"). Each hold displayed is linked to its administrative form, so staff can make any adjustments needed.

We have now gotten some confirmation in the Jira ticket that the assumptions in this work (laid out in the Jira thread) are acceptable to Jess - so I'm marking the "stakeholder approval" box as true.

#### Ticket

https://mitlibraries.atlassian.net/browse/ETD-453

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
