### PR TITLE
Dedup authors not graduated summary data

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -236,7 +236,7 @@ class Report
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
       row_data[term] = Thesis.with_files.where('grad_date = ?', term).includes(authors: :user).includes(:departments)
-                             .reject(&:authors_graduated?).count
+                             .reject(&:authors_graduated?).uniq.count
     end
     {
       label: 'Authors not graduated',


### PR DESCRIPTION
#### Why these changes are being introduced:

Theses with multiple files are being counted for each attached
file in the authors not graduated summary data.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-429

#### How this addresses that need:

This dedups theses to fix the count in the Report index.

#### Side effects of this change:

N/A.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
