### PR TITLE
Add holds by source report

### DIFF
--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -5,6 +5,7 @@ class ReportController < ApplicationController
   protect_from_forgery with: :exception
 
   include ThesisHelper
+  include HoldHelper
 
   def empty_theses
     term = params[:graduation] ? params[:graduation].to_s : 'all'
@@ -47,6 +48,17 @@ class ReportController < ApplicationController
     @terms = report.extract_terms theses
     subset = filter_theses_by_term theses
     @list = report.list_student_submitted_metadata subset
+  end
+
+  def holds_by_source
+    term = params[:graduation] ? params[:graduation].to_s : 'all'
+    @this_term = 'all terms'
+    @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
+    holds = Hold.all.includes(:thesis).includes(:hold_source).includes(thesis: :users).includes(thesis: :authors)
+    @terms = Report.new.extract_terms holds
+    @hold_sources = HoldSource.pluck(:source).uniq.sort
+    term_filtered = filter_holds_by_term holds
+    @list = filter_holds_by_source term_filtered
   end
 
   def index

--- a/app/helpers/hold_helper.rb
+++ b/app/helpers/hold_helper.rb
@@ -4,12 +4,28 @@ module HoldHelper
     field_value = 'n/a' if field_value.nil?
 
     # For foreign key fields, return a link to the record
-    if field_name == 'thesis_id' && thesis = Thesis.find_by(id: field_value)
+    if field_name == 'thesis_id' && (thesis = Thesis.find_by(id: field_value))
       field_value = link_to thesis.title, admin_thesis_path(field_value)
-    elsif field_name == 'hold_source_id' && hold_source = HoldSource.find_by(id: field_value)
+    elsif field_name == 'hold_source_id' && (hold_source = HoldSource.find_by(id: field_value))
       field_value = link_to hold_source.source, admin_hold_source_path(field_value)
     end
 
     field_value
+  end
+
+  def filter_holds_by_term(holds)
+    if params[:graduation] && params[:graduation] != 'all'
+      return holds.where('theses.grad_date = ?', params[:graduation]).references(:thesis)
+    end
+
+    holds
+  end
+
+  def filter_holds_by_source(holds)
+    if params[:hold_source] && params[:hold_source] != 'all'
+      return holds.where('hold_sources.source = ?', params[:hold_source]).references(:thesis)
+    end
+
+    holds
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,7 @@ class Ability
     can :term, Report
     can :empty_theses, Report
     can :expired_holds, Report
+    can :holds_by_source, Report
     can :student_submitted_theses, Report
 
     can %i[read update], Thesis

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -290,8 +290,14 @@ class Report
     result
   end
 
+  # This assumes a couple of things: first, that all items in a collection should be instances of the same model, and
+  # second, that the model of any non-thesis collections belongs_to the Thesis model.
   def extract_terms(collection)
-    collection.pluck(:grad_date).uniq.sort
+    if collection.first.is_a? Thesis
+      collection.pluck(:grad_date).uniq.sort
+    else
+      collection.includes(:thesis).pluck(:grad_date).uniq.sort
+    end
   end
 
   def record_empty_theses(collection)

--- a/app/views/report/_hold.html.erb
+++ b/app/views/report/_hold.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <td><%= link_to title_helper(hold.thesis), edit_admin_thesis_path(hold.thesis.id) %></td>
+  <td>
+    <% hold.thesis.authors.each do |author| %>
+      <%= author.user.display_name %><br>
+    <% end %>
+  </td>
+  <td><%= hold.thesis.graduation_month[...3] %> <%= hold.thesis.graduation_year %></td>
+  <td><%= hold.hold_source.source %></td>
+  <td><%= hold.status %></td>
+  <td><%= hold.date_requested %></td>
+  <td><%= hold.date_start %></td>
+  <td><%= hold.date_end %></td>
+</tr>

--- a/app/views/report/_hold_empty.html.erb
+++ b/app/views/report/_hold_empty.html.erb
@@ -1,0 +1,3 @@
+<tr>
+  <td colspan="8">There are no holds for the given term.</td>
+</tr>

