### PR TITLE
Report for authors without confirmed graduation

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -7,6 +7,17 @@ class ReportController < ApplicationController
   include ThesisHelper
   include HoldHelper
 
+  def authors_not_graduated
+    term = params[:graduation] ? params[:graduation].to_s : 'all'
+    @this_term = 'all terms'
+    @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
+    report = Report.new
+    theses = Thesis.with_files.includes(authors: :user).includes(:departments)
+    @terms = report.extract_terms theses
+    subset = filter_theses_by_term theses
+    @list = report.list_authors_not_graduated subset
+  end
+
   def empty_theses
     term = params[:graduation] ? params[:graduation].to_s : 'all'
     @this_term = 'all terms'

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -61,6 +61,7 @@ class Ability
     can :expired_holds, Report
     can :holds_by_source, Report
     can :student_submitted_theses, Report
+    can :authors_not_graduated, Report
 
     can %i[read update], Thesis
     can :annotate, Thesis

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -98,6 +98,7 @@ class Thesis < ApplicationRecord
   scope :date_asc, -> { order('grad_date') }
   scope :in_review, -> { where('publication_status = ?', 'Publication review') }
   scope :without_files, -> { where.missing(:files_attachments) }
+  scope :with_files, -> { joins(:files_attachments) }
   scope :without_sips, lambda {
                          includes(:submission_information_packages)
                            .where(submission_information_packages: { thesis_id: nil })

--- a/app/views/report/_not_graduated.html.erb
+++ b/app/views/report/_not_graduated.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= link_to title_helper(not_graduated), edit_admin_thesis_path(not_graduated.id) %></td>
+  <td>
+    <% not_graduated.authors.each do |author| %>
+      <%= link_to author.user.display_name, edit_admin_author_path(author.id) %><br>
+    <% end %>
+  </td>
+  <td>
+    <% not_graduated.departments.each do |dept| %>
+      <%= dept.name_dw %><br>
+    <% end %>
+  </td>
+  <td><%= not_graduated.graduation_month[...3] %> <%= not_graduated.graduation_year%></td>
+</tr>

--- a/app/views/report/_not_graduated_empty.html.erb
+++ b/app/views/report/_not_graduated_empty.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan="4">All thesis authors for the given term have confirmed graduation.</td>
+</tr>

--- a/app/views/report/authors_not_graduated.html.erb
+++ b/app/views/report/authors_not_graduated.html.erb
@@ -1,0 +1,34 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Authors without confirmed graduation for <%= @this_term %></h3>
+
+    <div class="alert alert-banner">
+      <p><i class="fa fa-info-circle fa-lg"></i> Note: This report only includes theses with files attached.</p>
+  </div>
+
+
+    <%= render 'shared/defined_terms_filter' %>
+
+    <table class="table" summary="This table presents a list of theses with metadata submitted by students from whom we have not confirmed graduation."
+     title="Not graduated metadata">
+      <thead>
+        <tr>
+          <th scope="col">Title</th>
+          <th scope="col">Author(s)</th>
+          <th scope="col">Department(s)</th>
+          <th scope="col">Degree date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'not_graduated', collection: @list) || render('not_graduated_empty') %>
+      </tbody>
+    </table>
+
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -14,6 +14,9 @@
       <% if can?(:student_submitted_thesis, Report) %>
         <li><%= link_to("Theses submitted by students", report_student_submitted_theses_path) %></li>
       <% end %>
+      <% if can?(:authors_not_graduated, Report) %>
+        <li><%= link_to("Thesis authors without confirmed graduation", report_authors_not_graduated_path) %></li>
+      <% end %>
       <% if can?(:publication_statuses, Thesis) %>
         <li><%= link_to("Theses by publication status", thesis_publication_statuses_path) %></li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   end
 
   get 'report', to: 'report#index', as: 'report_index'
+  get 'report/authors_not_graduated', to: 'report#authors_not_graduated', as: 'report_authors_not_graduated'
   get 'report/empty_theses', to: 'report#empty_theses', as: 'report_empty_theses'
   get 'report/expired_holds', to: 'report#expired_holds', as: 'report_expired_holds'
   get 'report/files', to: 'report#files', as: 'report_files'


### PR DESCRIPTION
#### Why these changes are being introduced:

We need to identify thesis records that have files attached and
one or more authors without confirmed graduation

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-429

#### How this addresses that need:

This adds an 'authors not graduated' report that is term-filterable.

Side effects of this change:

N/A.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
