### PR TITLE
Detect N+1 errors in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :production do
 end
 
 group :development, :test do
+  gem 'bullet'
   gem 'byebug'
   gem 'capybara'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     cancancan (3.5.0)
     capybara (3.38.0)
@@ -385,6 +388,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
+    uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -410,6 +414,7 @@ DEPENDENCIES
   aws-sdk-rails
   aws-sdk-s3
   bootsnap
+  bullet
   byebug
   cancancan
   capybara

--- a/app/controllers/registrar_controller.rb
+++ b/app/controllers/registrar_controller.rb
@@ -27,7 +27,7 @@ class RegistrarController < ApplicationController
   end
 
   def list_registrar
-    @registrars = Registrar.all
+    @registrars = Registrar.with_attached_graduation_list.includes([:user]).all
     @jobs = Delayed::Job.where(queue: 'default')
   end
 

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -31,12 +31,14 @@ class ReportController < ApplicationController
   end
 
   def expired_holds
-    @list = Hold.active_or_expired.ends_today_or_before.order(:date_end).includes([:thesis, thesis: [:authors, :departments]])
+    @list = Hold.active_or_expired.ends_today_or_before.order(:date_end).includes([:thesis, {
+                                                                                    thesis: %i[authors departments]
+                                                                                  }])
   end
 
   def files
     report = Report.new
-    theses = Thesis.all.with_attached_files.includes([:authors, :departments])
+    theses = Thesis.all.with_attached_files.includes(%i[authors departments])
     @terms = report.extract_terms theses
     subset = filter_theses_by_term theses
     @list = report.list_unattached_files subset
@@ -79,7 +81,7 @@ class ReportController < ApplicationController
     term = params[:graduation] ? params[:graduation].to_s : 'all'
     @this_term = 'all terms'
     @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
-    holds = Hold.all.includes([:thesis, :hold_source, thesis: [:authors, authors: :user]])
+    holds = Hold.all.includes([:thesis, :hold_source, { thesis: [:authors, { authors: :user }] }])
     @terms = Report.new.extract_terms holds
     @hold_sources = HoldSource.pluck(:source).uniq.sort
     term_filtered = filter_holds_by_term holds

--- a/app/controllers/report_controller.rb
+++ b/app/controllers/report_controller.rb
@@ -31,12 +31,12 @@ class ReportController < ApplicationController
   end
 
   def expired_holds
-    @list = Hold.active_or_expired.ends_today_or_before.order(:date_end)
+    @list = Hold.active_or_expired.ends_today_or_before.order(:date_end).includes([:thesis, thesis: [:authors, :departments]])
   end
 
   def files
     report = Report.new
-    theses = Thesis.all
+    theses = Thesis.all.with_attached_files.includes([:authors, :departments])
     @terms = report.extract_terms theses
     subset = filter_theses_by_term theses
     @list = report.list_unattached_files subset
@@ -69,7 +69,7 @@ class ReportController < ApplicationController
     @this_term = 'all terms'
     @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
     report = Report.new
-    theses = Thesis.all
+    theses = Thesis.all.includes([:versions])
     @terms = report.extract_terms theses
     subset = filter_theses_by_term theses
     @list = report.list_student_submitted_metadata subset
@@ -79,7 +79,7 @@ class ReportController < ApplicationController
     term = params[:graduation] ? params[:graduation].to_s : 'all'
     @this_term = 'all terms'
     @this_term = term.in_time_zone('Eastern Time (US & Canada)').strftime('%b %Y') if term != 'all'
-    holds = Hold.all.includes(:thesis).includes(:hold_source).includes(thesis: :users).includes(thesis: :authors)
+    holds = Hold.all.includes([:thesis, :hold_source, thesis: [:authors, authors: :user]])
     @terms = Report.new.extract_terms holds
     @hold_sources = HoldSource.pluck(:source).uniq.sort
     term_filtered = filter_holds_by_term holds

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -40,14 +40,15 @@ class ThesisController < ApplicationController
     # Get array of defined terms where theses have coauthors
     @terms = defined_terms Thesis.where.not('coauthors = ?', '')
     # Filter relevant theses by selected term from querystring
