### PR TITLE
Update location of metadata CSV in SIPs

### DIFF
--- a/app/models/submission_information_package.rb
+++ b/app/models/submission_information_package.rb
@@ -35,7 +35,7 @@ class SubmissionInformationPackage < ApplicationRecord
     file_locations = {}
     thesis.files.map { |f| file_locations["data/#{f.filename}"] = f.blob }
 
-    file_locations['data/metadata.csv'] = metadata
+    file_locations['data/metadata/metadata.csv'] = metadata
 
     file_locations
   end
@@ -55,7 +55,7 @@ class SubmissionInformationPackage < ApplicationRecord
     new_manifest = thesis.files.map { |f| "#{base64_to_hex(f.checksum)} data/#{f.filename}" }
 
     # metadata file
-    new_manifest << "#{ArchivematicaMetadata.new(thesis).md5} data/metadata.csv"
+    new_manifest << "#{ArchivematicaMetadata.new(thesis).md5} data/metadata/metadata.csv"
 
     self.manifest = new_manifest.join("\n")
   end

--- a/test/models/submission_information_package_test.rb
+++ b/test/models/submission_information_package_test.rb
@@ -38,7 +38,7 @@ class SubmissionInformationPackageTest < ActiveSupport::TestCase
     thesis = theses(:published)
     checksums = []
     checksums << "#{base64_to_hex(thesis.files.first.checksum)} data/a_pdf.pdf"
-    checksums << "#{ArchivematicaMetadata.new(thesis).md5} data/metadata.csv"
+    checksums << "#{ArchivematicaMetadata.new(thesis).md5} data/metadata/metadata.csv"
     sip = thesis.submission_information_packages.create
     assert_equal checksums.join("\n"), sip.manifest
   end
@@ -102,7 +102,7 @@ class SubmissionInformationPackageTest < ActiveSupport::TestCase
     t = theses(:published)
     sip = t.submission_information_packages.create
     expected = ArchivematicaMetadata.new(t).to_csv
-    assert_equal expected, sip.data['data/metadata.csv']
+    assert_equal expected, sip.data['data/metadata/metadata.csv']
   end
 
   test 'a SIP is valid if its thesis is baggable' do


### PR DESCRIPTION
#### Why these changes are being introduced:

The preservation package spec requires that metadata files be
stored as `data/metadata/metadata.csv`, but they are currently
stored as `data/metadata.csv.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-564

#### How this addresses that need:

This fixes the location of the metadata CSV in the
SubmissionInformationPackage model.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
