### PR TITLE
Broaden set of theses returned by not_consented_to_proquest scope

### DIFF
--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -141,7 +141,7 @@ class ThesisController < ApplicationController
   # TODO: we need to generate and send a budget report CSV for partially harvested theses (spec TBD).
   def proquest_export
     if Thesis.ready_for_proquest_export.any?
-      ProquestExportJob.perform_later(Thesis.partial_proquest_export, Thesis.full_proquest_export)
+      ProquestExportJob.perform_later(Thesis.partial_proquest_export.to_a, Thesis.full_proquest_export.to_a)
       flash[:success] = 'The theses you selected will be exported. ' \
                         'Status updates are not immediate.'
     else

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -122,7 +122,8 @@ class Thesis < ApplicationRecord
                                                                      .where(authors: { proquest_allowed: nil }))
                                 }
   scope :not_consented_to_proquest, lambda {
-                                      excluding(includes(authors: :user).where(authors: { proquest_allowed: true }))
+                                      left_joins(authors: :user).where(authors: { proquest_allowed: nil })
+                                                                .or(where(authors: { proquest_allowed: false }))
                                     }
   scope :exported_to_proquest, -> { where(proquest_exported: ['Partial harvest', 'Full harvest']) }
   scope :not_exported_to_proquest, -> { where(proquest_exported: 'Not exported') }


### PR DESCRIPTION
#### Why these changes are being introduced:

This is a similar issue to the one solved in #1108, but in the not_consented_to_proquest scope. Here, the scope excludes all theses with an author ProQuest consent value of 'true'. This works in most cases, except when one author has opted in and another hasn't, that thesis should still be partially harvested. With the current logic, it will not show up in the export preview because the scope sees a 'true' consent value and thus excludes the thesis.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-603

#### How this addresses that need:

This inverts the logic of the not_consented_to_proquest scope. Instead of excluding theses with at least one ProQuest consent value of true, it includes theses with at least one ProQuest consent value of false or nil, using the 'or' method to return the union.

#### Side effects of this change:

Since 'includes' is not compatible with the 'or' method, the scope now uses 'left_joins' to load the author records. This also means that the the result will be an ActiveRecord assocation rather than an array. ActiveJob does not accept associations as params, so we are now casting the params as arrays. I've done with this with both the full and partial export sets to avoid confusion, even though it's only needed at this stage for the partial export set.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
