### PR TITLE
Render hold status enums correctly

### DIFF
--- a/app/helpers/hold_helper.rb
+++ b/app/helpers/hold_helper.rb
@@ -10,6 +10,8 @@ module HoldHelper
       field_value = link_to hold_source.source, admin_hold_source_path(field_value)
     end
 
+    field_value = render_status(field_value) if field_name == 'status'
+
     field_value
   end
 
@@ -27,5 +29,22 @@ module HoldHelper
     end
 
     holds
+  end
+
+  # This patches a PaperTrail bug that saves enums to the version table as integers instead of their mapped values.
+  # We never noticed this bug because it occurs only with YAML data, but PT is able to correctly parse enums when it
+  # unserializes YAML data. This is not the case with JSON data, so historical statuses are stored as integers and
+  # render as integers. Because PT no longer maps the enums, we do so here.
+  def render_status(value)
+    case value
+    when 0
+      'active'
+    when 1
+      'expired'
+    when 2
+      'released'
+    else
+      value
+    end
   end
 end

--- a/app/models/hold.rb
+++ b/app/models/hold.rb
@@ -70,7 +70,12 @@ class Hold < ApplicationRecord
   # multiple times, this assumes we want the most recent date released.
   def date_released
     released_versions = versions.select do |version|
-      version.changeset['status'][1] == 'released' if version.changeset['status'].present?
+      next unless version.changeset['status'].present?
+
+      # We check for the integer 2 here because that corresponds with 'released', and PT has been incorrectly storing
+      # all enum values as integers since we started using it. That is fixed now that we migrated to JSON, but it
+      # remains a problem with historical data.
+      version.changeset['status'][1] == 'released' || version.changeset['status'][1] == 2
     end
     dates_released = released_versions.map { |version| version.changeset['updated_at'][1] }
     dates_released.max


### PR DESCRIPTION
#### Why these changes are being introduced:

Following the YAML to JSON migration of the versions table, hold statuses render in the UI as integers rather than strings. This is because they were always incorrectly stored as integers, but the PT YAML serializer apparently mapped them to strings as part of the deserialization process.

In JSON, this mapping no longer occurs, so we need some additional data handling to clean up the UI.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-629
* https://mitlibraries.atlassian.net/browse/ETD-630

#### How this addresses that need:

This addresses the two affected parts of the UI:

1. The hold history view, which renders `object_changes` changesets, currently displays integers for hold status. A new hold helper method maps the integers to the correct strings in the UI.
2. The hold admin UI has a 'date released' column that shows when the hold's status was most recently set to 'released'. The `Hold#date_released` method no longer evaluates this correctly, since migrated data stores that status as the integer 2. That method now expects either `released` or `2` as statuses.

#### Side effects of this change:

This fixes the bug superficially, but we need to decide what to do about the underlying problem. (Spike ticket ETD-630 addresses this.)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
