### PR TITLE
Pass environment to Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ you'd like to handle.
 this automatically. It is often nice in development as well.
 
 `SENTRY_DSN` - set to your project sentry key to enable exception logging
+`SENTRY_ENV` - Sentry environment for the application. Defaults to 'unknown' if unset.
 
 ## ActiveStorage Configuration
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,13 +2,5 @@ Sentry.init do |config|
   return unless ENV.has_key?('SENTRY_DSN')
   config.dsn = ENV.fetch('SENTRY_DSN')
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
-
-  # Set tracesSampleRate to 1.0 to capture 100%
-  # of transactions for performance monitoring.
-  # We recommend adjusting this value in production
-  # config.traces_sample_rate = 0.5
-  # # or
-  # config.traces_sampler = lambda do |context|
-  #   true
-  # end
+  config.environment = ENV.fetch('SENTRY_ENV', 'unknown')
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

All Sentry alerts currently display the environment as 'production'.
We would like Sentry to accurately show the environment in which
the alert was captured.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ENGX-181

#### How this addresses that need:

This sets the Sentry environment to `SENTRY_ENV`, defaulting to
'unknown' if that variable isn't set.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
