### PR TITLE
Warn for Degree and Dept issues when Processing

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -140,7 +140,9 @@ class Thesis < ApplicationRecord
       metadata_complete?,
       no_issues_found?,
       no_active_holds?,
-      authors_graduated?
+      authors_graduated?,
+      departments_have_dspace_name?,
+      degrees_have_types?
     ].all?
   end
 
@@ -195,6 +197,20 @@ class Thesis < ApplicationRecord
   def required_license?
     return true if copyright&.holder != 'Author'
     return true if license&.display_description
+
+    false
+  end
+
+  # This returns false if any associated departments are missing dspace names which is a requirment for publishing
+  def departments_have_dspace_name?
+    return true if departments.select { |d| d.name_dspace == '' || d.name_dspace.nil? }.count.zero?
+
+    false
+  end
+
+  # This returns false if any associated degrees are missing types which is a requirement for publishing
+  def degrees_have_types?
+    return true if degrees.select { |d| d.degree_type_id.nil? }.count.zero?
 
     false
   end

--- a/app/views/thesis/_degree_fields.html.erb
+++ b/app/views/thesis/_degree_fields.html.erb
@@ -10,4 +10,7 @@
 <div class="field-row layout-1q3q layout-band">
   <label class="col1q field-label" for="<%= field_id %>"><%= field_label %></label>
   <input id="<%= field_id %>" type="text" name="degree[]" readonly="readonly" value="<%= deg.name_dw %>" class="field field-text col3q disabled">
+  <% unless deg.degree_type %>
+    <span class="alert error col3q"><strong>This thesis cannot be published until this Degree has a type.</strong></span>
+  <% end %>
 </div>

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -168,6 +168,9 @@
       <p class="links col3q">
         <%= link_to_add_association 'Add another department', f, :department_theses %>
       </p>
+      <% unless f.object.departments_have_dspace_name? %>
+        <span class="alert error col3q"><strong>A Department does not have a DSpace name. This thesis cannot be published until all associated Departments have DSpace names.</strong></span>
+      <% end %>
     </div>
 
     <div class="layout-1q3q layout-band">

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -628,6 +628,8 @@ class ThesisTest < ActiveSupport::TestCase
     assert_equal true, thesis.authors_graduated?
     assert_equal false, thesis.active_holds?
     assert_equal true, thesis.no_active_holds?
+    assert_equal true, thesis.departments_have_dspace_name?
+    assert_equal true, thesis.degrees_have_types?
     assert_equal 'Publication review', thesis.publication_status
     # Attempting to set a different status will be overwritten by the update_status method
     thesis.publication_status = 'Not ready for publication'
@@ -947,6 +949,60 @@ class ThesisTest < ActiveSupport::TestCase
                     })
     assert_equal true, hold.valid?
     hold.save
+    thesis.reload
+    assert_equal 'Not ready for publication', thesis.publication_status
+  end
+
+  test 'One department without a dspace name will prevent "Publication review"' do
+    thesis = theses(:publication_review)
+    thesis.save
+    thesis.reload
+    assert_equal 'Publication review', thesis.publication_status
+    dept = thesis.departments.first
+    dept.name_dspace = nil
+    dept.save
+    thesis.save
+    thesis.reload
+    assert_equal 'Not ready for publication', thesis.publication_status
+  end
+
+  test 'Multiple departments with one without a dspace name will prevent "Publication review"' do
+    thesis = theses(:publication_review)
+    thesis.departments << departments(:two)
+    thesis.save
+    thesis.reload
+    assert_equal 'Publication review', thesis.publication_status
+    dept = thesis.departments.first
+    dept.name_dspace = nil
+    dept.save
+    thesis.save
+    thesis.reload
+    assert_equal 'Not ready for publication', thesis.publication_status
+  end
+
+  test 'One degree without a type name will prevent "Publication review"' do
+    thesis = theses(:publication_review)
+    thesis.save
+    thesis.reload
+    assert_equal 'Publication review', thesis.publication_status
+    degree = thesis.degrees.first
+    degree.degree_type_id = nil
+    degree.save
+    thesis.save
+    thesis.reload
+    assert_equal 'Not ready for publication', thesis.publication_status
+  end
+
+  test 'Multiple degrees with one without a type name will prevent "Publication review"' do
+    thesis = theses(:publication_review)
+    thesis.degrees << degrees(:two)
+    thesis.save
+    thesis.reload
+    assert_equal 'Publication review', thesis.publication_status
+    degree = thesis.degrees.first
+    degree.degree_type_id = nil
+    degree.save
+    thesis.save
     thesis.reload
     assert_equal 'Not ready for publication', thesis.publication_status
   end


### PR DESCRIPTION
Why are these changes being introduced:

* There is no clear indication of issues with associated Departments
  or Degrees on the Thesis processing pages. These issues _will_ prevent
  a Thesis from being published so it makes sense to inform at this
  stage so the Processor can resolve the issues proactively rather than
  find out about them during failed publication attempts.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-517
* https://mitlibraries.atlassian.net/browse/ETD-518

How does this address that need:

* Creates checks for missing Degree types and Department.name_spaces
* Updates the publication review checks to include these new checks
* Displays messages inline on the Thesis processing page near where
  a processor would be looking at this information anyway so they can
  be aware of problems and resolve them as appropraite.

Document any side effects to this change:

* We are now preventing the Publication Review status if there are
  blank Department.name_dspace and Degrees missing types
* Fixing a linked record, such as adding a Degree type or Department
  name_dspace does not update the Publication Status. This possibly
  related to this known issue:
  https://mitlibraries.atlassian.net/browse/ETD-507

NOTE: while I did run ANDI and it flagged no concerns around the changes, I do want to consider whether we are adequately highlighting problems with the record in an accessible way. The stakeholders preferred this inline solution, but we may want to reflect on accessibility as a whole on some of these types of interfaces that work by skimming and ensure we are providing the data to assistive devices in a way that also allows skimming. It's possible a more accessible approach would be to include this in the other summary data at the top (or both if stakeholders prefer this solution).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
