### PR TITLE
Adds Administrate Dashboard for SIPs

### DIFF
--- a/app/controllers/admin/submission_information_packages_controller.rb
+++ b/app/controllers/admin/submission_information_packages_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class SubmissionInformationPackagesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/submission_information_package_dashboard.rb
+++ b/app/dashboards/submission_information_package_dashboard.rb
@@ -1,0 +1,87 @@
+require 'administrate/base_dashboard'
+
+class SubmissionInformationPackageDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    thesis: Field::BelongsTo,
+    bag: AttachmentField,
+    id: Field::Number,
+    preserved_at: Field::DateTime,
+    preservation_status: Field::Select.with_options(
+      searchable: false,
+      collection: lambda { |field|
+                    field.resource.class.send(field.attribute.to_s.pluralize).keys
+                  }
+    ),
+    bag_declaration: Field::String,
+    bag_name: Field::String,
+    manifest: Field::Text,
+    metadata: Field::Text,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    bag_name
+    preservation_status
+    preserved_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    thesis
+    bag
+    id
+    preserved_at
+    preservation_status
+    bag_declaration
+    bag_name
+    manifest
+    metadata
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    thesis
+    preserved_at
+    preservation_status
+    bag_declaration
+    bag_name
+    manifest
+    metadata
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how submission information packages are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(submission_information_package)
+  #   "SubmissionInformationPackage ##{submission_information_package.id}"
+  # end
+end

--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -34,6 +34,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     publication_status: Field::Select.with_options(
       collection: Thesis::PUBLICATION_STATUS_OPTIONS
     ),
+    submission_information_packages: Field::HasMany,
     author_note: Field::Text,
     processor_note: Field::Text,
     metadata_complete: Field::Boolean,
@@ -76,6 +77,7 @@ class ThesisDashboard < Administrate::BaseDashboard
     holds
     status
     publication_status
+    submission_information_packages
     dspace_handle
     author_note
     processor_note

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,5 +91,8 @@ class Ability
     cannot 'destroy', :department
     cannot 'destroy', :hold_source
     cannot 'destroy', :license
+    cannot 'destroy', :submission_information_package
+    cannot 'update', :submission_information_package
+    cannot 'edit', :submission_information_package
   end
 end

--- a/app/views/fields/attachment_field/_show.html.erb
+++ b/app/views/fields/attachment_field/_show.html.erb
@@ -1,8 +1,12 @@
-<% field.attachments.each do |attachment| %>
-  <ul>
-    <li>Link: <%= link_to(attachment.filename, url_for(attachment)) %></li>
-    <li>Purpose: <%= attachment.purpose %></li>
-    <li>Description: <%= attachment.description %></li>
-  </ul>
-  <hr />
+<% if field.attachments.kind_of?(ActiveStorage::Attached::One) %>
+  <%= link_to(field.attachments.filename, url_for(field.attachments)) %>
+<% else %>
+  <% field.attachments.each do |attachment| %>
+    <ul>
+      <li>Link: <%= link_to(attachment.filename, url_for(attachment)) %></li>
+      <li>Purpose: <%= attachment.purpose %></li>
+      <li>Description: <%= attachment.description %></li>
+    </ul>
+    <hr />
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     resources :holds
     resources :hold_sources
     resources :licenses
+    resources :submission_information_packages
     resources :submitters
     resources :theses
     resources :transfers

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -155,7 +155,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'empty theses report shows a card' do
     sign_in users(:processor)
     get report_empty_theses_path
-    assert_select '.card-empty-theses span', text: '17 have no attached files', count: 1
+    assert_select '.card-empty-theses span', text: '18 have no attached files', count: 1
   end
 
   test 'empty theses report has links to processing pages' do
@@ -167,7 +167,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'empty theses report allows filtering by term' do
     sign_in users(:processor)
     get report_empty_theses_path
-    assert_select '.card-empty-theses span', text: '17 have no attached files', count: 1
+    assert_select '.card-empty-theses span', text: '18 have no attached files', count: 1
     get report_empty_theses_path, params: { graduation: '2018-09-01' }
     assert_select '.card-empty-theses span', text: '2 have no attached files', count: 1
   end
@@ -224,7 +224,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'term report shows a few fields' do
     sign_in users(:processor)
     get report_term_path
-    assert_select '.card-overall .message', text: '24 thesis records', count: 1
+    assert_select '.card-overall .message', text: '25 thesis records', count: 1
     assert_select '.card-files .message', text: '7 have files attached', count: 1
     assert_select '.card-issues span', text: '1 flagged with issues', count: 1
     assert_select '.card-students-contributing span', text: '0 have had metadata contributed by students', count: 1
@@ -237,7 +237,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
   test 'term report allows filtering' do
     sign_in users(:processor)
     get report_term_path
