### PR TITLE
Remove status field from Thesis model

### DIFF
--- a/app/dashboards/thesis_dashboard.rb
+++ b/app/dashboards/thesis_dashboard.rb
@@ -28,9 +28,6 @@ class ThesisDashboard < Administrate::BaseDashboard
     updated_at: Field::DateTime,
     files: AttachmentField,
     files_complete: Field::Boolean,
-    status: Field::Select.with_options(
-      collection: Thesis::STATUS_OPTIONS
-    ),
     publication_status: Field::Select.with_options(
       collection: Thesis::PUBLICATION_STATUS_OPTIONS
     ),
@@ -75,7 +72,6 @@ class ThesisDashboard < Administrate::BaseDashboard
     degrees
     advisors
     holds
-    status
     publication_status
     submission_information_packages
     dspace_handle
@@ -102,7 +98,6 @@ class ThesisDashboard < Administrate::BaseDashboard
     title
     coauthors
     abstract
-    status
     publication_status
     dspace_handle
     graduation_year

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  status             :string           default("active")
 #  processor_note     :text
 #  author_note        :text
 #  files_complete     :boolean          default(FALSE), not null
@@ -79,9 +78,6 @@ class Thesis < ApplicationRecord
   validates :issues_found, exclusion: [nil]
 
   validates :users, presence: true
-
-  STATUS_OPTIONS = %w[active withdrawn downloaded].freeze
-  validates_inclusion_of :status, in: STATUS_OPTIONS
 
   PUBLICATION_STATUS_OPTIONS = ['Not ready for publication',
                                 'Publication review',

--- a/db/migrate/20220329202143_remove_status_from_thesis.rb
+++ b/db/migrate/20220329202143_remove_status_from_thesis.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromThesis < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :theses, :status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_190428) do
+ActiveRecord::Schema.define(version: 2022_03_29_202143) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -199,7 +199,6 @@ ActiveRecord::Schema.define(version: 2022_01_26_190428) do
     t.date "grad_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "active"
     t.text "processor_note"
     t.text "author_note"
     t.boolean "files_complete", default: false, null: false

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  status             :string           default("active")
 #  processor_note     :text
 #  author_note        :text
 #  files_complete     :boolean          default(FALSE), not null
@@ -49,7 +48,6 @@ downloaded:
   grad_date: 2017-09-01
   departments: [one]
   degrees: [one]
-  status: 'downloaded'
 
 withdrawn:
   title: MyStringWithdrawn
@@ -57,7 +55,6 @@ withdrawn:
   grad_date: 2017-09-01
   departments: [one]
   degrees: [one]
-  status: 'withdrawn'
 
 active:
   title: MyStringActive
@@ -66,7 +63,6 @@ active:
   departments: [one]
   degrees: [one]
   coauthors: 'Coauthor, Student'
-  status: 'active'  # The default, but specified for testing purposes.
 
 with_note:
   title: MyStringNote
@@ -74,7 +70,6 @@ with_note:
   grad_date: 2017-09-01
   departments: [one]
   degrees: [one]
-  status: 'active'  # The default, but specified for testing purposes.
   processor_note: 'Absolutely for sure rocket science'
   copyright: mit
   license: nocc
@@ -85,7 +80,6 @@ with_hold:
   grad_date: 2017-09-01
   departments: [one]
   degrees: [one, two]
-  status: 'active'
   processor_note: 'Something sensitive'
 
 released_hold:
@@ -94,7 +88,6 @@ released_hold:
   grad_date: 2021-06-01
   departments: [one]
   degrees: [one]
-  status: 'active'
   processor_note: 'One hold, which was released'
 
 multiple_holds:
@@ -103,7 +96,6 @@ multiple_holds:
   grad_date: 2021-06-01
   departments: [one]
   degrees: [one]
-  status: 'active'
   processor_note: 'Multiple holds in various states'
 
 issues_found:

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -8,7 +8,6 @@
 #  grad_date          :date             not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
-#  status             :string           default("active")
 #  processor_note     :text
 #  author_note        :text
 #  files_complete     :boolean          default(FALSE), not null
@@ -221,34 +220,6 @@ class ThesisTest < ActiveSupport::TestCase
     thesis = theses(:one)
     thesis.degrees = [degrees(:one), degrees(:two)]
     assert(thesis.valid?)
-  end
-
-  test 'can have active status' do
-    thesis = theses(:one)
-    thesis.status = 'active'
-    thesis.save
-    assert(thesis.valid?)
-  end
-
-  test 'can have withdrawn status' do
-    thesis = theses(:one)
-    thesis.status = 'withdrawn'
-    thesis.save
-    assert(thesis.valid?)
-  end
-
-  test 'can have downloaded status' do
-    thesis = theses(:one)
-    thesis.status = 'downloaded'
-    thesis.save
-    assert(thesis.valid?)
-  end
-
-  test 'cannot have other statuses' do
-    thesis = theses(:one)
-    thesis.status = 'nobel prize-winning'
-    thesis.save
-    assert_not(thesis.valid?)
   end
 
   test 'can have author note' do


### PR DESCRIPTION
#### Why these changes are being introduced:

The status field is no longer used in the new application.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-94

#### How this addresses that need:

This removes the status field.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
