### PR TITLE
Validate checksums in Publication Results Job

### DIFF
--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -4,7 +4,7 @@ publication_review_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 publication_review_except_hold_files_blob:
@@ -13,7 +13,7 @@ publication_review_except_hold_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 pending_publication_files_blob:
@@ -22,7 +22,7 @@ pending_publication_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 published_files_blob:
@@ -31,7 +31,7 @@ published_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 bachelor_files_blob:
@@ -40,7 +40,7 @@ bachelor_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 master_files_blob:
@@ -49,7 +49,7 @@ master_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test
 
 doctor_files_blob:
@@ -58,5 +58,5 @@ doctor_files_blob:
   content_type: application/pdf
   metadata: '{"identified":true,"analyzed":true}'
   byte_size: 19333
-  checksum: 2800ec8c99c60f5b15520beac9939a46
+  checksum: KADsjJnGD1sVUgvqyZOaRg==
   service_name: test


### PR DESCRIPTION
Why are these changes being introduced:

* It is important that we validate the files we publish are the same as
  the files we intended to publish. DSpace is already providing DSS with
  checksums that DSS provides to ETD. This just implements validating
  the checksums that DSpace sends back with the checksums ETD already
  stores as part of ActiveStorage.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-523

How does this address that need:

* Validates that checksums coming back from DSS are valid for the Thesis
  being published.
* Sets theses to error state, logs errors, and alerts stakeholders if
  errors are detected so they can resolve them manually

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
