### PR TITLE
Adds a rake task for processing dss output queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,17 @@ Example usage:
   lines so you'll need to be careful to reconstruct this
 - `rails debug:saml['tmp/your_saml_to_debug.txt']`
 
+## Publishing workflow
+
+- stakeholders process theses until they are valid and accurate
+- stakeholders choose theses to publish (Process theses - Select term - Select Publication Review - Publish)
+- ETD will now automatically send data to DSS via the SQS queue
+- DSS runs (as of this writing that is a manual process documented in the
+  [DSS repo](https://github.com/MITLibraries/dspace-submission-service#run-stage))
+- ETD processes output queue to update records and send email to stakeholders with summary data and list
+  of any error records (as of now this is a manual process, but can be triggered via rake task using the
+  Heroku run command such as `heroku run rails dss:process_output_queue --app TARGET-HEROKU-APP`)
+
 ## Validation of thesis record
 
 Prior to theses being published to external systems (such as the repository, or
@@ -219,38 +230,38 @@ by looking at the `evaluate_status` method on the Thesis model.
 The following table lists the components of a Thesis record, including whether
 each is required - and where that check is performed.
 
-| Field                 | Required?    | Verified by           |
-|--------------------   |-----------   |--------------------   |
-| ID                    | yes          | valid?                |
-| Created_at            | yes          | valid?                |
-| Updated_at            | yes          | valid?                |
-| Title                 | yes          | required_fields?      |
-| Abstract              | sometimes    | required_abstract?    |
-| Grad_date             | yes          | valid?                |
-| Status                | yes          | valid?                |
-| Processor_note        | no           |                       |
-| Author_note           | no           |                       |
-| Files_complete        | yes          | evaluate_status       |
-| Metadata_complete     | yes          | evaluate_status       |
-| Publication_status    | yes          | valid?                |
-| Coauthors             | no           |                       |
-| Copyright_id          | yes          | required_fields?      |
-| License_id            | sometimes    | required_license?     |
-| Dspace_handle         | no           |                       |
-| Issues_found          | yes          | no_issues_found?      |
+| Field              | Required? | Verified by        |
+| ------------------ | --------- | ------------------ |
+| ID                 | yes       | valid?             |
+| Created_at         | yes       | valid?             |
+| Updated_at         | yes       | valid?             |
+| Title              | yes       | required_fields?   |
+| Abstract           | sometimes | required_abstract? |
+| Grad_date          | yes       | valid?             |
+| Status             | yes       | valid?             |
+| Processor_note     | no        |                    |
+| Author_note        | no        |                    |
+| Files_complete     | yes       | evaluate_status    |
+| Metadata_complete  | yes       | evaluate_status    |
+| Publication_status | yes       | valid?             |
+| Coauthors          | no        |                    |
+| Copyright_id       | yes       | required_fields?   |
+| License_id         | sometimes | required_license?  |
+| Dspace_handle      | no        |                    |
+| Issues_found       | yes       | no_issues_found?   |
 
 ### Related records
 
-| Record                | Required?    | Verified by                                                                                                                                                                                                                    |
-|--------------------   |-----------   |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
-| Advisor               | yes          | advisors?                                                                                                                                                                                                                      |
-| Author                | yes          | Two checks<br>- validations<br>- authors_graduated checks the graduated flag on each author record                                                                                                                             |
-| Copyright             | yes          | copyright_id?                                                                                                                                                                                                                  |
-| Degree                | yes          | degrees?                                                                                                                                                                                                                       |
-| Department            | yes          | validations                                                                                                                                                                                                                    |
-| File                  | yes          | Three checks<br>- files? confirms that at least one file is attached<br>- file_have_purpose? confirms that each file has an assigned purpose<br>- one_thesis_pdf? confirms one-and-only-one file has a "thesis_pdf" purpose    |
-| Hold                  | yes          | no_active_holds? confirms that no attached hold has an "active" or "expired" status<br>("released" holds are okay)                                                                                                             |
-| License               | sometimes    | required_license? checks who holds copyright and requires a license if that is the author                                                                                                                                      |
+| Record     | Required? | Verified by                                                                                                                                                                                                                 |
+| ---------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Advisor    | yes       | advisors?                                                                                                                                                                                                                   |
+| Author     | yes       | Two checks<br>- validations<br>- authors_graduated checks the graduated flag on each author record                                                                                                                          |
+| Copyright  | yes       | copyright_id?                                                                                                                                                                                                               |
+| Degree     | yes       | degrees?                                                                                                                                                                                                                    |
+| Department | yes       | validations                                                                                                                                                                                                                 |
+| File       | yes       | Three checks<br>- files? confirms that at least one file is attached<br>- file_have_purpose? confirms that each file has an assigned purpose<br>- one_thesis_pdf? confirms one-and-only-one file has a "thesis_pdf" purpose |
+| Hold       | yes       | no_active_holds? confirms that no attached hold has an "active" or "expired" status<br>("released" holds are okay)                                                                                                          |
+| License    | sometimes | required_license? checks who holds copyright and requires a license if that is the author                                                                                                                                   |
 
 ## Alternate file upload feedback
 

--- a/lib/tasks/dss.rake
+++ b/lib/tasks/dss.rake
@@ -1,0 +1,6 @@
+namespace :dss do
+  desc 'Runs job to process DSS output queue'
+  task process_output_queue: :environment do
+    DspacePublicationResultsJob.perform_now
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* We need a way to run the output processing job

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-501

How does this address that need:

* Creates a rake task to allow us to easily trigger the job to run on
  Heroku from our local CLI rather than having to create a console
  session in Heroku to run job

Document any side effects to this change:

If multiple apps are connected to the same output queue
(such as local dev and staging), running in one (such as local dev) will
only update the local instance but possibly be processing output for
different environemnts. In practice, this should not be a risk in
production as nobody should have configuration locally to connect to
production output queues so the risk is more associated with PR builds,
Staging and Development environemnts which seem low enough risk to have
the benefits outweigh this concern.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
