### PR TITLE
Change email 'from' address

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ this automatically. It is often nice in development as well.
 ### Development
 
 `MAINTAINER_EMAIL` - used for `to` field of virus detected emails.
-`THESIS_ADMIN_EMAIL` - used for `from` field of receipt emails. Also the email to which reports are sent.
+`ETD_APP_EMAIL` - used for `from` field of receipt emails.
+`THESIS_ADMIN_EMAIL` - the email to which reports are sent.
 `MAINTAINER_EMAIL` - used for `cc` field of report emails.
 `SCOUT_DEV_TRACE` - include this and set it to `true` to enable perfomance monitoring in development. Very useful to
 track down N+1 queries!

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV['THESIS_ADMIN_EMAIL']
+  default from: ENV['ETD_APP_EMAIL']
   layout 'mailer'
 end

--- a/app/mailers/batch_mailer.rb
+++ b/app/mailers/batch_mailer.rb
@@ -4,7 +4,7 @@ class BatchMailer < ApplicationMailer
 
     @theses = theses
     attachments[marc_zip_filename.to_s] = File.binread(marc_zip_file)
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: ENV['METADATA_ADMIN_EMAIL'],
          cc: ENV['MAINTAINER_EMAIL'],
          subject: 'ETD MARC batch export')
@@ -18,7 +18,7 @@ class BatchMailer < ApplicationMailer
       mime_type: json_blob.content_type,
       content: json_blob.download
     }
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: ENV['THESIS_ADMIN_EMAIL'],
          cc: ENV['MAINTAINER_EMAIL'],
          subject: 'ETD ProQuest export')

--- a/app/mailers/receipt_mailer.rb
+++ b/app/mailers/receipt_mailer.rb
@@ -6,7 +6,7 @@ class ReceiptMailer < ApplicationMailer
 
     @user = user
     @thesis = thesis
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: @user.email,
          subject: 'Your thesis information submission')
   end
@@ -16,7 +16,7 @@ class ReceiptMailer < ApplicationMailer
 
     @user = user
     @transfer = transfer
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: @user.email,
          cc: ENV['THESIS_ADMIN_EMAIL'],
          subject: 'Thesis files transferred')
@@ -26,7 +26,7 @@ class ReceiptMailer < ApplicationMailer
     return unless ENV.fetch('DISABLE_ALL_EMAIL', 'true') == 'false' # allows PR builds to disable emails
 
     @transfer = transfer
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: ENV['MAINTAINER_EMAIL'],
          cc: ENV['THESIS_ADMIN_EMAIL'],
          subject: 'Thesis files with virus detected')

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -4,7 +4,7 @@ class ReportMailer < ApplicationMailer
 
     @registrar = registrar
     @results = results
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: ENV['THESIS_ADMIN_EMAIL'],
          cc: ENV['MAINTAINER_EMAIL'],
          subject: 'Registrar data import summary')
@@ -14,7 +14,7 @@ class ReportMailer < ApplicationMailer
     return unless ENV.fetch('DISABLE_ALL_EMAIL', 'true') == 'false' # allows PR builds to disable emails
 
     @results = results
-    mail(from: "MIT Libraries <#{ENV['THESIS_ADMIN_EMAIL']}>",
+    mail(from: "MIT Libraries <#{ENV['ETD_APP_EMAIL']}>",
          to: ENV['THESIS_ADMIN_EMAIL'],
          cc: ENV['MAINTAINER_EMAIL'],
          subject: 'DSpace publication results summary')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
   ENV['SP_PRIVATE_KEY'] = ''
   ENV['SP_CERTIFICATE'] = ''
   ENV['THESIS_ADMIN_EMAIL'] = 'test@example.com'
+  ENV['ETD_APP_EMAIL'] = 'app@example.com'
   ENV['METADATA_ADMIN_EMAIL'] = 'test-metadata@example.com'
   ENV['SQS_INPUT_QUEUE_URL'] = 'http://localhost:5000/123456789012/etd-test-input'
   ENV['SQS_OUTPUT_QUEUE_NAME'] = 'etd-test-output'

--- a/test/mailers/batch_mailer_test.rb
+++ b/test/mailers/batch_mailer_test.rb
@@ -13,7 +13,7 @@ class BatchMailerTest < ActionMailer::TestCase
       end
 
       # Make sure it was sent to the right person with the expected attachment.
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['test-metadata@example.com'], email.to
       assert_equal 'ETD MARC batch export', email.subject
       assert_equal 'marc.zip', email.attachments.first.filename
@@ -48,7 +48,7 @@ class BatchMailerTest < ActionMailer::TestCase
       end
 
       # Make sure it was sent to the right person with the expected attachment.
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['test@example.com'], email.to
       assert_equal 'ETD ProQuest export', email.subject
       assert_equal 'pq.json', email.attachments.first.filename

--- a/test/mailers/receipt_mailer_test.rb
+++ b/test/mailers/receipt_mailer_test.rb
@@ -13,7 +13,7 @@ class ReceiptMailerTest < ActionMailer::TestCase
       end
 
       # Test the body of the sent email contains what we expect it to
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['admin@example.com'], email.to
       assert_equal 'Your thesis information submission', email.subject
       assert_equal read_fixture('receipt_email').join, email.body.to_s
@@ -64,7 +64,7 @@ class ReceiptMailerTest < ActionMailer::TestCase
       end
 
       # Test the body of the sent email contains what we expect it to
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['transfer@example.com'], email.to
       assert_equal 'Thesis files transferred', email.subject
       # Please note: we are not attempting to assert_equal on the entire

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -15,7 +15,7 @@ class ReportMailerTest < ActionMailer::TestCase
 
       # Make sure it was sent to the right person with the right content. We are only testing a subset of the body
       # rather than a full sample email to avoid future testing complications
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['test@example.com'], email.to
       assert_equal 'Registrar data import summary', email.subject
       assert_match 'New theses: 1', email.body.to_s
@@ -32,7 +32,7 @@ class ReportMailerTest < ActionMailer::TestCase
         email.deliver_now
       end
 
-      assert_equal ['test@example.com'], email.from
+      assert_equal ['app@example.com'], email.from
       assert_equal ['test@example.com'], email.to
       assert_equal 'DSpace publication results summary', email.subject.to_s
       assert_match 'Total theses in output queue: 2', email.body.to_s


### PR DESCRIPTION
#### Why these changes are being introduced:

The 'from' and 'to' addresses are currently the same, which causes an unwanted loop in libanswers.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-618

#### How this addresses that need:

This sets the 'form' address in all mailers to a new env, ETD_APP_EMAIL.

#### Side effects of this change:

The new env will need to be added to all pipelines.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
