### PR TITLE
Move descriptive text of ProQuest opt-in outside of field label

### DIFF
--- a/app/assets/stylesheets/thing.scss
+++ b/app/assets/stylesheets/thing.scss
@@ -160,6 +160,12 @@ form.simple_form {
       margin-bottom: 1rem;
       font-weight:  $fw-normal;
     }
+    .opt-border {
+      display:  block;
+      border:  .1px dotted;
+      margin-top: 1rem;
+      margin-bottom:  1rem;
+    }
     .radio.field-subitem {
       margin-top: 1rem;
     }

--- a/app/views/thesis/_author_fields.html.erb
+++ b/app/views/thesis/_author_fields.html.erb
@@ -1,8 +1,13 @@
-<fieldset class="proquest">
-  <legend>Consent to send thesis to ProQuest</legend>
-  <%= f.input :proquest_allowed, as: :radio_buttons,
-                                 collection: [['Yes', true], ['No', false]],
-                                 required: true,
-                                 validate_presence: true,
-                                 label: "We are conducting a pilot program to provide additional open access to MIT theses through <a href='http://libguides.mit.edu/dissertations'>ProQuest Dissertation & Theses Global</a> (PQDT). The aim is to make theses more visible and discoverable.<br><br>There is no cost to you and your thesis will not be sent to ProQuest until it is published by MIT. See <a href='https://about.proquest.com/en/dissertations/proquest-dissertations-frequently-asked-questions/proquest-dissertations-authors-frequently-asked-questions/'>PQDT's Author Dissertations FAQs</a> for more information about participating.<br><br>--<br><br>I would like the full-text of my thesis to be made openly available in ProQuest Dissertation & Theses Global.".html_safe %>
-</fieldset>
+<h4>Consent to send thesis to ProQuest</h4>
+<div class="proquest">
+  <p>We are conducting a pilot program to provide additional open access to MIT theses through <a href='http://libguides.mit.edu/dissertations'>ProQuest Dissertation & Theses Global</a> (PQDT). The aim is to make theses more visible and discoverable.</p>
+  <p>There is no cost to you and your thesis will not be sent to ProQuest until it is published by MIT. See <a href='https://about.proquest.com/en/dissertations/proquest-dissertations-frequently-asked-questions/proquest-dissertations-authors-frequently-asked-questions/'>PQDT's Author Dissertations FAQs</a> for more information about participating.</p>
+  <fieldset>
+    <legend>ProQuest consent *</legend>
+    <%= f.input :proquest_allowed, as: :radio_buttons,
+                                   collection: [['Yes', true], ['No', false]],
+                                   required: true,
+                                   validate_presence: true,
+                                   label: "I would like the full-text of my thesis to be made openly available in ProQuest Dissertation & Theses Global.".html_safe %>
+  </fieldset>
+</div>


### PR DESCRIPTION
#### Why these changes are being introduced:

During a11y review, we determined that interactive content is not advisable inside a label. Anchors and other interactive elements can confuse screen reader navigation within the label, and make it difficult for people to activate the corresponding form input.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-602

#### How this addresses that need:

This moves the bulk of the descriptive content outside of the field label, so the label is more direct in what it is asking of the user. This also adds a header to the ProQuest field, which Dhruti recommended.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
