### PR TITLE
Show count of preserved theses in publication results email

### DIFF
--- a/app/views/report_mailer/publication_results_email.html.erb
+++ b/app/views/report_mailer/publication_results_email.html.erb
@@ -7,7 +7,7 @@
 <ul>
   <li>Total theses in output queue: <%= @results[:total] %></li>
   <li>Total theses updated: <%= @results[:processed] %></li>
-  <li>Total theses sent to preservation: <%= @results[:preservation_ready] %>
+  <li>Total theses sent to preservation: <%= @results[:preservation_ready].count %>
   <li>Errors found: <%= @results[:errors].count %></li>
 </ul>
 

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -24,7 +24,8 @@ class ReportMailerTest < ActionMailer::TestCase
 
   test 'sends reports for DSpace publication results' do
     ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
-      results = { total: 2, processed: 1, errors: ["Couldn't find Thesis with 'id'=9999999999999"] }
+      results = { total: 2, processed: 1, errors: ["Couldn't find Thesis with 'id'=9999999999999"],
+                  preservation_ready: [] }
       email = ReportMailer.publication_results_email(results)
 
       assert_emails 1 do
@@ -37,6 +38,7 @@ class ReportMailerTest < ActionMailer::TestCase
       assert_match 'Total theses in output queue: 2', email.body.to_s
       assert_match 'Total theses updated: 1', email.body.to_s
       assert_match 'Errors found: 1', email.body.to_s
+      assert_match 'Total theses sent to preservation: 0', email.body.to_s
       assert_match 'Couldn&#39;t find Thesis with &#39;id&#39;=9999999999999', email.body.to_s
     end
   end


### PR DESCRIPTION
#### Why these changes are being introduced:

The publication results email shows the full array of preserved
thesis. It should show the total count instead.

#### Relevant ticket(s):

N/A.

#### How this addresses that need:

This changes the publication results email view to render the count
of preserved theses.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
