### PR TITLE
Provides a rake task to publish a single thesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,20 @@ Example usage:
 - DSS runs (as of this writing that is a manual process documented in the
   [DSS repo](https://github.com/MITLibraries/dspace-submission-service#run-stage))
 - ETD processes output queue to update records and send email to stakeholders with summary data and list
-  of any error records (as of now this is a manual process, but can be triggered via rake task using the
-  Heroku run command such as `heroku run rails dss:process_output_queue --app TARGET-HEROKU-APP`)
+  of any error records. As of now this is a manual process, but can be triggered via rake task using the
+  Heroku run command such as:
+
+  ```shell
+  heroku run rails dss:process_output_queue --app TARGET-HEROKU-APP
+  ```
+
+## Publishing a single thesis
+
+You can publish a single thesis that is already in `Publication review` status by passing the `thesis_id` to a rake task like:
+
+```shell
+heroku run rails dss:publish_thesis_by_id[THESIS_ID] --app TARGET-HEROKU-APP
+```
 
 ## Validation of thesis record
 

--- a/lib/tasks/dss.rake
+++ b/lib/tasks/dss.rake
@@ -3,4 +3,21 @@ namespace :dss do
   task process_output_queue: :environment do
     DspacePublicationResultsJob.perform_now
   end
+
+  desc 'Publishes a single thesis to DSS'
+  task :publish_thesis_by_id, [:thesis_id] => :environment do |_t, args|
+    if args.thesis_id
+      Rails.logger.info("Beginning manual publishing of thesis #{args.thesis_id}")
+      thesis = Thesis.find(args.thesis_id)
+
+      # Our publication job expects to be only sent theses that are ready to be published so we need to check here
+      if thesis.publication_status == 'Publication review'
+        DspacePublicationJob.perform_now(thesis)
+      else
+        Rails.logger.info("Thesis status of #{thesis.publication_status} is not publishable.")
+      end
+    else
+      Rails.logger.info('No thesis ID provided')
+    end
+  end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Publishing a full batch without being able to test a single
  thesis is inherently risky and should be avoided.
* There may also be cases where we want to publish a single thesis a bit
  early and this would support that.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-535

How does this address that need:

* Provides a rake task that can be run through the Heroku console to
  publish a single already publishable thesis

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
