### PR TITLE
Fix publication status update logic

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -92,7 +92,8 @@ class Thesis < ApplicationRecord
 
   VALID_MONTHS = %w[February May June September].freeze
 
-  before_save :combine_graduation_date, :update_status
+  before_save :combine_graduation_date
+  after_validation :update_status
   after_find :split_graduation_date
 
   scope :date_asc, -> { order('grad_date') }
@@ -122,7 +123,7 @@ class Thesis < ApplicationRecord
 
   # Returns a true/false value if there are any associated advisors.
   def advisors?
-    !advisors.count.zero?
+    advisors.any?
   end
 
   # Returns a true/false value (rendered as "yes" or "no") if all authors
@@ -138,7 +139,7 @@ class Thesis < ApplicationRecord
 
   # Returns a true/false value if there are any affiliated degrees.
   def degrees?
-    !degrees.count.zero?
+    degrees.any?
   end
 
   # This is the summation of all status checks, which must all return a boolean TRUE in order for a thesis record to be
@@ -162,7 +163,7 @@ class Thesis < ApplicationRecord
 
   # Returns a true/false value if there are any attached files.
   def files?
-    !files.count.zero?
+    files.any?
   end
 
   # Returns a true/false value if all files have a defined purpose.
@@ -233,12 +234,8 @@ class Thesis < ApplicationRecord
   # required in certain conditions (i.e. abstracts are required for master and doctoral theses, but not for bachelor
   # theses). These checks are summarized on the thesis processing form using the "Sufficient metadata?" field in the
   # status panel.
-  #
-  # Please note, further, that the valid? call in this method will run all defined data validations. A number of fields
-  # in the data model (i.e. graduation_month and graduation_year) are only covered by this approach.
   def required_fields?
     if [
-      valid?,
       required_abstract?,
       advisors?,
       copyright_id?,


### PR DESCRIPTION
#### Why these changes are being introduced:

When a thesis is saved, Thesis#evaluate_status will not evaluate as
expected, due to certain convenience methods used within
`Thesis#required_fields?`. These methods return the wrong value
before the record is saved, requiring processors to submit the
processing form twice in order to update a thesis' publication status.

Because we use the `before_save` callback, this bug can also occur if
nested attributes are updated, but the Thesis model is not (e.g.,
a new degree is attached, but none of the thesis attributes are
changed). This means that the thesis record is not technically saved,
and the `before_save` callback won't fire.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-507

#### How this addresses that need:

* Updates the logic in `Thesis#advisors?` and `Thesis#degrees?`
to use `any?` rather than `count.zero?`, which evaluates correctly
before the thesis is saved.
* Uses the `after_validation` ActiveRecord callback instead of
`before_save`, so `Thesis#update_status` will be called when only
nested attributes are updated.

#### Side effects of this change:

* Refactored `Thesis#files?` to mirror the logic in `#advisors?`
and `#degrees?`.
* Removed the `valid?` call from `Thesis#evaluate_status` to avoid
an infinite loop. This call seemed redundant since `validate` is
called before `save`, but I'd be interested in discussing this
in case I'm missing an edge case.
* This feature uses many other convenience methods, some of which
could be refactored or possibly removed. I opened a ticket to
address this here: https://mitlibraries.atlassian.net/browse/ETD-578

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
