### PR TITLE
Ensure updated counts for new Transfers

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -14,6 +14,7 @@ class Transfer < ApplicationRecord
   belongs_to :user
   belongs_to :department
   before_save :update_files_count
+  after_create_commit :initial_files_count
 
   has_many_attached :files
 
@@ -85,6 +86,14 @@ class Transfer < ApplicationRecord
       end
     end
     count
+  end
+
+  # This ensures that the activestorage objects are actually available before we update the initial files counts.
+  # The files are not available until the after_create_commit callback so our before_save callback does not work
+  # for initial Transfer creation. This does mean we calculate the counts twice on creation (once with the count as
+  # always zero, then the initial commit, then during the after_create_commit we re-save which counts them properly).
+  def initial_files_count
+    save
   end
 
   # This is triggered on before_save, but we must also remember to call Transfer#save to trigger this

--- a/test/integration/transfer_test.rb
+++ b/test/integration/transfer_test.rb
@@ -25,6 +25,13 @@ class TransferIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal @transfer_params[:graduation_year], Transfer.last.graduation_year
   end
 
+  test 'file counts are correct after creation' do
+    mock_auth(users(:transfer_submitter))
+    post transfer_index_path, params: { transfer: @transfer_params }
+    assert_equal 1, Transfer.last.unassigned_files_count
+    assert_equal 1, Transfer.last.files_count
+  end
+
   test 'including a note still success' do
     mock_auth(users(:transfer_submitter))
     orig_count = Transfer.count


### PR DESCRIPTION
**NOTE: You can test this manually by creating a Transfer with a file in Stage and noting it shows up as 0/1 in the Transfer Select page and comparing that to the PR build or locally doing the same should show up as 1/1 (or 5/5 if you upload five files, etc)**

**Note: we'll want to run the rake task in production after this merges to ensure any Transfers created between when this bug occurred and now are updated with proper counts**

Why are these changes being introduced:

* unassigned_files_count was not updated for newly created Transfers due to how ActiveStorage objects are not available until the `after_create_commit` callback

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-613

How does this address that need:

* Adds an `after_create_commit` to Transfers that re-saves the record and thus updates the counts properly.

Document any side effects to this change:

Every newly created Transfer is saved twice. This is not a high volume route so it seems okay, albeit unfortunate.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
