### PR TITLE
Fix bug in summary report for authors not graduated

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -235,8 +235,9 @@ class Report
     row_data = {}
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
-      row_data[term] = Thesis.includes(users: :authors).with_files.where('grad_date = ?', term)
-                             .map(&:authors_graduated?).count(false)
+      row_data[term] = Thesis.with_files.includes(authors: :user).includes(:departments).select do |t|
+        !t.authors_graduated?
+      end.uniq.count
     end
     {
       label: 'Authors not graduated',


### PR DESCRIPTION
#### Why these changes are being introduced:

QA on #916 revealed a discrepancy between the number
of authors not graduated in the summary report and
the authors not graduated report. This is because we
were not deduping thesis records in
Report#data_authors_not_graduated.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-429

#### How this addresses that need:

In Report#data_authors_not_graduated, this calls `select` instead
of `map` to identify ungraduated authors, then calls `uniq` on the
result to avoid counting duplicate records.

#### Side effects of this change:

This went unnoticed until QA in part because we do not extensively
test the summary report. It's probably okay to test that feature
minimally since this sort of thing is likely to be caught by
stakeholders, but we should consider extending unit testing for
reporting if it happens again.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
