### PR TITLE
Add text mapping for "No Creative Commons" license type

### DIFF
--- a/app/models/dspace_metadata.rb
+++ b/app/models/dspace_metadata.rb
@@ -1,4 +1,4 @@
-# Generates Dublin Core metadata require to publish a Thesis object to DSpace@MIT via the DSpace Submission System
+# Generates Dublin Core metadata required to publish a Thesis object to DSpace@MIT via the DSpace Submission System
 # DSS. This class assumes that the input Thesis is ready for publication and has all the requisite metadata and file
 # attachments. Validation of those requirements will occur in the Thesis model.
 
@@ -73,7 +73,7 @@ class DspaceMetadata
       @dc['dc.rights'] = "© #{thesis_copyright.holder}"
       @dc['dc.rights.uri'] = thesis_copyright.url if thesis_copyright.url
     elsif thesis_license # author holds copyright and provides a license
-      @dc['dc.rights'] = thesis_license.license_type
+      @dc['dc.rights'] = thesis_license.map_license_type
       @dc['dc.rights'] = 'Copyright retained by author(s)'
 
       # Theoretically both license and copyright URLs are required for publication, but there are no constraints on

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -14,4 +14,12 @@ class License < ApplicationRecord
 
   validates :display_description, presence: true
   validates :license_type, presence: true
+
+  def map_license_type
+    if license_type == 'No Creative Commons License'
+      'In Copyright - Educational Use Permitted'
+    else
+      license_type.to_s
+    end
+  end
 end

--- a/test/models/dspace_metadata_test.rb
+++ b/test/models/dspace_metadata_test.rb
@@ -132,7 +132,6 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     serialized = DspaceMetadata.new(t).serialize_dss_metadata
     unserialized = JSON.parse(serialized)
 
-    refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'No Creative Commons License' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'Attribution 4.0 International (CC BY 4.0)' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'In Copyright' })
@@ -154,7 +153,6 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     serialized = DspaceMetadata.new(t).serialize_dss_metadata
     unserialized = JSON.parse(serialized)
 
-    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'No Creative Commons License' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'Attribution 4.0 International (CC BY 4.0)' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'In Copyright' })
@@ -163,7 +161,7 @@ class DspaceMetadataTest < ActiveSupport::TestCase
                                                'value' => 'https://creativecommons.org/licenses/by/4.0/' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'https://rightsstatements.org/page/InC/1.0/' })
-    refute unserialized['metadata'].include?({ 'key' => 'dc.rights',
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'In Copyright - Educational Use Permitted' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'U+00A9 MIT' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
@@ -176,7 +174,6 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     serialized = DspaceMetadata.new(t).serialize_dss_metadata
     unserialized = JSON.parse(serialized)
 
-    refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'No Creative Commons License' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'Attribution 4.0 International (CC BY 4.0)' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'In Copyright' })
@@ -198,7 +195,6 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     serialized = DspaceMetadata.new(t).serialize_dss_metadata
     unserialized = JSON.parse(serialized)
 
-    refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'No Creative Commons License' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights',
                                                'value' => 'Attribution 4.0 International (CC BY 4.0)' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'In Copyright' })

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -52,4 +52,17 @@ class LicenseTest < ActiveSupport::TestCase
     assert_equal license_count - 1, License.count
     assert_equal thesis_count, Thesis.count
   end
+
+  test 'license types are mapped correctly' do
+    # Maps license text for no Creative Commons licenses
+    nocc = licenses(:nocc)
+    assert_equal 'In Copyright - Educational Use Permitted', nocc.map_license_type
+
+    # Does not map license text otherwise
+    ccby = licenses(:ccby)
+    assert_equal 'Attribution 4.0 International (CC BY 4.0)', ccby.map_license_type
+
+    ccbysa = licenses(:ccbysa)
+    assert_equal 'Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)', ccbysa.map_license_type
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

During publication workflow testing, stakeholders noted that "No
Creative Commons" looks odd in DSpace, and it would be preferable
for these license types to read as "In Copyright -- Educational Use
Permitted" instead.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-514

#### How this addresses that need:

This adds a method to the license model that returns the desired
phrase for "No Creative Commons" license types, and otherwise
returns the license type as stored in the database. We then use
that method in the Dspace Metadata model to ensure that the mapped
value appears in DSpace.

#### Side effects of this change:

This change complicates the testing approach we use for the Dspace
Metadata model, which effectively checks for all possible values of
dc.rights in the unserialized metadata against a given thesis'
copyright and license. Now that we are using the same value for two
different copyright/license states, the tests are a little more
ambiguous. This isn't a problem yet, but it's worth documenting here.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
