### PR TITLE
ETD-515 Don't use copyright unicode character

### DIFF
--- a/app/models/dspace_metadata.rb
+++ b/app/models/dspace_metadata.rb
@@ -70,7 +70,7 @@ class DspaceMetadata
   def copyright(thesis_copyright, thesis_license)
     if thesis_copyright.holder != 'Author' # copyright holder is anyone but author
       @dc['dc.rights'] = thesis_copyright.statement_dspace
-      @dc['dc.rights'] = "© #{thesis_copyright.holder}"
+      @dc['dc.rights'] = "Copyright #{thesis_copyright.holder}"
       @dc['dc.rights.uri'] = thesis_copyright.url if thesis_copyright.url
     elsif thesis_license # author holds copyright and provides a license
       @dc['dc.rights'] = thesis_license.license_type

--- a/test/models/dspace_metadata_test.rb
+++ b/test/models/dspace_metadata_test.rb
@@ -209,7 +209,7 @@ class DspaceMetadataTest < ActiveSupport::TestCase
                                                'value' => 'https://rightsstatements.org/page/InC/1.0/' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'In Copyright - Educational Use Permitted' })
-    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => '© MIT' })
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'Copyright MIT' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'http://rightsstatements.org/page/InC-EDU/1.0/' })
   end


### PR DESCRIPTION
#### Why these changes are being introduced:

We learned that unicode characters are not accepted by
Archivematica.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-515

#### How this addresses that need:

We are not printing the word 'Copyright' instead of the
unicode character.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
