### PR TITLE
Add ProQuest opt-in to thesis submission forms

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -155,6 +155,14 @@ form.simple_form {
       width: 100%;
     }
   }
+  .proquest {
+    label {
+      margin-bottom: 1rem;
+    }
+    .radio.field-subitem {
+      margin-top: 1rem;
+    }
+  }
 }
 
 // transfer processing form

--- a/app/dashboards/author_dashboard.rb
+++ b/app/dashboards/author_dashboard.rb
@@ -15,6 +15,7 @@ class AuthorDashboard < Administrate::BaseDashboard
     ),
     thesis: Field::BelongsTo,
     graduation_confirmed: Field::Boolean,
+    proquest_allowed: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -28,6 +29,7 @@ class AuthorDashboard < Administrate::BaseDashboard
     user
     thesis
     graduation_confirmed
+    proquest_allowed
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -36,6 +38,7 @@ class AuthorDashboard < Administrate::BaseDashboard
     user
     thesis
     graduation_confirmed
+    proquest_allowed
     created_at
     updated_at
   ].freeze
@@ -47,6 +50,7 @@ class AuthorDashboard < Administrate::BaseDashboard
     user
     thesis
     graduation_confirmed
+    proquest_allowed
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -18,4 +18,9 @@ module ThesisHelper
 
     theses
   end
+
+  def satisfies_advanced_degree?(thesis)
+    advanced_degree_types = %w[Doctoral Engineer Master]
+    thesis.degrees.any? { |d| advanced_degree_types.include? d.degree_type.name }
+  end
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -47,6 +47,7 @@ class Thesis < ApplicationRecord
   has_one_attached :dspace_metadata
 
   accepts_nested_attributes_for :users
+  accepts_nested_attributes_for :authors
   accepts_nested_attributes_for :advisors, allow_destroy: true
   accepts_nested_attributes_for :department_theses, allow_destroy: true
   accepts_nested_attributes_for :files_attachments, allow_destroy: true

--- a/app/views/thesis/_author_fields.html.erb
+++ b/app/views/thesis/_author_fields.html.erb
@@ -1,0 +1,8 @@
+<fieldset class="proquest">
+  <legend>Consent to send thesis to ProQuest</legend>
+  <%= f.input :proquest_allowed, as: :radio_buttons,
+                                 collection: [['Yes', true], ['No', false]],
+                                 required: true,
+                                 validate_presence: true,
+                                 label: "I would like the full-text of my thesis to be made available openly in <a href='https://about.proquest.com/en/dissertations/proquest-dissertations-frequently-asked-questions/proquest-dissertations-authors-frequently-asked-questions/'>ProQuest Dissertation & Theses Global</a>. The Libraries’ new pilot for open access inclusion in PQDT is at no cost to you and aims to increase the visibility and discoverability of your thesis.  Your thesis will not be sent to ProQuest until it is published by MIT.".html_safe %>
+</fieldset>

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -182,6 +182,12 @@
                                 hint: 'If anything is incorrect in the non-editable fields, tell us here.'.html_safe,
                                 hint_html: { id: 'thesis_author_note-hint', class: 'col3q' } %>
 
+      <%= f.simple_fields_for :authors do |author| %>
+        <% if author.object.user_id == current_user.id && satisfies_advanced_degree?(@thesis) %>
+          <%= render 'author_fields', f: author %>
+        <% end %>
+      <% end %>
+
       <div class='field-row'>
         <%= submit_tag 'Submit thesis information', class: 'btn button-primary' %>
       </div>