-    @thesis = filter_theses_by_term Thesis.where.not('coauthors = ?', '').includes([:departments, :users])
+    @thesis = filter_theses_by_term Thesis.where.not('coauthors = ?', '').includes(%i[departments users])
   end
 
   def publication_statuses
     @terms = defined_terms Thesis.all
     @publication_statuses = Thesis.all.pluck(:publication_status).uniq.sort
     # Filter relevant theses by selected term from querystring
-    term_filtered = filter_theses_by_term Thesis.all.includes(:degrees, :departments, :users).includes(degrees: :degree_type)
+    term_filtered = filter_theses_by_term Thesis.all.includes(:degrees, :departments,
+                                                              :users).includes(degrees: :degree_type)
     @thesis = filter_theses_by_publication_status term_filtered
   end
 
@@ -79,8 +80,8 @@ class ThesisController < ApplicationController
     # Get array of defined terms where unpublished theses have files attached
     @terms = defined_terms Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', 'Published')
     # Filter relevant theses by selected term from querystring
-    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).includes([:departments, :users]).group(:id).where('publication_status != ?',
-                                                                                      'Published')
+    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).includes(%i[departments users]).group(:id).where('publication_status != ?',
+                                                                                                                      'Published')
   end
 
   def show
@@ -109,7 +110,9 @@ class ThesisController < ApplicationController
   end
 
   def process_theses
-    @thesis = Thesis.with_attached_files.includes([:departments, authors: [:user], degrees: [:degree_type]]).find(params[:id])
+    @thesis = Thesis.with_attached_files.includes([:departments, {
+                                                    authors: [:user], degrees: [:degree_type]
+                                                  }]).find(params[:id])
   end
 
   def process_theses_update

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -80,8 +80,9 @@ class ThesisController < ApplicationController
     # Get array of defined terms where unpublished theses have files attached
     @terms = defined_terms Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', 'Published')
     # Filter relevant theses by selected term from querystring
-    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).includes(%i[departments users]).group(:id).where('publication_status != ?',
-                                                                                                                      'Published')
+    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).includes(%i[departments users]).group(:id).where(
+      'publication_status != ?', 'Published'
+    )
   end
 
   def show

--- a/app/controllers/thesis_controller.rb
+++ b/app/controllers/thesis_controller.rb
@@ -40,19 +40,19 @@ class ThesisController < ApplicationController
     # Get array of defined terms where theses have coauthors
     @terms = defined_terms Thesis.where.not('coauthors = ?', '')
     # Filter relevant theses by selected term from querystring
-    @thesis = filter_theses_by_term Thesis.where.not('coauthors = ?', '')
+    @thesis = filter_theses_by_term Thesis.where.not('coauthors = ?', '').includes([:departments, :users])
   end
 
   def publication_statuses
     @terms = defined_terms Thesis.all
     @publication_statuses = Thesis.all.pluck(:publication_status).uniq.sort
     # Filter relevant theses by selected term from querystring
-    term_filtered = filter_theses_by_term Thesis.all.includes(:degrees, :departments, :users)
+    term_filtered = filter_theses_by_term Thesis.all.includes(:degrees, :departments, :users).includes(degrees: :degree_type)
     @thesis = filter_theses_by_publication_status term_filtered
   end
 
   def edit
-    @thesis = Thesis.find(params[:id])
+    @thesis = Thesis.includes([degrees: :degree_type]).find(params[:id])
     @thesis.association(:advisors).add_to_target(Advisor.new) if @thesis.advisors.count.zero?
   end
 
@@ -79,7 +79,7 @@ class ThesisController < ApplicationController
     # Get array of defined terms where unpublished theses have files attached
     @terms = defined_terms Thesis.joins(:files_attachments).group(:id).where('publication_status != ?', 'Published')
     # Filter relevant theses by selected term from querystring
