### PR TITLE
Add term filter to summary of authors_not_graduated data

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -235,9 +235,8 @@ class Report
     row_data = {}
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
-      row_data[term] = Thesis.with_files.includes(authors: :user).includes(:departments).select do |t|
-        !t.authors_graduated?
-      end.uniq.count
+      row_data[term] = Thesis.with_files.where('grad_date = ?', term).includes(authors: :user).includes(:departments)
+                             .reject(&:authors_graduated?).count
     end
     {
       label: 'Authors not graduated',

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -51,6 +51,28 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal result['departments'][0][:data].values, [0, 3, 0, 0, 0, 0, 0, 4, 0]
   end
 
+  test 'index includes summary data of authors not graduated' do
+    thesis = theses(:bachelor)
+    another_thesis = theses(:published)
+    assert_not_equal thesis.grad_date, another_thesis.grad_date
+    assert thesis.files?
+    assert another_thesis.files?
+
+    a = thesis.authors.first
+    a.graduation_confirmed = false
+    a.save
+    assert_not thesis.authors_graduated?
+
+    a = another_thesis.authors.first
+    a.graduation_confirmed = false
+    a.save
+    assert_not another_thesis.authors_graduated?
+
+    r = Report.new
+    result = r.index_data
+    assert_equal result['summary'][5][:data].values, [0, 1, 0, 0, 0, 0, 0, 1, 0]
+  end
+
   # ~~~~ Term detail report
   test 'term detail includes a breakdown of departments' do
     r = Report.new


### PR DESCRIPTION
#### Why these changes are being introduced:

Report#data_authors_not_graduated does not include a grad_date filter,
so all theses with ungraduated authors are shown for each term
instead of just the theses for the corresponding term.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-429

#### How this addresses that need:

This adds the term filter into Report#data_authors_not_graduated

#### Side effects of this change:

N/A.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
