### PR TITLE
Create and attach zipped bag to SIP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'sentry-ruby'
 gem 'simple_form'
 gem 'skylight'
 gem 'uglifier'
+gem 'zip_tricks'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
+    zip_tricks (5.6.0)
 
 PLATFORMS
   ruby
@@ -406,6 +407,7 @@ DEPENDENCIES
   timecop
   uglifier
   web-console
+  zip_tricks
 
 RUBY VERSION
    ruby 2.7.2p137

--- a/app/models/submission_information_package_zipper.rb
+++ b/app/models/submission_information_package_zipper.rb
@@ -1,0 +1,53 @@
+# SubmissionInformationPackageZipper creates a temporary zip file containing a bag and then attaches it via
+# ActiveStorage. The `keygen` method creates the `path` to the file in S3. We are relying on S3 Replication to copy
+# the objects from the ETD bucket to the Archivematica bucket. There is no automatic communication back from S3 or
+# Archivematica to ETD, so we treat the successful save of the zip file as `preserved`.
+class SubmissionInformationPackageZipper
+  def initialize(sip)
+    Tempfile.create([sip.bag_name.to_s, '.zip'], binmode: true) do |tmpfile|
+      bagamatic(sip, tmpfile)
+
+      sip.bag.attach(io: File.open(tmpfile),
+                     key: keygen(sip),
+                     filename: "#{sip.bag_name}.zip",
+                     content_type: 'application/zip')
+    end
+  end
+
+  private
+
+  # This key needs to be unique. By default, ActiveStorage generates a UUID, but since we want a file path for our
+  # Archivematica needs, we are generating a key. We handle uniqueness on the `bag_name` side.
+  def keygen(sip)
+    "etdsip/#{sip.thesis.graduation_year}/#{sip.thesis.graduation_month}/#{sip.bag_name}.zip"
+  end
+
+  # bagamatic takes a sip, creates a temporary zip file, and returns that file
+  def bagamatic(sip, tmpfile)
+    ZipTricks::Streamer.open(tmpfile) do |zip|
+      # bag manifest
+      zip.write_deflated_file('manifest-md5.txt') do |sink|
+        sink << sip.manifest
+      end
+
+      # bag_declaration
+      zip.write_deflated_file('bagit.txt') do |sink|
+        sink << sip.bag_declaration
+      end
+
+      # files. metadata.csv is just a string so we have to treat it differently than the binary stored files
+      sip.data.each do |data|
+        if data[1].is_a?(String)
+          zip.write_deflated_file(data[0]) do |sink|
+            sink << data[1]
+          end
+        else
+          zip.write_stored_file(data[0]) do |sink|
+            sink << data[1].download
+          end
+        end
+      end
+    end
+    tmpfile.close
+  end
+end

--- a/test/models/submission_information_package_test.rb
+++ b/test/models/submission_information_package_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: submission_information_packages
+#
+#  id                  :integer          not null, primary key
+#  preserved_at        :datetime
+#  preservation_status :integer          default(0), not null
+#  bag_declaration     :string
+#  bag_name            :string
+#  manifest            :text
+#  metadata            :text
+#  thesis_id           :integer          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
 require 'test_helper'
 
 class SubmissionInformationPackageTest < ActiveSupport::TestCase
@@ -40,7 +55,7 @@ class SubmissionInformationPackageTest < ActiveSupport::TestCase
 
   test 'generates bag name on create' do
     sip = theses(:published).submission_information_packages.create
-    assert_equal '1234.5_6789-thesis', sip.bag_name
+    assert_equal '1234.5_6789-thesis-1', sip.bag_name
   end
 
   test 'generates metadata file on create' do

--- a/test/models/submission_information_package_zipper_test.rb
+++ b/test/models/submission_information_package_zipper_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class SubmissionInformationPackageZipperTest < ActiveSupport::TestCase
+    
+  # because we need to actually use the file it's easier to attache it in the test rather
+  # than use our fixtures as the fixtures oddly don't account for the file actually being
+  # where ActiveStorage expects them to be. We also need this to be a record that looks like
+  # a published record so we'll use the published fixture, remove the fixtured files, and attach
+  # one again.
+  def setup_thesis
+    thesis = theses(:published)
+    thesis.files = []
+    thesis.save
+    file = Rails.root.join('test', 'fixtures', 'files', 'registrar_data_small_sample.csv')
+    thesis.files.attach(io: File.open(file), filename: 'registrar_data_small_sample.csv')
+    thesis
+  end
+
+  test 'sip has an attached zipped bag' do
+    thesis = setup_thesis
+    sip = thesis.submission_information_packages.create
+    SubmissionInformationPackageZipper.new(sip)
+
+    assert_equal("application/zip", thesis.submission_information_packages.first.bag.blob.content_type)
+  end
+
+  # Failure to properly close the handles can allow the zip creation to appear correct but actually be invalid
+  # this is a regression test to ensure we avoid that situation
+  # You can see this test fail by removing the `tmpfile.close` from the end of bagamatic.
+  test 'zip is valid' do
+    thesis = setup_thesis
+    sip = thesis.submission_information_packages.create
+    SubmissionInformationPackageZipper.new(sip)
+
+    blob = thesis.submission_information_packages.last.bag.blob
+    Zip::File.open(blob.service.send(:path_for, blob.key)) do |zipfile|
+      assert_nil(zipfile.find_entry("file_not_in_zipfile.txt"))
+      assert_equal('manifest-md5.txt', zipfile.find_entry("manifest-md5.txt").to_s)
+    end
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* delivery of a bag to s3 is how we are handling preservation

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-531
* https://mitlibraries.atlassian.net/browse/ETD-558

How does this address that need:

* Creates a temporary zip file on disk and streams objects for a thesis
  into that tempfile
* Attaches that tempfile via ActiveStorage to a newly created
  SubmissionInformationPackage

Document any side effects to this change:

* This uses Heroku's filesystem to store the tempfiles to create the zip
which is non-ideal but because this all happens in a single event it
should be safe to do this. The use of a tempfile ensures the file is
deleted when the handle is closed so if this occurred over multiple
requests it would already fail for non-Heroku reaons.

* This streams objects from S3 into Heroku and back as a zip file. This
will cost data transfer in both directions. A more cost effective
solution if this proves expensive would be to move the logic to create
the zip files to AWS and run it in the same region as the S3 buckets
which would remove the transfer costs.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
