### PR TITLE
Rename published param in ProQuest report

### DIFF
--- a/app/helpers/thesis_helper.rb
+++ b/app/helpers/thesis_helper.rb
@@ -42,7 +42,7 @@ module ThesisHelper
   end
 
   def filter_theses_by_published(theses)
-    return theses.where(publication_status: 'Published') if params[:published] && params[:published] == 'true'
+    return theses.where(publication_status: 'Published') if params[:published_only] && params[:published_only] == 'true'
 
     theses
   end

--- a/test/controllers/report_controller_test.rb
+++ b/test/controllers/report_controller_test.rb
@@ -918,7 +918,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     get report_proquest_status_path
     assert_select 'table tbody tr', count: thesis_count
 
-    get report_proquest_status_path, params: { published: 'true' }
+    get report_proquest_status_path, params: { published_only: 'true' }
     assert_select 'table tbody tr', count: published_count
   end
 
@@ -931,7 +931,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     get report_proquest_status_path
     assert_select 'table tbody tr', count: thesis_count
 
-    get report_proquest_status_path, params: { published: 'false' }
+    get report_proquest_status_path, params: { published_only: 'false' }
     assert_select 'table tbody tr', count: thesis_count
   end
 
@@ -949,7 +949,7 @@ class ReportControllerTest < ActionDispatch::IntegrationTest
     assert_select 'table tbody tr', count: thesis_count
 
     get report_proquest_status_path,
-        params: { graduation: '2018-06-01', degree_type: 'Engineer', published: 'true' }
+        params: { graduation: '2018-06-01', degree_type: 'Engineer', published_only: 'true' }
     assert_select 'table tbody tr', count: filtered_count
   end
 

--- a/test/helpers/thesis_helper_test.rb
+++ b/test/helpers/thesis_helper_test.rb
@@ -130,13 +130,13 @@ class ThesisHelperTest < ActionView::TestCase
 
   test 'filter_theses_by_published returns a filtered set of theses' do
     theses = Thesis.all
-    params[:published] = 'true'
+    params[:published_only] = 'true'
     assert_not_equal theses.count, filter_theses_by_published(theses).count
   end
 
   test 'filter_theses_by_published does nothing when published param is set to false' do
     theses = Thesis.all
-    params[:published] = 'false'
+    params[:published_only] = 'false'
     assert_equal theses.count, filter_theses_by_published(theses).count
   end
 
@@ -157,7 +157,7 @@ class ThesisHelperTest < ActionView::TestCase
 
     # Set params to correspond with expected conditions.
     params[:graduation] = '2018-06-01'
-    params[:published] = 'false'
+    params[:published_only] = 'false'
     params[:department] = departments(:one).name_dw
     params[:degree] = degrees(:two).name_dw
     params[:multi_author] = 'true'


### PR DESCRIPTION
#### Why these changes are being introduced:

The param to filter published theses in
ThesisHelper#filter_published_by_thesis is currently named `published`. This is an ambiguous name for the param. When it is set to false, the helper method returns all theses, including those that are published. However, `published=false` would indicate a result set that excludes published theses.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-591
https://mitlibraries.atlassian.net/browse/ETD-599

#### How this addresses that need:

This renames the param to `published_only`, which more clearly articulates what it's supposed to do.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
