### PR TITLE
Add license URL to theses with no-CC license

### DIFF
--- a/app/models/dspace_metadata.rb
+++ b/app/models/dspace_metadata.rb
@@ -78,7 +78,7 @@ class DspaceMetadata
 
       # Theoretically both license and copyright URLs are required for publication, but there are no constraints on
       # the models, and we want to future-proof this.
-      @dc['dc.rights.uri'] = thesis_license.url if thesis_license.url
+      @dc['dc.rights.uri'] = thesis_license.evaluate_license_url
     else # author holds copyright and no license provided
       @dc['dc.rights'] = thesis_copyright.statement_dspace
       @dc['dc.rights'] = 'Copyright retained by author(s)'

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -15,11 +15,25 @@ class License < ApplicationRecord
   validates :display_description, presence: true
   validates :license_type, presence: true
 
+  # DSpace publication helper method. When the author holds copyright and provides a no-CC license, the thesis should
+  # have a dc.rights statement of 'In Copyright - Educational Use Permitted'.
   def map_license_type
     if license_type == 'No Creative Commons License'
       'In Copyright - Educational Use Permitted'
     else
       license_type.to_s
+    end
+  end
+
+  # Another DSpace publication helper method. No-CC license theses with a dc.rights statement of 'In Copyright -
+  # Educational Use Permitted' as a result of License#map_license_type should also have the corresponding dc.rights.uri.
+  # We do this here rather than modifying the database to minimize the risk of publishing the wrong rights URL. (I.e.,
+  # if a record has a no-CC license but doesn't meet the condition that would trigger the map_license_type method.)
+  def evaluate_license_url
+    if url
+      url.to_s
+    elsif license_type == 'No Creative Commons License'
+      'https://rightsstatements.org/page/InC-EDU/1.0/'
     end
   end
 end

--- a/test/models/dspace_metadata_test.rb
+++ b/test/models/dspace_metadata_test.rb
@@ -147,7 +147,7 @@ class DspaceMetadataTest < ActiveSupport::TestCase
                                                'value' => 'http://rightsstatements.org/page/InC-EDU/1.0/' })
 
     # No URI
-    t.license = licenses(:nocc)
+    t.license = licenses(:sacrificial)
     t.save
     dss_friendly_thesis(t)
     serialized = DspaceMetadata.new(t).serialize_dss_metadata
@@ -162,7 +162,7 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'https://rightsstatements.org/page/InC/1.0/' })
     assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
-                                               'value' => 'In Copyright - Educational Use Permitted' })
+                                               'value' => 'This will be deleted during testing.' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'U+00A9 MIT' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'http://rightsstatements.org/page/InC-EDU/1.0/' })
@@ -187,6 +187,27 @@ class DspaceMetadataTest < ActiveSupport::TestCase
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'U+00A9 MIT' })
     refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
                                                'value' => 'http://rightsstatements.org/page/InC-EDU/1.0/' })
+
+    # Author holds copyright and provides a license, but license is no-CC
+    t.license = licenses(:nocc)
+    t.save
+    dss_friendly_thesis(t)
+    serialized = DspaceMetadata.new(t).serialize_dss_metadata
+    unserialized = JSON.parse(serialized)
+
+    refute unserialized['metadata'].include?({ 'key' => 'dc.rights',
+                                               'value' => 'Attribution 4.0 International (CC BY 4.0)' })
+    refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'In Copyright' })
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'Copyright retained by author(s)' })
+    refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
+                                               'value' => 'https://creativecommons.org/licenses/by/4.0/' })
+    refute unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
+                                               'value' => 'https://rightsstatements.org/page/InC/1.0/' })
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights',
+                                               'value' => 'In Copyright - Educational Use Permitted' })
+    refute unserialized['metadata'].include?({ 'key' => 'dc.rights', 'value' => 'U+00A9 MIT' })
+    assert unserialized['metadata'].include?({ 'key' => 'dc.rights.uri',
+                                               'value' => 'https://rightsstatements.org/page/InC-EDU/1.0/' })
 
     # Any other copyright holder
     t.copyright = copyrights(:mit)

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -65,4 +65,20 @@ class LicenseTest < ActiveSupport::TestCase
     ccbysa = licenses(:ccbysa)
     assert_equal 'Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)', ccbysa.map_license_type
   end
+
+  test 'license urls are mapped correctly' do
+    # Maps license url for no Creative Commons licenses
+    nocc = licenses(:nocc)
+    assert_equal 'https://rightsstatements.org/page/InC-EDU/1.0/', nocc.evaluate_license_url
+
+    # Returns regular license url otherwise
+    ccby = licenses(:ccby)
+    assert_equal 'https://creativecommons.org/licenses/by/4.0/', ccby.evaluate_license_url
+
+    ccbysa = licenses(:ccbysa)
+    assert_equal 'https://creativecommons.org/licenses/by-sa/4.0/', ccbysa.evaluate_license_url
+
+    nourl = licenses(:sacrificial)
+    assert_nil nourl.evaluate_license_url
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

In the DspaceMetadata class, we map thesis records with author
copyright and no CC license to a dc.rights value of “In Copyright -
Educational Use Permitted.” However, because the no-CC license
record has no URL associated, these thesis records show up in
DSpace with no dc.rights.uri field. We want the dc.rights.uri
field to match the statement, so we need to associate this rights
URL with no-cc license theses: 'In Copyright - Educational Use
Permitted | Rights Statements'.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-534

#### How this addresses that need:

This adds an evaluate_license_url method to the License model that
returns the desired URL if the corresponding license_type is equal
to "No Creative Commons License". This method is then invoked in
DspaceMetadata#copyright, in the condition branch for which the
author holds copyright and provides a license.

#### Side effects of this change:

Hopefully minimal, as this approach will limit the scope of the
effects. (The alternative of modifying the database directly would
affect _all_ records with the no-cc license, which might yield
unexpected results.)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
