### PR TITLE
MARC 040$b should be eng

### DIFF
--- a/app/models/marc.rb
+++ b/app/models/marc.rb
@@ -32,7 +32,7 @@ class Marc
     @record.append(MARC::DataField.new(
                      '040', ' ', ' ',
                      %w[a MYG],
-                     %w[b env],
+                     %w[b eng],
                      %w[e rda],
                      %w[c MYG]
                    ))


### PR DESCRIPTION
Why are these changes being introduced:

* we were incorrectly setting this value previous

Relevant ticket(s):

* https://github.com/MITLibraries/thing/issues/950

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
