### PR TITLE
ETD-510 Further describe DSS status errors

### DIFF
--- a/app/jobs/dspace_publication_results_job.rb
+++ b/app/jobs/dspace_publication_results_job.rb
@@ -45,11 +45,12 @@ class DspacePublicationResultsJob < ActiveJob::Base
     when 'success'
       update_handle(thesis, body, results)
     when 'error'
-      error = body['ExceptionMessage']
+      error = body['DSpaceResponse']
       thesis.publication_status = 'Publication error'
       thesis.save
       Rails.logger.info("Thesis #{thesis.id} updated to status #{thesis.publication_status}. Error from DSS: #{error}")
-      results[:errors] << "#{error} (thesis #{thesis.id})"
+      results[:errors] << "Status updated to #{thesis.publication_status}. Error from DSS: #{error} \
+                           (thesis #{thesis.id})"
     else
       thesis.publication_status = 'Publication error'
       thesis.save


### PR DESCRIPTION
#### Why these changes are being introduced:

When the DSpace Publication Results Job sees a record with a result
type of error, it adds the exception message and the thesis ID to
the errors array. We've seen at least once instance where the result
type is error but the exception message is empty, which results in
an unhelpful message like this: " (thesis ID 42)".

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-510

#### How this addresses that need:

This adds a bit more context to the error message described above,
so can determine the following:

1. That DSS encountered an error while processing the record; and
2. What the publication status was updated to (hopefully 'error').

#### Side effects of this change:

This will change (i.e., enrich) how errors are reported in the
publication results email.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
