### PR TITLE
ETD-519 Add dspace_handle to administrate thesis dashboard

### DIFF
--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -102,6 +102,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     abstract
     status
     publication_status
+    dspace_handle
     graduation_year
     graduation_month
     author_note

--- a/test/integration/admin/admin_thesis_test.rb
+++ b/test/integration/admin/admin_thesis_test.rb
@@ -197,4 +197,15 @@ class AdminThesisTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'can assign dspace_handle to theses via thesis panel' do
+    handle = '1234/5678'
+    mock_auth(users(:thesis_admin))
+    thesis = theses(:one)
+    assert_not_equal thesis.dspace_handle, handle
+
+    patch admin_thesis_path(thesis), params: { thesis: { dspace_handle: handle } }
+    thesis.reload
+    assert_equal thesis.dspace_handle, handle
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Ordinarily dspace_handle will be automatically generated as part of
the publication workflow, but there are some cases in which a thesis
must be published manually, which would require the processor to input
the handle in administrate.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-519

#### How this addresses that need:

This makes dspace_handle a form attribute in the administrate thesis
dashboard.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
