### PR TITLE
ETD-315 Add report on theses by publication status

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -221,3 +221,6 @@ ul.thesis-start {
   font-size: 200%;
   font-weight: bolder;
 }
+.multi-form-tag {
+  margin-bottom:  1.5rem;
+}

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -39,6 +39,14 @@ class ThesisController < ApplicationController
     @thesis = filter_theses_by_term Thesis.where.not('coauthors = ?', '')
   end
 
+  def publication_statuses
+    @terms = defined_terms Thesis.all
+    @publication_statuses = Thesis.all.pluck(:publication_status).uniq.sort
+    # Filter relevant theses by selected term from querystring
+    term_filtered = filter_theses_by_term Thesis.all
+    @thesis = filter_theses_by_publication_status term_filtered
+  end
+
   def edit
     @thesis = Thesis.find(params[:id])
     @thesis.association(:advisors).add_to_target(Advisor.new) if @thesis.advisors.count.zero?

--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -12,4 +12,10 @@ module ThesisHelper
 
     theses
   end
+
+  def filter_theses_by_publication_status(theses)
+    return theses.where('publication_status = ?', params[:status]) if params[:status] && params[:status] != 'all'
+
+    theses
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -70,6 +70,7 @@ class Ability
     can :publish_preview, Thesis
     can :publish_to_dspace, Thesis
     can :select, Thesis
+    can :publication_statuses, Thesis
 
     can :read, Transfer
     can :select, Transfer

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -14,6 +14,9 @@
       <% if can?(:student_submitted_thesis, Report) %>
         <li><%= link_to("Theses submitted by students", report_student_submitted_theses_path) %></li>
       <% end %>
+      <% if can?(:publication_statuses, Thesis) %>
+        <li><%= link_to("Theses by publication status", thesis_publication_statuses_path) %></li>
+      <% end %>
       <% if can?(:files, Report) %>
         <li><%= link_to("Files without purpose", report_files_path) %></li>
       <% end %>

--- a/app/views/thesis/_publication_status_filter.html.erb
+++ b/app/views/thesis/_publication_status_filter.html.erb
@@ -1,0 +1,31 @@
+<%= form_tag(nil, method: "get") do %>
+  <div class="multi-form-tag">
+    <label>
+      Include only theses from:
+      <select name="graduation">
+        <option value="all">All terms</option>
+        <% @terms.each do |term| %>
+          <option value="<%= term %>"<%= ' selected="selected"'.html_safe if params[:graduation].to_s == term.to_s %>>
+            <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
+          </option>
+        <% end %>
+      </select>
+    </label>
+  </div>
+
+  <div class="multi-form-tag">
+    <label>
+      Filter by publication status:
+      <select name="status">
+        <option value="all">All statuses</option>
+        <% @publication_statuses.each do |status| %>
+          <option value="<%= status %>"<%= ' selected="selected"'.html_safe if params[:status].to_s == status.to_s %>>
+            <%= status %>
+          </option>
+        <% end %>
+      </select>
+    </label>
+  </div>
+
+  <%= submit_tag('Apply filters', class: 'btn button-primary') %>
+<% end %>

--- a/app/views/thesis/_thesis_publication_status.html.erb
+++ b/app/views/thesis/_thesis_publication_status.html.erb
@@ -1,0 +1,21 @@
+<tr>
+  <td><%= link_to title_helper(thesis_publication_status), edit_admin_thesis_path(thesis_publication_status.id) %></td>
+  <td>
+    <% thesis_publication_status.users.each do |user| %>
+      <%= user.display_name %><br>
+    <% end %>
+  </td>
+  <td><%= thesis_publication_status.coauthors %></td>
+  <td>
+    <% thesis_publication_status.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td>
+    <% thesis_publication_status&.degrees.each do |degree| %>
+      <%= degree.degree_type&.name %>
+    <% end %>
+  </td>
+  <td><%= thesis_publication_status.graduation_month[...3] %> <%= thesis_publication_status.graduation_year %></td>
+  <td><%= thesis_publication_status.publication_status %></td>
+</tr>

--- a/app/views/thesis/publication_statuses.html.erb
+++ b/app/views/thesis/publication_statuses.html.erb
@@ -1,0 +1,46 @@
+<%= content_for(:title, "Publication Status Report | MIT Libraries") %>
+
+<% content_for :additional_js do %>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+<% end %>
+
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Theses by publication status</h3>
+
+    <%= render 'publication_status_filter' %>
+
+    <table class="table" id="thesisQueue" title="Thesis processing queue">
+      <thead>
+        <tr>
+          <th scope="col">Title</th>
+          <th scope="col">Author(s)</th>
+          <th scope="col">Coauthor(s)</th>
+          <th scope="col">Department(s)</th>
+          <th scope="col">Degree type(s)</th>
+          <th scope="col">Degree date</th>
+          <th scope="col">Publication status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'thesis_publication_status', collection: @thesis) || render('select_empty') %>
+      </tbody>
+    </table>
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>
+
+<script type="text/javascript">
+$(document).ready( function () {
+  if( document.getElementById('thesisQueue').getElementsByClassName('empty').length === 0 ) {
+    var table = $('#thesisQueue').DataTable({
+      stateSave: true
+    });
+  };
+});
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get 'report/term', to: 'report#term', as: 'report_term'
   get 'thesis/confirm', to: 'thesis#confirm', as: 'thesis_confirm'
   get 'thesis/deduplicate', to: 'thesis#deduplicate', as: 'thesis_deduplicate'
+  get 'thesis/publication_statuses', to: 'thesis#publication_statuses', as: 'thesis_publication_statuses'
   get 'thesis/:id/process', to: 'thesis#process_theses', as: 'thesis_process'
   patch 'thesis/:id/process', to: 'thesis#process_theses_update', as: 'thesis_process_update'
   get 'thesis/publish_preview', to: 'thesis#publish_preview', as: 'thesis_publish_preview'

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -35,4 +35,21 @@ class ThesisHelperTest < ActionView::TestCase
     params[:graduation] = "all"
     assert_equal @theses.count, filter_theses_by_term(@theses).count
   end
+
+  test 'filter_theses_by_publication_status returns a filtered set of theses' do
+    status_count = Thesis.where(publication_status: 'Not ready for publication').count
+    assert_not_equal status_count, Thesis.count
+
+    params[:status] = 'Not ready for publication'
+    assert_equal status_count, filter_theses_by_publication_status(Thesis.all).count
+  end
+
+  test 'filter_theses_by_publication_status does nothing when no status param is set' do
+    assert_equal Thesis.all.count, filter_theses_by_publication_status(Thesis.all).count
+  end
+
+  test 'filter_theses_by_publication_status does nothing when status param is "all"' do
+    params[:status] = 'all'
+    assert_equal Thesis.all.count, filter_theses_by_publication_status(Thesis.all).count
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Processors need a report that clearly shows the current publication
status of the theses in the application.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-315

#### How this addresses that need:

This creates a report that lists theses' current publication statuses.
The report includes param filters to optionally refine the results by
term, publication status, or both. DataTables is included for additional
filtering if needed.

#### Side effects of this change:

Adds a CSS rule to create some spacing between the two selects.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
