### PR TITLE
Update SQS config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ We use AWS SQS queues to publish theses to DSpace and read data about published 
 
 `SQS_INPUT_QUEUE_URL` - The URL of the SQS input queue used for publication to DSpace.
 `SQS_OUTPUT_QUEUE_NAME` - The name of the SQS output queue. This is used to build the SQS message attributes.
+`SQS_OUTPUT_QUEUE_URL` - The URL of the SQS output queue used to read the results from a publication run.
 
 `SQS_RESULT_MAX_MESSAGES`: Configures the :max_number_of_messages arg of the AWS poll method, which specifies how
 many messages to receive with each polling attempt. Defaults to 10 if unset.


### PR DESCRIPTION
#### Why these changes are being introduced:

The SQS configuration section of the readme does not include the
required field of `SQS_OUTPUT_QUEUE_URL`.

#### Relevant ticket(s):

None.

#### How this addresses that need:

This adds the missing info to the readme.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
