### PR TITLE
testing allowing more clock drift during auth

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -60,6 +60,7 @@ Devise.setup do |config|
                     private_key: Base64.strict_decode64(ENV['SP_PRIVATE_KEY']),
                     issuer: ENV['SP_ENTITY_ID'],
                     request_attributes: {},
+                    allowed_clock_drift: 2.seconds,
                     attribute_statements: { uid: [ENV['URN_UID']],
                                             email: [ENV['URN_EMAIL']],
                                             given_name: [ENV['URN_GIVEN_NAME']],


### PR DESCRIPTION
We are seeing clock drift issues in authentication.

This is a quick fix that seems to resolve it. I'll open a ticket to dig in deeper but want to resolve the production bug asap first.