### PR TITLE
Remove ProQuest reference from student submission welcome partial

### DIFF
--- a/app/views/thesis/_welcome.html.erb
+++ b/app/views/thesis/_welcome.html.erb
@@ -8,8 +8,7 @@
     <li>The title page of your thesis must match the information you provide
       us today - please review it as needed.</li>
     <li>Submit your thesis files with the <a href="https://libguides.mit.edu/c.php?g=176367&p=8229377#s-lg-box-wrapper-30716057" target="_blank">required
-      filename format</a>, along with the <a href="https://libraries.mit.edu/wp-content/uploads/2019/08/umi-proquest-form.pdf" target="_blank">Proquest
-      form</a> (PhDs only) <strong>directly to your departments</strong>.</li>
+      filename format</a> <strong>directly to your department</strong>.</li>
     <li>If needed, you can update certain fields until graduation day.</li>
   </ul>
   <p>Please contact us with any questions: <a href="mailto:mit-theses@mit.edu?Subject=Thesis%20submission%20help" target="_blank">mit-theses@mit.edu</a></p>


### PR DESCRIPTION
#### Why these changes are being introduced:

The welcome partial asks students to send the ProQuest form directly to their departments. This will now be integrated into the student submission form.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-601

#### How this addresses that need:

This removes the ProQuest form text from the welcome partial.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