@@ -198,6 +204,13 @@
 
 <script type="text/javascript">
   $("form.thesisSubmission").validate({
+    errorPlacement: function(error, element) {
+      if (element.attr("name") == "thesis[authors_attributes][0][proquest_allowed]") {
+        error.insertBefore(element);
+      } else {
+        error.insertAfter(element);
+      }
+    },
     invalidHandler: function(event, validator) {
       var errors = validator.numberOfInvalids();
       if (errors) {

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -169,18 +169,22 @@
                              rows: 10,
                            } %>
 
-      <%= f.input :author_note, as: :text,
-                                label: 'Notes',
-                                label_html: { class: 'col1q' },
-                                wrapper_html: { class: 'field-row layout-1q3q layout-band' },
-                                input_html: { class: 'field field-text col3q',
-                                  rows: 5,
-                                  aria: { describedby: 'thesis_author_note-hint' }
-                                },
-                                hint: 'If anything is incorrect in the non-editable fields, tell us here.'.html_safe,
-                                hint_html: { id: 'thesis_author_note-hint', class: 'col3q' } %>
+    <%= f.input :author_note, as: :text,
+                              label: 'Notes',
+                              label_html: { class: 'col1q' },
+                              wrapper_html: { class: 'field-row layout-1q3q layout-band' },
+                              input_html: { class: 'field field-text col3q',
+                                rows: 5,
+                                aria: { describedby: 'thesis_author_note-hint' }
+                              },
+                              hint: 'If anything is incorrect in the non-editable fields, tell us here.'.html_safe,
+                              hint_html: { id: 'thesis_author_note-hint', class: 'col3q' } %>
 
-
+    <%= f.simple_fields_for :authors do |author| %>
+      <% if author.object.user_id == current_user.id %>
+        <%= render 'author_fields', f: author %>
+      <% end %>
+    <% end %>
 
     <div class='field-row'>
       <%= submit_tag 'Submit thesis information', class: 'btn button-primary' %>
@@ -195,6 +199,13 @@
 
 <script type="text/javascript">
   $("#new_thesis").validate({
+    errorPlacement: function(error, element) {
+      if (element.attr("name") == "thesis[authors_attributes][0][proquest_allowed]") {
+        error.insertBefore(element);
+      } else {
+        error.insertAfter(element);
+      }
+    },
     invalidHandler: function(event, validator) {
       var errors = validator.numberOfInvalids();
       if (errors) {

--- a/db/migrate/20220826202539_add_proquest_allowed_to_authors.rb
+++ b/db/migrate/20220826202539_add_proquest_allowed_to_authors.rb
@@ -1,0 +1,5 @@
+class AddProquestAllowedToAuthors < ActiveRecord::Migration[6.1]
+  def change
+    add_column :authors, :proquest_allowed, :boolean, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_29_202143) do
+ActiveRecord::Schema.define(version: 2022_08_26_202539) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 2022_03_29_202143) do
     t.boolean "graduation_confirmed", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "proquest_allowed"
     t.index ["thesis_id"], name: "index_authors_on_thesis_id"
     t.index ["user_id"], name: "index_authors_on_user_id"
   end

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -52,4 +52,28 @@ class ThesisHelperTest < ActionView::TestCase
     params[:status] = 'all'
     assert_equal Thesis.all.count, filter_theses_by_publication_status(Thesis.all).count
   end
+
+  test 'satisfies_advanced_degree? returns true for graduate degree types' do
+    doctoral_thesis = Thesis.new(degrees: [degrees(:two)])
+    master_thesis = Thesis.new(degrees: [degrees(:three)])
+    engineer_thesis = Thesis.new(degrees: [degrees(:four)])
+    assert_equal true, satisfies_advanced_degree?(doctoral_thesis)
+    assert_equal true, satisfies_advanced_degree?(master_thesis)
+    assert_equal true, satisfies_advanced_degree?(engineer_thesis)
+  end
+
+  test 'satisfies_advanced_degree? returns false for undergraduate degree types' do
+    undergrad_thesis = Thesis.new(degrees: [degrees(:one)])
+    assert_equal false, satisfies_advanced_degree?(undergrad_thesis)
+  end
+
+  test 'satisfies_advanced_degree? returns true if a thesis satisfies multiple advanced degree types' do
+    grad_thesis = Thesis.new(degrees: [degrees(:two), degrees(:three)])
+    assert_equal true, satisfies_advanced_degree?(grad_thesis)
+  end
+
+  test 'satisfies_advanced_degree? returns true if a thesis satisfies both undergraduate and graduate degree types' do
+    hybrid_thesis = Thesis.new(degrees: [degrees(:one), degrees(:two)])
+    assert_equal true, satisfies_advanced_degree?(hybrid_thesis)
+  end
 end

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -60,4 +60,10 @@ class AuthorTest < ActiveSupport::TestCase
     author.reload
     assert author.graduation_confirmed
   end
+
+  test 'valid without proquest_allowed' do
+    a = authors(:one)
+    assert_nil a.proquest_allowed
+    assert a.valid?
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We need to document permission from authors of graduate theses as to whether we can send their theses to ProQuest or not.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-587

#### How this addresses that need:

This adds a proquest_allowed boolean field to the author model thesis and adds it as a field to the new and edit thesis forms. As per the ticket requirements, this field only shows in the edit form for graduate degree types. Null values are allowed in the data model, but the field is validated in the form.

#### Side effects of this change:

* The new field has been added to the author administrate dashboard. This was not specified in the success criteria, but it seemed like it would be useful to processors.
* The new form element will need UXWS review before we deploy it to production.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

NO
