### PR TITLE
Fix bug in consented_to_proquest scope ignoring null values

### DIFF
--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -118,6 +118,8 @@ class Thesis < ApplicationRecord
                                   includes(authors: :user).where(authors: { proquest_allowed: true })
                                                           .excluding(includes(authors: :user)
                                                                      .where(authors: { proquest_allowed: false }))
+                                                          .excluding(includes(authors: :user)
+                                                                     .where(authors: { proquest_allowed: nil }))
                                 }
   scope :not_consented_to_proquest, lambda {
                                       excluding(includes(authors: :user).where(authors: { proquest_allowed: true }))

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -1269,8 +1269,25 @@ class ThesisTest < ActiveSupport::TestCase
     thesis = theses(:with_hold)
     assert_not_includes Thesis.consented_to_proquest, thesis
 
-    # multi-author thesis with conflicting opt-in statuses is excluded
+    # multi-author thesis with conflicting opt-in statuses (true, false) is excluded
     thesis = theses(:doctor)
+    assert_not_includes Thesis.consented_to_proquest, thesis
+
+    # multi-author thesis with conflicting opt-in statuses (true, nil) is excluded
+    first_author = thesis.authors.first
+    second_author = thesis.authors.second
+    assert_equal 2, thesis.authors.count
+    assert_equal true, first_author.proquest_allowed
+
+    second_author.proquest_allowed = nil
+    second_author.save
+    assert_nil second_author.proquest_allowed
+    assert_not_includes Thesis.consented_to_proquest, thesis
+
+    # multi-author thesis with conflicting opt-in statuses (false, nil) is excluded
+    first_author.proquest_allowed = false
+    thesis.save
+    assert_equal false, first_author.proquest_allowed
     assert_not_includes Thesis.consented_to_proquest, thesis
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

The consented_to_proquest scope returns thesis for which all authors have a proquest_allowed value of true and not false. This ignores author records with a null proquest_allowed value, so if a thesis has multiple authors and at least one of them has not selected an opt-in status, it will incorrectly be flagged as ready for ProQuest export.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-588
https://mitlibraries.atlassian.net/browse/ETD-603

#### How this addresses that need:

This chains an additional `excluding` call to the scope that checks for authors with null proquest_allowed, and adds regression tests to confirm the correct behavior.

#### Side effects of this change:

The additional `excluding` call is a bit ugly, but after fiddling with it for a while I decided it was more important to land a working solution than an elegant one.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
