### PR TITLE
Adds Thesis scopes for sips

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -95,12 +95,18 @@ class Thesis < ApplicationRecord
   before_save :combine_graduation_date, :update_status
   after_find :split_graduation_date
 
-  # scope :name_asc, lambda {
-  #  includes(:user).order('users.surname, users.given_name')
-  # }
   scope :date_asc, -> { order('grad_date') }
   scope :in_review, -> { where('publication_status = ?', 'Publication review') }
   scope :without_files, -> { where.missing(:files_attachments) }
+  scope :without_sips, lambda {
+                         includes(:submission_information_packages)
+                           .where(submission_information_packages: { thesis_id: nil })
+                       }
+  scope :with_sips, lambda {
+                      includes(:submission_information_packages)
+                        .where.not(submission_information_packages: { thesis_id: nil })
+                    }
+  scope :published_without_sips, -> { where(publication_status: 'Published').without_sips }
   scope :valid_months_only, lambda {
     select { |t| VALID_MONTHS.include? t.grad_date.strftime('%B') }
   }

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -1127,4 +1127,47 @@ class ThesisTest < ActiveSupport::TestCase
     assert_equal 1, thesis.dspace_metadata.attachments.length
     assert thesis.valid?
   end
+
+  test 'without_sips scope accurately returns only theses without sips' do
+    orig_count = Thesis.without_sips.count
+    thesis = theses(:published)
+    assert_includes Thesis.without_sips, thesis
+
+    thesis.submission_information_packages.create
+    assert_equal orig_count-1, Thesis.without_sips.count
+    assert_not_includes Thesis.without_sips, thesis
+  end
+
+  test 'with_sips scope accurately returns only theses with sips' do
+    orig_count = Thesis.with_sips.count
+    thesis = theses(:published)
+    assert_not_includes Thesis.with_sips, thesis
+
+    thesis.submission_information_packages.create
+    assert_equal orig_count+1, Thesis.with_sips.count
+    assert_includes Thesis.with_sips, thesis
+  end
+
+  test 'published_without_sips scope accurately returns only published without sips' do
+    orig_count = Thesis.published_without_sips.count
+
+    # published status no sip
+    thesis = theses(:published)
+    assert_includes Thesis.published_without_sips, thesis
+
+    # published status has sip
+    thesis.submission_information_packages.create
+    assert_equal orig_count-1, Thesis.published_without_sips.count
+    assert_not_includes Thesis.published_without_sips, thesis
+
+    # no published status has sip
+    thesis.publication_status = 'Publication error'
+    thesis.save
+    assert_not_includes Thesis.published_without_sips, thesis
+
+    # no published status no sip
+    thesis.submission_information_packages.first.destroy
+    thesis.save
+    assert_not_includes Thesis.published_without_sips, thesis
+  end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* Initially, we need a way to identify Theses that we have published
  before we had Preservation was completed and this should make it easy
  to do that
* Longer term, this feels like a set of queries that might be useful in
  reports to make it more visible if anything didn't get preserved
  during the publication process

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-563

How does this address that need:

* adds scopes and tests to confirm they are accurate

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
