### PR TITLE
Resolve N+1 queries in pub status report and index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development do
   gem 'listen'
   gem 'rubocop'
   gem 'rubocop-rails'
+  gem 'scout_apm'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scout_apm (5.1.1)
+      parser
     selectize-rails (0.12.6)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
@@ -407,6 +409,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails
+  scout_apm
   selenium-webdriver
   sentry-rails
   sentry-ruby

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ this automatically. It is often nice in development as well.
 `MAINTAINER_EMAIL` - used for `to` field of virus detected emails.
 `THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails. Also the email to which reports are sent.
 `MAINTAINER_EMAIL` - used for `cc` field of report emails.
+`SCOUT_DEV_TRACE` - include this and set it to `true` to enable perfomance monitoring in development. Very useful to
+track down N+1 queries!
 
 ### Production
 

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -43,7 +43,7 @@ class ThesisController < ApplicationController
     @terms = defined_terms Thesis.all
     @publication_statuses = Thesis.all.pluck(:publication_status).uniq.sort
     # Filter relevant theses by selected term from querystring
-    term_filtered = filter_theses_by_term Thesis.all
+    term_filtered = filter_theses_by_term Thesis.all.includes(:degrees, :departments, :users)
     @thesis = filter_theses_by_publication_status term_filtered
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -223,7 +223,7 @@ class Report
     row_data = {}
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
-      row_data[term] = Thesis.where('grad_date = ?', term).map(&:student_contributed?).count(true)
+      row_data[term] = Thesis.where('grad_date = ?', term).includes(:versions).map(&:student_contributed?).count(true)
     end
     {
       label: 'Students contributing',


### PR DESCRIPTION
Why are these changes being introduced:

* There were multiple N+1 queries that when combined with production
  data led to Heroku timeouts

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-550
* https://mitlibraries.atlassian.net/browse/ETD-551

How does this address that need:

* eager load the relevant data to eliminate the N+1 problems

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