-    assert_select '.card-overall .message', text: '24 thesis records', count: 1
+    assert_select '.card-overall .message', text: '25 thesis records', count: 1
     get report_term_path, params: { graduation: '2018-09-01' }
     assert_select '.card-overall .message', text: '2 thesis records', count: 1
     assert_response :success

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -45,3 +45,8 @@ doctor_files_attachment:
   record: doctor (Thesis)
   purpose: thesis_pdf
   blob: doctor_files_blob
+
+sip_one_bag_attachment:
+  name: bag
+  record: sip_one (SubmissionInformationPackage)
+  blob: doctor_files_blob

--- a/test/fixtures/submission_information_packages.yml
+++ b/test/fixtures/submission_information_packages.yml
@@ -1,0 +1,49 @@
+sip_one:
+  preserved_at: Master of Fine Arts
+  preservation_status: 0
+  bag_declaration: |-
+    BagIt-Version: 1.0
+    Tag-File-Character-Encoding: UTF-8
+  bag_name: 123456_67890-thesis-1
+  manifest: |-
+    196128f55c62f4c246bed52b07d3ae1c data/registrar.csv
+    3ac6f5cac4e09a6c95ee4004ebe19c51 data/metadata.csv
+  metadata: >-
+    filename,Level_of_DPCommitment,dc.title,dc.date.issued,dc.date.submitted,dc.type,dc.description.abstract,dc.identifier.uri,BitstreamDescription,BitstreamChecksumValue,BitstreamChecksumAlgorithm,dc.publisher,dc.terms.isPartOf,dc.terms.isPartOf,dc.contributor.author,dc.contributor.author,dc.identifier.orcid,dc.identifier.orcid,dc.contributor.advisor,dc.contributor.advisor,dc.description.degree,thesis.degree.name,mit.thesis.degree,dc.description.degree,thesis.degree.name,mit.thesis.degree,dc.contributor.department,dc.contributor.department,dc.rights,dc.rights,dc.rights.uri
+
+    data/registrar.csv,Level 3,On the importance of titles,2022-02,2021-08-13
+    18:22:45 UTC,Thesis,"Lorem ipsum dolor sit amet, consectetur adipiscing
+    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Risus viverra adipiscing at in. Scelerisque viverra mauris in aliquam sem
+    fringilla. Tellus orci ac auctor augue. Dui sapien eget mi proin sed. Vel
+    fringilla est ullamcorper eget nulla. Tristique et egestas quis ipsum
+    suspendisse. Nibh ipsum consequat nisl vel pretium lectus quam id. Enim
+    neque volutpat ac tincidunt. Vestibulum rhoncus est pellentesque elit
+    ullamcorper dignissim cras tincidunt lobortis. Id semper risus in hendrerit
+    gravida rutrum quisque non tellus. At volutpat diam ut venenatis tellus in
+    metus vulputate. Urna neque viverra justo nec ultrices dui sapien eget mi.
+    Tellus pellentesque eu tincidunt tortor aliquam. Pharetra vel turpis nunc
+    eget lorem dolor sed viverra ipsum. Sit amet aliquam id diam maecenas
+    ultricies mi eget mauris. Vulputate enim nulla aliquet porttitor. Egestas
+    tellus rutrum tellus pellentesque. In hac habitasse platea dictumst
+    vestibulum rhoncus est. Volutpat sed cras ornare arcu dui. Dui nunc mattis
+    enim ut tellus elementum. Donec massa sapien faucibus et molestie ac. Metus
+    aliquam eleifend mi in nulla posuere sollicitudin aliquam ultrices. Sem et
+    tortor consequat id porta nibh. Blandit massa enim nec dui. Pellentesque
+    adipiscing commodo elit at imperdiet dui accumsan. Egestas erat imperdiet
+    sed euismod nisi porta lorem mollis aliquam. Condimentum id venenatis a
+    condimentum vitae sapien pellentesque habitant morbi. Molestie a iaculis at
+    erat pellentesque. Tellus elementum sagittis vitae et leo duis ut.
+    Suspendisse in est ante in nibh mauris cursus mattis molestie. Consectetur
+    purus ut faucibus pulvinar elementum integer. Quis lectus nulla at volutpat
+    diam ut venenatis tellus in. Volutpat commodo sed egestas
+    egestas.",123456/67890,Thesis
+    PDF,196128f55c62f4c246bed52b07d3ae1c,MD5,Massachusetts Institute of
+    Technology,AIC#BEH_theses,AIC#Course_16_theses,"Adams, Samuel
+    Alexandra","Lastname, Firstname","","","Superlast,
+    Superfirst","Anothersuperlast, Anothersuperfirst",Env.E.,Environmental
+    Engineer,Engineer,S.B.,Bachelor of Science in Music and Theater
+    Arts,Bachelor,asdf,Massachusetts Institute of Technology. Department of
+    Aeronautics and Astronautics,In Copyright - Educational Use
+    Permitted,Copyright MIT,http://rightsstatements.org/page/InC-EDU/1.0/
+  thesis: published_with_sip

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -167,6 +167,18 @@ published:
   dspace_handle: '1234.5/6789'
   copyright: mit
 
