### PR TITLE
ETD-515 Use UTF-8 character instead of code for copyright symbol

### DIFF
--- a/app/models/dspace_metadata.rb
+++ b/app/models/dspace_metadata.rb
@@ -43,8 +43,8 @@ class DspaceMetadata
     orcids = thesis_users.map(&:orcid).compact
     return unless orcids.present?
 
-    orcids.each do |orchid|
-      @dc['dc.identifier.orcid'] = orchid
+    orcids.each do |orcid|
+      @dc['dc.identifier.orcid'] = orcid
     end
   end
 
@@ -70,7 +70,7 @@ class DspaceMetadata
   def copyright(thesis_copyright, thesis_license)
     if thesis_copyright.holder != 'Author' # copyright holder is anyone but author
       @dc['dc.rights'] = thesis_copyright.statement_dspace
-      @dc['dc.rights'] = "U+00A9 #{thesis_copyright.holder}"
+      @dc['dc.rights'] = "© #{thesis_copyright.holder}"
       @dc['dc.rights.uri'] = thesis_copyright.url if thesis_copyright.url
     elsif thesis_license # author holds copyright and provides a license
       @dc['dc.rights'] = thesis_license.license_type

--- a/test/models/dspace_metadata_test.rb
+++ b/test/models/dspace_metadata_test.rb
@@ -209,7 +209,7 @@ class DspaceMetadataTest < ActiveSupport::TestCase
                                                'value' => 'https://rightsstatements.org/page/InC/1.0/' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'In Copyright - Educational Use Permitted' })
-    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'U+00A9 MIT' })
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => '© MIT' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'http://rightsstatements.org/page/InC-EDU/1.0/' })
   end


### PR DESCRIPTION
#### Why these changes are being introduced:

DSpace does not support UTF-8 codes or HTML entities, so the
only way to display a copyright symbol is to use the UTF-8
character itself.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-515

#### How this addresses that need:

This uses the UTF-8 character in the Dspace Metadata mdoel instead
of the UTF-8 code.

#### Side effects of this change:

None expected, but we'll need to determine whether this will publish
successfully. I've confirmed that DSpace test renders the character
when editing the record metadata in the DSpace UI, but I haven't
confirmed that the full publication workflow will run as expected.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