-    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).group(:id).where('publication_status != ?',
+    @thesis = filter_theses_by_term Thesis.joins(:files_attachments).includes([:departments, :users]).group(:id).where('publication_status != ?',
                                                                                       'Published')
   end
 
@@ -98,7 +98,7 @@ class ThesisController < ApplicationController
   end
 
   def update
-    @thesis = Thesis.find(params[:id])
+    @thesis = Thesis.includes([authors: :user]).find(params[:id])
     if @thesis.update(thesis_params)
       flash[:success] = "#{@thesis.title} has been updated."
       ReceiptMailer.receipt_email(@thesis, current_user).deliver_later
@@ -109,7 +109,7 @@ class ThesisController < ApplicationController
   end
 
   def process_theses
-    @thesis = Thesis.find(params[:id])
+    @thesis = Thesis.with_attached_files.includes([:departments, authors: [:user], degrees: [:degree_type]]).find(params[:id])
   end
 
   def process_theses_update
@@ -135,7 +135,7 @@ class ThesisController < ApplicationController
   end
 
   def proquest_export_preview
-    @theses = Thesis.ready_for_proquest_export
+    @theses = Thesis.includes([authors: :user]).ready_for_proquest_export
   end
 
   # TODO: we need to generate and send a budget report CSV for partially harvested theses (spec TBD).

--- a/app/controllers/transfer_controller.rb
+++ b/app/controllers/transfer_controller.rb
@@ -51,18 +51,19 @@ class TransferController < ApplicationController
   end
 
   def select
-    @transfers = Transfer.all.with_attached_files.includes(:user).includes(:department)
+    @transfers = Transfer.all.includes(:user).includes(:department)
   end
 
   def show
     # Load the details of the requested Transfer record
-    @transfer = Transfer.find(params[:id])
+    @transfer = Transfer.with_attached_files.find(params[:id])
 
     # Load the Thesis records for the period covered by this Transfer (the
     # graduation month/year, and the department)
     @theses = Thesis.where('grad_date = ?', @transfer.grad_date)
     @theses = @theses.includes(:departments).where('departments.name_dw = ?',
                                                    @transfer.department.name_dw).references(:departments)
+    @theses.with_attached_files
   end
 
   private

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -15,11 +15,11 @@ class Report
       'value' => subset.pluck(:id).uniq.count,
       'verb' => 'has',
       'label' => 'files attached',
-      'note' => 'Only theses with a status of "Not ready for publication" and "Publication review" will be visible '\
+      'note' => 'Only theses with a status of "Not ready for publication" and "Publication review" will be visible ' \
                 'in the processing queue.',
       'link' => {
         'url' => url_helpers.thesis_select_path(graduation: term),
-        'text' => "See #{subset.where('publication_status != ?', 'Published').pluck(:id).uniq.count} unpublished "\
+        'text' => "See #{subset.where('publication_status != ?', 'Published').pluck(:id).uniq.count} unpublished " \
                   'theses in processing queue'
       }
     }
