### PR TITLE
Create structure for BagIt bags

### DIFF
--- a/app/jobs/dspace_publication_results_job.rb
+++ b/app/jobs/dspace_publication_results_job.rb
@@ -1,4 +1,6 @@
 class DspacePublicationResultsJob < ActiveJob::Base
+  include Checksums
+
   MAX_MESSAGES = ENV.fetch('SQS_RESULT_MAX_MESSAGES', 10)
   WAIT_TIME_SECONDS = ENV.fetch('SQS_RESULT_WAIT_TIME_SECONDS', 10)
   IDLE_TIMEOUT = ENV.fetch('SQS_RESULT_IDLE_TIMEOUT', 0)
@@ -108,10 +110,6 @@ class DspacePublicationResultsJob < ActiveJob::Base
 
   def convert_checksums(thesis)
     thesis.files.map { |f| base64_to_hex(f.checksum) }
-  end
-
-  def base64_to_hex(base64_string)
-    Base64.decode64(base64_string).each_byte.map { |b| format('%02x', b.to_i) }.join
   end
 
   def update_publication_status(thesis, body, results, status)

--- a/app/lib/checksums.rb
+++ b/app/lib/checksums.rb
@@ -1,0 +1,5 @@
+module Checksums
+  def base64_to_hex(base64_string)
+    Base64.decode64(base64_string).each_byte.map { |b| format('%02x', b.to_i) }.join
+  end
+end

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -1,0 +1,44 @@
+# Creates the structure for an individual thesis to be preserved in Archivematica according to the BagIt spec:
+# https://datatracker.ietf.org/doc/html/rfc8493.
+class Bag
+  include Checksums
+
+  def initialize(thesis)
+    @thesis = thesis
+    raise 'This thesis is not baggable' unless baggable?
+  end
+
+  def data
+    file_locations = {}
+    @thesis.files.map { |f| file_locations["data/#{f.filename}"] = f.blob }
+
+    # TODO: build csv, add it to hash
+
+    file_locations
+  end
+
+  def bag_declaration
+    "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8"
+  end
+
+  def manifest
+    @thesis.files.map { |f| "#{base64_to_hex(f.checksum)} data/#{f.filename}" }.join("\n")
+  end
+
+  def bag_name
+    safe_handle = @thesis.dspace_handle.gsub('/', '_')
+    "#{safe_handle}-thesis"
+  end
+
+  # Before we try to bag anything, we need to check if it meets a few conditions. All published theses should have
+  # at least one file attached, no duplicate filenames, and a handle pointing to its DSpace record.
+  # TODO: add a check for metadata csv
+  def baggable?
+    @thesis.files.any? && @thesis.dspace_handle.present? && !duplicate_filenames?
+  end
+
+  def duplicate_filenames?
+    filenames = @thesis.files.map { |f| f.filename.to_s }
+    filenames.select { |f| filenames.count(f) > 1 }.uniq.any?
+  end
+end

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -164,6 +164,7 @@ published:
   metadata_complete: true
   issues_found: false
   publication_status: 'Published'
+  dspace_handle: '1234.5/6789'
 
 june_2018:
   title: MyStringJune

