### PR TITLE
Enqueue preservation job within publication results job

### DIFF
--- a/app/views/report_mailer/publication_results_email.html.erb
+++ b/app/views/report_mailer/publication_results_email.html.erb
@@ -7,6 +7,7 @@
 <ul>
   <li>Total theses in output queue: <%= @results[:total] %></li>
   <li>Total theses updated: <%= @results[:processed] %></li>
+  <li>Total theses sent to preservation: <%= @results[:preservation_ready] %>
   <li>Errors found: <%= @results[:errors].count %></li>
 </ul>
 


### PR DESCRIPTION
#### Why these changes are being introduced:

We need to automate the preservation workflow.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-560

#### How this addresses that need:

* Collects valid theses from the DspacePublicationResultsJob SQS
queue as `results[:preservation_ready]`.
* Enqueues PreservationSubmissionPrepJob with preservation-ready
theses.
* Reports total number of theses submitted to preservation in
publication results job email.

#### Side effects of this change:

Now that we're tying the preservation workflow into the publication
workflow, there is likely some duplication in our validations.
Specifically, `SubmissionInformationPackage#baggable_theses?` checks
for things that are also validated in DspacePublicationResultsJob.
This may be a useful failsafe rather than potentially harmful
duplication, but I wanted to bring it to the reviewer's attention.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
