### PR TITLE
Update theme gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'json'
 gem 'kaminari'
 gem 'lograge'
 gem 'marc'
-gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.0.1'
+gem 'mitlibraries-theme', git: 'https://github.com/mitlibraries/mitlibraries-theme', tag: 'v1.0.2'
 gem 'net-imap', require: false
 gem 'net-pop', require: false
 gem 'net-smtp', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mitlibraries/mitlibraries-theme
-  revision: bd1b8bdbe49df5deeafeb8b245b95f78674e119d
-  tag: v1.0.1
+  revision: bbd5bb9f8f977251651a41be47b59aa5bd1b22c1
+  tag: v1.0.2
   specs:
-    mitlibraries-theme (1.0.0)
+    mitlibraries-theme (1.0.2)
       rails (>= 6, < 8)
       sassc-rails (~> 2)
 


### PR DESCRIPTION
Why these changes are being introduced:

The new theme gem version includes some footer updates requested by UXWS.

Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1507

How this addresses that need:

This updates the theme gem.

Side effects of this change:

The previous version missed the `versions.rb` change, so the lockfile will show an increment from `1.0.0` to `1.0.2`, when in reality it is from `1.0.1` to `1.0.2`.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
