### PR TITLE
Optional settings for test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - name: run tests
         run: |
           bundle exec rails test
+        env:
+          SPEC_REPORTER: true
       - name: Coveralls
         uses: coverallsapp/github-action@v1.0.1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 
 group :test do
   gem 'climate_control'
+  gem 'minitest-reporters'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     annotate (3.1.1)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 14.0)
+    ansi (1.5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.542.0)
@@ -220,6 +221,11 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.15.0)
+    minitest-reporters (1.5.0)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mitlibraries-theme (0.6.0)
       rails (>= 5, < 7)
       sassc (~> 2)
@@ -400,6 +406,7 @@ DEPENDENCIES
   letter_opener
   listen
   lograge
+  minitest-reporters
   mitlibraries-theme
   omniauth-saml
   paper_trail

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ this automatically. It is often nice in development as well.
 `MAINTAINER_EMAIL` - used for `cc` field of report emails.
 `SCOUT_DEV_TRACE` - include this and set it to `true` to enable perfomance monitoring in development. Very useful to
 track down N+1 queries!
+`SKIP_SLOW` - set this to skip tests flagged as slow
+`SPEC_REPORTER` - set this to see a detailed list of tests and times during test runs
 
 ### Production
 

--- a/test/jobs/registrar_import_job_test.rb
+++ b/test/jobs/registrar_import_job_test.rb
@@ -18,6 +18,7 @@ class RegistrarImportJobTest < ActiveJob::TestCase
   end
 
   test 'job runs and returns expected results' do
+    skip "Slow test skipped due to env settings" if ENV.fetch("SKIP_SLOW", false)
     registrar = Registrar.last
     registrar.graduation_list.attach(io: File.open('test/fixtures/files/registrar_data_full_anonymized.csv'),
                                      filename: 'registrar_data_full_anonymized.csv')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,12 @@ SimpleCov.start('rails')
 require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 
+require "minitest/reporters"
+if ENV.fetch("SPEC_REPORTER", false)
+  Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+else
+  Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
+end
 module ActiveSupport
   class TestCase
     # Setup all fixtures in test/fixtures/*.yml for all tests in alpha order.


### PR DESCRIPTION
Why are these changes being introduced:

* we have a few really slow tests that are in isolated pieces of code
  that are useful to have around but are annoying during most
  development

How does this address that need:

* Adds two environment settings that control the test formating and
  whether to skip tests defined as slow (as of this commit, only one is
  flagged as slow)
* This sets Actions to use a more detailed report of all the tests
  instead of the terse default version and allows developers to use the
  version they prefer locally

Document any side effects to this change:

* The defaults do not change for either of these new settings, other
  than in Actions where this commit includes explicitly setting the
  test reporter to use the SpecReporter
* The skipped tests are a bit more obvious when the tests run which might be slightly annoying but is probably not a bad thing so we can either remove them or fix them rather than just skip them forever.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
