### PR TITLE
Implement MARC export workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,15 @@ Assigning roles and the `Admin` flag is done in the web UI.
 
 ## Sending Receipt Email in Production
 
-`SMTP_ADDRESS`
-`SMTP_PASSWORD`
-`SMTP_PORT`
-`SMTP_USER`
+`SMTP_ADDRESS`, `SMTP_PASSWORD`, `SMTP_PORT`, `SMTP_USER` - all required to send mail.
+
 `THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails. Also the email to which reports are sent.
+
 `MAINTAINER_EMAIL` - used for `cc` field of report emails.
+
+`METADATA_ADMIN_EMAIL` - used for `to` field of MARC export report emails (see
+[Metadata export workflow](#metadata-export-workflow)).
+
 `DISABLE_ALL_EMAIL` - emails won't be sent unless this is set to `false`.
 
 In development, emails are written to a file in `tmp`. In testing, they are
@@ -280,6 +283,12 @@ You can manually send a published thesis to preservation by passing the thesis I
 ```shell
 heroku run rails preservation:preserve_thesis_by_id[THESIS_ID] --app TARGET-HEROKU-APP
 ```
+
+## Metadata export workflow
+
+The publishing workflow will automatically trigger a MARC export of all the published theses  in the results queue. The
+generated marcxml file is zipped, attached to an email, and sent to the cataloging team (see [Sending Receipt Email in
+Production](#sending-receipt-email-in-production)).
 
 ## Validation of thesis record
 

--- a/app/jobs/marc_export_job.rb
+++ b/app/jobs/marc_export_job.rb
@@ -1,0 +1,20 @@
+class MarcExportJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(theses)
+    marc_filename = "#{filename}.xml"
+    zip_filename = "#{filename}.zip"
+    begin
+      zip_file = MarcBatch.new(theses, marc_filename, zip_filename).build
+      BatchMailer.marc_batch_email(zip_filename, zip_file, theses).deliver_now
+    ensure
+      zip_file.close
+    end
+  end
+
+  private
+
+  def filename
+    "marc_#{DateTime.now.utc.strftime('%y%m%d_%H_%M')}"
+  end
+end

--- a/app/mailers/batch_mailer.rb
+++ b/app/mailers/batch_mailer.rb
@@ -1,0 +1,12 @@
+class BatchMailer < ApplicationMailer
+  def marc_batch_email(marc_zip_filename, marc_zip_file, theses)
+    return unless ENV.fetch('DISABLE_ALL_EMAIL', 'true') == 'false' # allows PR builds to disable emails
+
+    @theses = theses
+    attachments[marc_zip_filename.to_s] = File.binread(marc_zip_file)
+    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+         to: ENV['METADATA_ADMIN_EMAIL'],
+         cc: ENV['MAINTAINER_EMAIL'],
+         subject: 'ETD MARC batch export')
+  end
+end

--- a/app/models/marc_batch.rb
+++ b/app/models/marc_batch.rb
@@ -1,0 +1,33 @@
+class MarcBatch
+  def initialize(theses, marc_filename, zip_filename)
+    @theses = theses
+    @marc_filename = marc_filename
+    @zip_filename = zip_filename
+  end
+
+  def build
+    marc_file = Tempfile.new(@marc_filename)
+    zip_file = Tempfile.new(@zip_filename, binmode: true)
+    create_marc_file(marc_file)
+    zip_marc_file(zip_file, marc_file)
+    zip_file
+  end
+
+  private
+
+  def create_marc_file(marc_file)
+    writer = MARC::XMLWriter.new(marc_file.path)
+    @theses.each do |thesis|
+      record = Marc.new(thesis)
+      writer.write(record.record)
+    end
+    writer.close
+  end
+
+  def zip_marc_file(zip_file, marc_file)
+    Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
+      zip.add(@marc_filename, marc_file.path)
+    end
+    marc_file.close
+  end
+end

--- a/app/views/batch_mailer/marc_batch_email.html.erb
+++ b/app/views/batch_mailer/marc_batch_email.html.erb
@@ -1,0 +1,6 @@
+<p>Hello,</p>
+
+<p>Attached is a metadata export of <%= @theses.count %> theses generated on
+<%= Date.current.strftime('%A, %B %d, %Y') %> at <%= Time.now.strftime('%r %Z') %>.
+
+<p>Please contact the ETD team at <%= ENV['THESIS_ADMIN_EMAIL'] %> with any questions.</p>

--- a/app/views/report_mailer/publication_results_email.html.erb
+++ b/app/views/report_mailer/publication_results_email.html.erb
@@ -8,6 +8,7 @@
   <li>Total theses in output queue: <%= @results[:total] %></li>
   <li>Total theses updated: <%= @results[:processed] %></li>
   <li>Total theses sent to preservation: <%= @results[:preservation_ready].count %>
+  <li>Total theses exported as MARC: <%= @results[:marc_exports].count %>
   <li>Errors found: <%= @results[:errors].count %></li>
 </ul>
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
   ENV['SP_PRIVATE_KEY'] = ''
   ENV['SP_CERTIFICATE'] = ''
   ENV['THESIS_ADMIN_EMAIL'] = 'test@example.com'
+  ENV['METADATA_ADMIN_EMAIL'] = 'test-metadata@example.com'
   ENV['SQS_INPUT_QUEUE_URL'] = 'http://localhost:5000/123456789012/etd-test-input'
   ENV['SQS_OUTPUT_QUEUE_NAME'] = 'etd-test-output'
   ENV['SQS_OUTPUT_QUEUE_URL'] = 'http://localhost:5000/123456789012/etd-test-output'

--- a/test/jobs/marc_export_job_test.rb
+++ b/test/jobs/marc_export_job_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class MarcExportJobTest < ActiveJob::TestCase
+  include ActionMailer::TestHelper
+
+  test 'sends batch email' do
+    ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
+      theses = [theses(:one)]
+      assert_emails 1 do
+        MarcExportJob.perform_now(theses)
+      end
+    end
+  end
+
+  test 'sent email attachments use expected filename format' do
+    ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
+      theses = [theses(:one)]
+      Timecop.freeze(Time.utc(2022, 2, 14, 17, 10, 0)) do
+        email = MarcExportJob.perform_now(theses)
+        assert_equal 'marc_220214_17_10.zip', email.attachments.first.filename
+      end
+    end
+  end
+end

--- a/test/mailers/batch_mailer_test.rb
+++ b/test/mailers/batch_mailer_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class BatchMailerTest < ActionMailer::TestCase
+  test 'sends emails for MARC batch exports' do
+    ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
+      theses = [theses(:one), theses(:two)]
+      zip_file =  MarcBatch.new(theses, 'marc.xml', 'marc.zip').build
+      email = BatchMailer.marc_batch_email('marc.zip', zip_file, theses)
+
+      # Send the email, then test that it got queued
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      # Make sure it was sent to the right person with the expected attachment.
+      assert_equal ['test@example.com'], email.from
+      assert_equal ['test-metadata@example.com'], email.to
+      assert_equal 'ETD MARC batch export', email.subject
+      assert_equal 'marc.zip', email.attachments.first.filename
+      assert_includes '2 theses', email.body.to_s
+    end
+  end
+
+  test 'zip file is attached with correct mimetype' do
+    ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
+      theses = [theses(:one), theses(:two)]
+      zip_file =  MarcBatch.new(theses, 'marc.xml', 'marc.zip').build
+      email = BatchMailer.marc_batch_email('marc.zip', zip_file, theses)
+      attachment = email.attachments['marc.zip']
+      assert_equal 'application/zip; filename=marc.zip', attachment.content_type
+    end
+  end
+end

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -25,7 +25,7 @@ class ReportMailerTest < ActionMailer::TestCase
   test 'sends reports for DSpace publication results' do
     ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
       results = { total: 2, processed: 1, errors: ["Couldn't find Thesis with 'id'=9999999999999"],
-                  preservation_ready: [] }
+                  preservation_ready: [], marc_exports: [theses(:one)] }
       email = ReportMailer.publication_results_email(results)
 
       assert_emails 1 do
@@ -39,6 +39,7 @@ class ReportMailerTest < ActionMailer::TestCase
       assert_match 'Total theses updated: 1', email.body.to_s
       assert_match 'Errors found: 1', email.body.to_s
       assert_match 'Total theses sent to preservation: 0', email.body.to_s
+      assert_match 'Total theses exported as MARC: 1', email.body.to_s
       assert_match 'Couldn&#39;t find Thesis with &#39;id&#39;=9999999999999', email.body.to_s
     end
   end

--- a/test/models/marc_batch_test.rb
+++ b/test/models/marc_batch_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class MarcBatchTest < ActiveSupport::TestCase
+  test 'builds zip file' do
+    zip_file = MarcBatch.new([theses(:one)], 'marc.xml', 'marc.zip').build
+    assert File.exists?(zip_file)
+  end
+
+  test 'zip file contains only marcxml file' do
+    zip_file = MarcBatch.new([theses(:one)], 'marc.xml', 'marc.zip').build
+    Zip::File.open(zip_file) do |file|
+      assert_nil file.find_entry("not_marc.xml")
+      assert_equal 'marc.xml', file.find_entry('marc.xml').to_s
+    end
+    zip_file.close
+  end
+
+  test 'marc file is explicitly closed after zip file is built' do
+    batch = MarcBatch.new([theses(:one)], 'marc.xml', 'marc.zip')
+    zip_file = batch.build
+    marc_tempfile_path = batch.instance_variable_get(:@marc_filename)    
+    assert_not File.exists?(marc_tempfile_path)
+  end
+end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need an automated way to export published records as MARC and
send them to the cataloging team.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-564

#### How this addresses that need:

* Adds a MarcBatch model that builds a compressed marcxml
file from an array of theses.
* Adds a BatchMailer that attaches a compressed marcxml file
built by the MarcBatch model and sends it to the cataloging
team.
* Adds a MarcExportJob that takes an array of theses, builds
a marcxml file for them, and sends a BatchMailer email.
* Updates DspacePublicationResultsJob to run MarcExportJob for
all published theses in the results queue.

#### Side effects of this change:

* MarcExportJob doesn't employ the 'prep job' pattern that we use
elsewhere. It didn't seem necessary here to differentiate between
processing a single thesis versus an array, since I couldn't
figure a use case for exporting a single thesis. If I'm wrong
about that, this can easily be refactored.
* The tempfiles used to build the compressed marcxml file are
explicitly unlinked in the MarcBatch class, so we pass binary data
to the mailer instead. This felt safer than relying on garbage
collection, but it's a bit less direct than reading the tempfile
in the mailer.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod **(with engx email as placeholder value)**
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