--- a/app/views/report/_holds_by_source_filter.html.erb
+++ b/app/views/report/_holds_by_source_filter.html.erb
@@ -1,0 +1,31 @@
+<%= form_tag(nil, method: "get") do %>
+  <div class="multi-form-tag">
+    <label>
+      Include only theses from:
+      <select name="graduation">
+        <option value="all">All terms</option>
+        <% @terms.each do |term| %>
+          <option value="<%= term %>"<%= ' selected="selected"'.html_safe if params[:graduation].to_s == term.to_s %>>
+            <%= term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') %>
+          </option>
+        <% end %>
+      </select>
+    </label>
+  </div>
+
+  <div class="multi-form-tag">
+    <label>
+      Filter by hold source:
+      <select name="hold_source">
+        <option value="all">All sources</option>
+        <% @hold_sources.each do |source| %>
+          <option value="<%= source %>"<%= ' selected="selected"'.html_safe if params[:hold_source].to_s == source.to_s %>>
+            <%= source %>
+          </option>
+        <% end %>
+      </select>
+    </label>
+  </div>
+
+  <%= submit_tag('Apply filters', class: 'btn button-primary') %>
+<% end %>

--- a/app/views/report/holds_by_source.html.erb
+++ b/app/views/report/holds_by_source.html.erb
@@ -1,0 +1,32 @@
+<%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
+
+<div class="layout-3q1q layout-band">
+  <div class="col3q">
+    <h3 class="title title-page">Holds by source for <%= @this_term %></h3>
+
+    <%= render 'holds_by_source_filter' %>
+
+    <table class="table" summary="This table presents a list of holds filtered by source."
+     title="Student submitted metadata">
+      <thead>
+        <tr>
+          <th scope="col">Title</th>
+          <th scope="col">Author(s)</th>
+          <th scope="col">Grad date</th>
+          <th scope="col">Hold source</th>
+          <th scope="col">Status</th>
+          <th scope="col">Date requested</th>
+          <th scope="col">Start date</th>
+          <th scope="col">End date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render(partial: 'hold', collection: @list) || render('hold_empty') %>
+      </tbody>
+    </table>
+  </div>
+
+  <aside class="content-sup col1q-r">
+    <%= render 'shared/report_submenu' %>
+  </aside>
+</div>

--- a/app/views/shared/_report_submenu.html.erb
+++ b/app/views/shared/_report_submenu.html.erb
@@ -20,6 +20,9 @@
       <% if can?(:files, Report) %>
         <li><%= link_to("Files without purpose", report_files_path) %></li>
       <% end %>
+      <% if  can?(:holds_by_source, Report) %>
+        <li><%= link_to("Holds by source", report_holds_by_source_path) %></li>
+      <% end %>
       <% if can?(:expired_holds, Report) %>
         <li><%= link_to("Unreleased holds which have ended", report_expired_holds_path) %></li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   get 'report/empty_theses', to: 'report#empty_theses', as: 'report_empty_theses'
   get 'report/expired_holds', to: 'report#expired_holds', as: 'report_expired_holds'
   get 'report/files', to: 'report#files', as: 'report_files'
+  get 'report/holds_by_source', to: 'report#holds_by_source', as: 'report_holds_by_source'
   get 'report/proquest_files', to: 'report#proquest_files', as: 'report_proquest_files'
   get 'report/student_submitted_theses', to: 'report#student_submitted_theses', as: 'report_student_submitted_theses'
   get 'report/term', to: 'report#term', as: 'report_term'


### PR DESCRIPTION
#### Why these changes are being introduced:

We need to be able to see the holds for a given degree period,
filtered by hold source.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-462

#### How this addresses that need:

This adds a report of holds that allows filtering on thesis
grad date and hold source.

#### Side effects of this change:

* Report#extract_terms now checks for the type of items in the
collection, so as to accommodate non-thesis collections.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
