### PR TITLE
Refactor tests for consented_to_proquest scopes

### DIFF
--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -121,3 +121,27 @@ eighteen:
   thesis: ready_for_full_export
   graduation_confirmed: true
   proquest_allowed: true
+
+nineteen:
+  user: yo
+  thesis: pq_conflict_true_nil
+  graduation_confirmed: true
+  proquest_allowed: true
+
+twenty:
+  user: basic
+  thesis: pq_conflict_true_nil
+  graduation_confirmed: true
+  proquest_allowed: false
+
+twentyone:
+  user: yo
+  thesis: pq_conflict_false_nil
+  graduation_confirmed: true
+  proquest_allowed: false
+
+twentytwo:
+  user: basic
+  thesis: pq_conflict_false_nil
+  graduation_confirmed: true
+  proquest_allowed: nil

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -312,3 +312,19 @@ ready_for_partial_export:
   grad_date: 2023-02-01
   degrees: [two]
   publication_status: Published
+
+pq_conflict_true_nil:
+  title: ProQuest export conflict (doctoral, one yes, one nil)
+  dspace_handle: '2345/6789'
+  grad_date: 2023-02-01
+  degrees: [two]
+  departments: [one]
+  publication_status: Published
+
+pq_conflict_false_nil:
+  title: ProQuest export conflict (doctoral, one yes, one nil)
+  dspace_handle: '2345/6789'
+  grad_date: 2023-02-01
+  degrees: [two]
+  departments: [one]
+  publication_status: Published

--- a/test/integration/thesis_test.rb
+++ b/test/integration/thesis_test.rb
@@ -111,12 +111,12 @@ class ThesisIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test 'students can edit their advisor name via thesis form' do
-    mock_auth(users(:yo))
     count = Advisor.count
-    sample = users(:yo).theses.fourth
-    sample_advisor = sample.advisors.first
+    sample_advisor = advisors(:first)
+    sample = sample_advisor.theses.first
     assert_not_equal 'Another Name', sample_advisor.name
 
+    mock_auth(sample.users.first)
     updated = sample.serializable_hash
     sample_advisor.name = 'Another Name'
     updated['advisors_attributes'] = sample_advisor.serializable_hash

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -1274,20 +1274,11 @@ class ThesisTest < ActiveSupport::TestCase
     assert_not_includes Thesis.consented_to_proquest, thesis
 
     # multi-author thesis with conflicting opt-in statuses (true, nil) is excluded
-    first_author = thesis.authors.first
-    second_author = thesis.authors.second
-    assert_equal 2, thesis.authors.count
-    assert_equal true, first_author.proquest_allowed
-
-    second_author.proquest_allowed = nil
-    second_author.save
-    assert_nil second_author.proquest_allowed
+    thesis = theses(:pq_conflict_true_nil)
     assert_not_includes Thesis.consented_to_proquest, thesis
 
     # multi-author thesis with conflicting opt-in statuses (false, nil) is excluded
-    first_author.proquest_allowed = false
-    thesis.save
-    assert_equal false, first_author.proquest_allowed
+    thesis = theses(:pq_conflict_false_nil)
     assert_not_includes Thesis.consented_to_proquest, thesis
   end
 
@@ -1331,19 +1322,11 @@ class ThesisTest < ActiveSupport::TestCase
     assert_includes Thesis.not_consented_to_proquest, thesis
 
     # multi-author thesis with one opt-in and one null is included
-    assert_equal 2, thesis.authors.count
-    first_author = thesis.authors.first
-    second_author = thesis.authors.second
-    assert_equal true, first_author.proquest_allowed
-    assert_equal false, second_author.proquest_allowed
-
-    second_author.proquest_allowed = nil
-    second_author.save
+    thesis = theses(:pq_conflict_true_nil)
     assert_includes Thesis.not_consented_to_proquest, thesis
 
     # multi-author thesis with one opt-out and one null is included
-    first_author.proquest_allowed = false
-    first_author.save
+    thesis = theses(:pq_conflict_false_nil)
     assert_includes Thesis.not_consented_to_proquest, thesis
   end
 


### PR DESCRIPTION
Why these changes are being introduced:

Tests for the `consented_to_proquest` and `not_consented_to_proquest` scopes alter data in fixtures used for previous assertions rather than using fixtures that specifically meet each test case. This can be brittle, if one were to modify the test without noticing the changes in between assertions.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-621

How this addresses that need:

This adds more fixtures to meet each test case of the ProQuest consent scopes.

#### Side effects of this change:

Updated a couple of tests to pass, including refactoring an advisor test not to attempt to select a specific thesis attached to a specific user. That caused the test to fail in this case, and the new approach seems more resilient.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
