### PR TITLE
Add DataTables to ProQuest opt-in status report

### DIFF
--- a/app/views/report/proquest_status.html.erb
+++ b/app/views/report/proquest_status.html.erb
@@ -1,5 +1,11 @@
 <%= content_for(:title, "Thesis Reporting | MIT Libraries") %>
 
+<% content_for :additional_js do %>
+  <script src="https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min.js"></script>
+<% end %>
+
+<link href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css" rel="stylesheet">
+
 <div class="layout-3q1q layout-band">
   <div class="col3q">
     <h3 class="title title-page">ProQuest opt-in status for theses in <%= @this_term %></h3>
@@ -8,7 +14,7 @@
 
     <%= render partial: 'proquest_status_card', locals: { counts: @data, theses: @list } %>
 
-    <table class="table" summary="This table presents a list of theses with their ProQuest opt-in status."
+    <table class="table" id="proquestStatus" summary="This table presents a list of theses with their ProQuest opt-in status."
      title="ProQuest opt-in status">
       <thead>
         <tr>
@@ -28,3 +34,15 @@
     <%= render 'shared/report_submenu' %>
   </aside>
 </div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+  $('#proquestStatus').DataTable({
+    pageLength: -1,
+    lengthMenu: [
+      [10, 25, 50, -1],
+      [10, 25, 50, 'All'],
+    ],
+  });
+});
+</script>


### PR DESCRIPTION
#### Why these changes are being introduced:

During QA for ETD-591 and ETD-599, stakeholders noted that it would be useful to sort on the the 'Opted in to ProQuest?' column in the ProQuest opt-in status report.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-591
* https://mitlibraries.atlassian.net/browse/ETD-599

#### How this addresses that need:

This adds DataTables to the ProQuest status report, which provides sorting on all columns, searching, and pagination. The default page length is 'All'. This reflects the current behavior of the report, which stakeholders have indicated meets their needs, but the lengthMenu parameter is included in case a smaller result set is desired.

#### Side effects of this change:

DataTables may be a heavier tool than we need to accommodate this feature request. However, it shouldn't affect performance much. The DataTables performance issues we've seen elsewhere in the app are related to loading all data at once rather than paginating. This report already does that, and its page load time in production is acceptable (presumably thanks to its use of counter_cache).

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO (although, we are loading a JS library)