@@ -235,7 +235,8 @@ class Report
     row_data = {}
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
-      row_data[term] = Thesis.with_files.where('grad_date = ?', term).includes([:authors]).reject(&:authors_graduated?).uniq.count
+      row_data[term] =
+        Thesis.with_files.where('grad_date = ?', term).includes([:authors]).reject(&:authors_graduated?).uniq.count
     end
     {
       label: 'Authors not graduated',
@@ -372,7 +373,7 @@ class Report
     table_populate_defaults result, Copyright.pluck(:holder)
     {
       'title' => 'Thesis counts by copyright',
-      'summary' => 'This table presents a summary of thesis records by their copyright status. The second column '\
+      'summary' => 'This table presents a summary of thesis records by their copyright status. The second column ' \
                    'names the copyright holder, while the first column shows how many records have that copyright.',
       'column' => 'Copyright holder',
       'data' => result
@@ -384,10 +385,10 @@ class Report
     table_populate_defaults result, Department.pluck(:name_dw)
     {
       'title' => 'Thesis counts by department',
-      'summary' => 'This table presents a summary of which departments have how many theses for the selected term. '\
-                   'The second column shows the programs at MIT which grant degrees, while the first column shows how '\
+      'summary' => 'This table presents a summary of which departments have how many theses for the selected term. ' \
+                   'The second column shows the programs at MIT which grant degrees, while the first column shows how ' \
                    'many theses have come from that program during this period.',
-      'note' => 'Please note: total theses indicated by this table may be greater than the overall number of theses '\
+      'note' => 'Please note: total theses indicated by this table may be greater than the overall number of theses ' \
                 'because some theses have multiple departments.',
       'column' => 'Department',
       'data' => result
@@ -406,10 +407,10 @@ class Report
     table_populate_defaults result, License.pluck(:display_description)
     {
       'title' => 'Thesis counts by Creative Commons license',
-      'summary' => 'This table presents a summary of which Creative Commons license has been selected by the author, '\
-                   'for those theses for which the author retains copyright. The second column gives the specific CC '\
+      'summary' => 'This table presents a summary of which Creative Commons license has been selected by the author, ' \
+                   'for those theses for which the author retains copyright. The second column gives the specific CC ' \
                    'license selected, while the first column shows how many theses have selected it.',
-      'note' => 'Please note: theses for which the author does not claim copyright will have "Undefined" in this '\
+      'note' => 'Please note: theses for which the author does not claim copyright will have "Undefined" in this ' \
                 'field.',
       'column' => 'License',
       'data' => result
@@ -437,7 +438,7 @@ class Report
     table_populate_defaults result, Thesis.publication_statuses
     {
       'title' => 'Thesis counts by publication status',
-      'summary' => 'This table presents a summary of thesis records by their publication status. The second column '\
+      'summary' => 'This table presents a summary of thesis records by their publication status. The second column ' \
                    'gives the status, while the first column gives how many records have that status.',
       'column' => 'Publication status',
       'data' => result

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -235,8 +235,7 @@ class Report
     row_data = {}
     terms = Thesis.all.pluck(:grad_date).uniq.sort
     terms.each do |term|
-      row_data[term] = Thesis.with_files.where('grad_date = ?', term).includes(authors: :user).includes(:departments)
-                             .reject(&:authors_graduated?).uniq.count
+      row_data[term] = Thesis.with_files.where('grad_date = ?', term).includes([:authors]).reject(&:authors_graduated?).uniq.count
     end
     {
       label: 'Authors not graduated',

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -386,8 +386,8 @@ class Report
     {
       'title' => 'Thesis counts by department',
       'summary' => 'This table presents a summary of which departments have how many theses for the selected term. ' \
-                   'The second column shows the programs at MIT which grant degrees, while the first column shows how ' \
-                   'many theses have come from that program during this period.',
+                   'The second column shows the programs at MIT which grant degrees, while the first column shows ' \
+                   'how many theses have come from that program during this period.',
       'note' => 'Please note: total theses indicated by this table may be greater than the overall number of theses ' \
                 'because some theses have multiple departments.',
       'column' => 'Department',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = false
+    Bullet.bullet_logger = false
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,18 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+
+  # Bullet configuration: currently disabled because we can't currently fix all issues
+  # This configuration block is still useful to allow manually enabling detection locally
+  # to investigate problems.
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = false # raise an error if n+1 query occurs
+    Bullet.unused_eager_loading_enable = false
+    Bullet.counter_cache_enable        = false
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   ENV['SP_PRIVATE_KEY'] = ''


### PR DESCRIPTION
Why are these changes being introduced:

* This app has a history of poor performance in production that we have been able to slowly adjust by investigating N+1 queries
* The bullet gem gives us a more structured way of detecting, logging, and addressing these types of issues during development so we can avoid pushing new problems into production

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-569
* https://mitlibraries.atlassian.net/browse/ETD-570
* https://mitlibraries.atlassian.net/browse/ETD-609
* https://mitlibraries.atlassian.net/browse/ETD-608

How does this address that need:

* Adds Bullet gem and associated configuration
* Using application in development and test envs, used the information provided to address N+1 queries and removed a few over eager loads.

Document any side effects to this change:

* Running Bullet as part of our test suite would be ideal, but administrate is a bit complicated to fix the reported issues. We could probably ignore all of the administrate errors, but it was not yet clear if that was a good path so leaving it disabled in test is the current plan.
* There are some over eager loads that track back to ActiveStorage. From my reading of the documentation, we are doing the calls properly so it wasn't clear yet how to proceed.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