--- a/test/models/bag_test.rb
+++ b/test/models/bag_test.rb
@@ -1,0 +1,106 @@
+require 'test_helper'
+
+class BagTest < ActiveSupport::TestCase
+  include Checksums
+
+  test 'creates bag declaration' do
+    bag = Bag.new(theses(:published))
+    assert_equal "BagIt-Version: 1.0\nTag-File-Character-Encoding: UTF-8", bag.bag_declaration
+  end
+
+  test 'bag declaration does not vary' do
+    another_published_thesis = theses(:publication_review)
+    another_published_thesis.dspace_handle = '1234.5678'
+    another_published_thesis.save
+
+    bag = Bag.new(theses(:published))
+    another_bag = Bag.new(another_published_thesis)
+    assert_equal bag.bag_declaration, another_bag.bag_declaration
+  end
+
+  test 'creates manifest' do
+    thesis = theses(:published)
+    checksum = base64_to_hex(thesis.files.first.checksum)
+    bag = Bag.new(thesis)
+    assert_equal "#{checksum} data/a_pdf.pdf", bag.manifest
+  end
+
+  test 'files in manifest are separated with newlines' do
+    thesis = theses(:published)
+    file = Rails.root.join('test', 'fixtures', 'files', 'registrar_data_small_sample.csv')
+    thesis.files.attach(io: File.open(file), filename: 'registrar_data_small_sample.csv')
+    assert thesis.files.length > 1
+
+    bag = Bag.new(thesis)
+    assert_includes bag.manifest, "\n"
+  end
+
+  test 'creates bag name' do
+    bag = Bag.new(theses(:published))
+    assert_equal '1234.5_6789-thesis', bag.bag_name
+  end
+
+  test 'data generates file location hash' do
+    bag = Bag.new(theses(:published))
+    expected_hash = { 'data/a_pdf.pdf' => theses(:published).files.first.blob }
+    assert_equal expected_hash, bag.data
+  end
+
+  test 'detects duplicate filenames' do
+    # one file
+    thesis = theses(:published)
+    bag = Bag.new(thesis)
+    assert_not bag.duplicate_filenames?
+
+    # multiple files, no duplicate filenames
+    file = Rails.root.join('test', 'fixtures', 'files', 'registrar_data_small_sample.csv')
+    thesis.files.attach(io: File.open(file), filename: 'registrar_data_small_sample.csv')
+    bag = Bag.new(thesis)
+    assert_not bag.duplicate_filenames?
+
+    # multiple files, duplicate filenames
+    file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    thesis.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
+    assert_raises 'This thesis is not baggable' do
+      bag = Bag.new(thesis)
+    end
+  end
+
+  test 'raises exception if the thesis is not baggable' do
+    # baggable thesis (files attached, DSpace handle, no duplicate filenames)
+    thesis = theses(:published)
+    assert_nothing_raised do
+      Bag.new(thesis)
+    end
+
+    # unbaggable thesis (DSpace handle is nil)
+    thesis.dspace_handle = nil
+    thesis.save
+    assert_raises 'This thesis is not baggable' do 
+      Bag.new(thesis)
+    end
+
+    # unbaggable thesis (DSpace handle is an empty string)
+    thesis.dspace_handle = ''
+    thesis.save
+    assert_raises 'This thesis is not baggable' do 
+      Bag.new(thesis)
+    end
+
+    # unbaggable thesis (duplicate filenames)
+    thesis.dspace_handle = '1234/5678'
+    file = Rails.root.join('test', 'fixtures', 'files', 'a_pdf.pdf')
+    thesis.files.attach(io: File.open(file), filename: 'a_pdf.pdf')
+    thesis.save
+    assert_raises 'This thesis is not baggable' do 
+      Bag.new(thesis)
+    end
+
+    # unbaggable thesis (no files attached)
+    thesis.files = nil
+    thesis.save
+    assert_raises 'This thesis is not baggable' do 
+      Bag.new(thesis)
+    end
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need a data structure that creates the foundation for preservation
bags.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-530

#### How this addresses that need:

This creates a Bag model that takes a thesis and generates generates
a bag declaration, manifest and bag name for it. It also includes
a `data` method that returns a hash of filepaths for the bag's data
directory, along with their corresponding blobs.

#### Side effects of this change:

* The base64_to_hex method has been moved to a new Checksums module,
as it is now used both in the publication results job and in this
new model. We may choose to move additional checksum logic to this
module if it is required in multiple places.
* Once ETD-529 is complete, we will need to build the metadata CSV
in this class and add it to the data hash. It's possible this can
all happen within the `data` method, depending on how that ticket
is implemented.
* While this PR meets the need of the ticket conceptually speaking,
additional refinements will likely be required as we determine how
we will create the bags and save them to S3.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