+published_with_sip:
+  title: MyPublishedThesis
+  abstract: "A thesis that has been published to DSpace@MIT"
+  grad_date: 2021-06-01
+  departments: [one]
+  degrees: [one]
+  files_complete: true
+  metadata_complete: true
+  issues_found: false
+  publication_status: 'Published'
+  dspace_handle: '1234.5/6789'
+  copyright: mit
 
 june_2018:
   title: MyStringJune

--- a/test/integration/admin/admin_submission_information_package_test.rb
+++ b/test/integration/admin/admin_submission_information_package_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+class AdminSubmissionInformationPackageTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'non-admin users cannot access sip dashboard' do
+    mock_auth(users(:basic))
+    get '/admin/submission_information_packages'
+    assert_response :redirect
+
+    mock_auth(users(:transfer_submitter))
+    get '/admin/submission_information_packages'
+    assert_response :redirect
+  end
+
+  test 'thesis admins can access sip dashboard' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/submission_information_packages'
+    assert_response :success
+  end
+
+  test 'users with admin rights can access sip dashboard' do
+    mock_auth(users(:admin))
+    get '/admin/submission_information_packages'
+    assert_response :success
+  end
+
+  test 'processors can access sip dashboard' do
+    mock_auth(users(:processor))
+    get '/admin/submission_information_packages'
+    assert_response :success
+  end
+
+  test 'thesis admins can view sip details through dashboard' do
+    mock_auth(users(:thesis_admin))
+    get "/admin/submission_information_packages/#{submission_information_packages(:sip_one).id}"
+    assert_response :success
+  end
+
+  test 'processors can view sip details through dashboard' do
+    mock_auth(users(:processor))
+    get "/admin/submission_information_packages/#{submission_information_packages(:sip_one).id}"
+    assert_response :success
+  end
+
+  test 'non-admin users cannot view sip details through dashboard' do
+    mock_auth(users(:basic))
+    get "/admin/submission_information_packages/#{submission_information_packages(:sip_one).id}"
+    assert_response :redirect
+
+    mock_auth(users(:transfer_submitter))
+    get "/admin/submission_information_packages/#{submission_information_packages(:sip_one).id}"
+    assert_response :redirect
+  end
+
+  test 'thesis admins cannot delete sips' do
+    sip = submission_information_packages(:sip_one)
+    mock_auth(users(:thesis_admin))
+    delete admin_submission_information_package_path(sip)
+    assert_response :redirect
+    follow_redirect!
+    assert_equal '/', path
+    assert @response.body.include? 'Not authorized.'
+  end
+
+  test 'processors cannot delete sips' do
+    sip = submission_information_packages(:sip_one)
+    mock_auth(users(:processor))
+    delete admin_submission_information_package_path(sip)
+    assert_response :redirect
+    follow_redirect!
+    assert_equal '/', path
+    assert @response.body.include? 'Not authorized.'
+  end
+
+  test 'thesis admins cannot edit sips' do
+    sip = submission_information_packages(:sip_one)
+    mock_auth(users(:thesis_admin))
+
+    patch admin_submission_information_package_path(sip),
+      params: { submission_information_package: { bag_name: "hallo" } }
+    follow_redirect!
+    assert_equal '/', path
+    assert @response.body.include? 'Not authorized.'
+  end
+
+  test 'processors cannot edit sips' do
+    sip = submission_information_packages(:sip_one)
+    mock_auth(users(:processor))
+
+    patch admin_submission_information_package_path(sip),
+      params: { submission_information_package: { bag_name: "hallo" } }
+    follow_redirect!
+    assert_equal '/', path
+    assert @response.body.include? 'Not authorized.'
+  end
+end


### PR DESCRIPTION
Why are these changes being introduced:

* Being able to see the SIPs for a Thesis as well as all of the SIPs
  will be useful to better understand the state of Preservation

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-562

How does this address that need:

* Adds link to SIP(s) from the Thesis show pages
* Adds a new SIP Dashboard to view all SIPs

Document any side effects to this change:

* Some tests around reports got updated with a new value to account for
  a change to fixtures
* Our custom field for ActiveStorage in Administrate got a bit weirder
  to handle the difference between HasOne and HasMany ActiveStorage
  relationships

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
