### PR TITLE
[WIP] Confirm that new proof-of-concept theme works for Rails 6 apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'simple_form'
 gem 'skylight'
+gem 'tesseract', tag: '0.5.0', git: 'https://github.com/matt-bernhardt/tesseract.git'
 gem 'uglifier'
 gem 'zip_tricks'
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'json'
 gem 'kaminari'
 gem 'lograge'
 gem 'marc'
-gem 'mitlibraries-theme'
+gem 'mitlibraries-theme', tag: '0.9.0', git: 'https://github.com/mitlibraries/mitlibraries-theme', branch: 'engx-175-rebuild'
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false
@@ -33,7 +33,6 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 gem 'simple_form'
 gem 'skylight'
-gem 'tesseract', tag: '0.5.0', git: 'https://github.com/matt-bernhardt/tesseract.git'
 gem 'uglifier'
 gem 'zip_tricks'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
-  remote: https://github.com/matt-bernhardt/tesseract.git
-  revision: 3554f275290f565b98ad1306db8c24fabbc04f30
-  tag: 0.5.0
+  remote: https://github.com/mitlibraries/mitlibraries-theme
+  revision: 8b36148d0150cb8a854d0421d55e3710fc7ac57c
+  branch: engx-175-rebuild
+  tag: 0.9.0
   specs:
-    tesseract (0.5.0)
-      debug (~> 1)
+    mitlibraries-theme (0.9.0)
       rails (>= 6, < 8)
       sassc-rails (~> 2)
 
@@ -143,9 +143,6 @@ GEM
     cocoon (1.2.15)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
-    debug (1.6.2)
-      irb (>= 1.3.6)
-      reline (>= 0.3.1)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -171,9 +168,6 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    io-console (0.5.11)
-    irb (1.4.1)
-      reline (>= 0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
@@ -224,9 +218,6 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mitlibraries-theme (0.8.0)
-      rails (>= 5, < 8)
-      sassc (~> 2)
     msgpack (1.5.4)
     net-imap (0.2.3)
       digest
@@ -305,8 +296,6 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -431,7 +420,7 @@ DEPENDENCIES
   lograge
   marc
   minitest-reporters
-  mitlibraries-theme
+  mitlibraries-theme!
   net-imap
   net-pop
   net-smtp
@@ -454,7 +443,6 @@ DEPENDENCIES
   simplecov-lcov
   skylight
   sqlite3
-  tesseract!
   timecop
   uglifier
   web-console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/matt-bernhardt/tesseract.git
+  revision: 3554f275290f565b98ad1306db8c24fabbc04f30
+  tag: 0.5.0
+  specs:
+    tesseract (0.5.0)
+      debug (~> 1)
+      rails (>= 6, < 8)
+      sassc-rails (~> 2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -133,6 +143,9 @@ GEM
     cocoon (1.2.15)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    debug (1.6.2)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     delayed_job (4.1.10)
       activesupport (>= 3.0, < 8.0)
     delayed_job_active_record (4.1.7)
@@ -158,6 +171,9 @@ GEM
     hashie (5.0.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
@@ -289,6 +305,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.5.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -436,6 +454,7 @@ DEPENDENCIES
   simplecov-lcov
   skylight
   sqlite3
+  tesseract!
   timecop
   uglifier
   web-console

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :ensure_domain
   before_action :set_paper_trail_whodunnit
 
-  helper Tesseract::Engine.helpers
+  helper Mitlibraries::Theme::Engine.helpers
 
   rescue_from CanCan::AccessDenied do
     redirect_to root_path, alert: 'Not authorized.'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   before_action :ensure_domain
   before_action :set_paper_trail_whodunnit
 
+  helper Tesseract::Engine.helpers
+
   rescue_from CanCan::AccessDenied do
     redirect_to root_path, alert: 'Not authorized.'
   end


### PR DESCRIPTION
** Why are these changes being introduced:

* As part of ENGX-175, I've set up a separate theme gem starting from a
  blank slate named Tesseract. I need to confirm that this gem can
  function as a drop-in replacement for our current theme.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/engx-175

** How does this address that need:

* This removes the current theme gem from the application, replacing it
  with the Tesseract gem (loaded directly from Github, to avoid the need
  to publish a proof-of-concept gem to RubyGems).
* Because the new gem implements helpers differently, this also adds a
  line to the application controller to load the new gem's helpers.

** Document any side effects to this change:

* See note above about there being one additional implementation step
  for the new gem.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES | NO

#### Includes new or updated dependencies?

YES | NO
