### PR TITLE
Add scope note to ProQuest opt-in status report

### DIFF
--- a/app/views/report/proquest_status.html.erb
+++ b/app/views/report/proquest_status.html.erb
@@ -9,6 +9,10 @@
 <div class="layout-3q1q layout-band">
   <div class="col3q">
     <h3 class="title title-page">ProQuest opt-in status for theses in <%= @this_term %></h3>
+    <div class="alert alert-banner">
+      <p><i class="fa fa-info-circle fa-lg"></i> This report only lists theses that satisfy advanced degrees and have
+      at least one file attached.</p>
+    </div>
 
     <%= render 'proquest_status_filter' %>
 


### PR DESCRIPTION
#### Why these changes are being introduced:

The ProQuest opt-in status report only lists theses with advanced degrees and files attached. These conditions are not clear in the current UI.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-604

#### How this addresses that need:

This adds an alert banner clarifying the scope of the report.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
