### PR TITLE
Remove YAML permitted columns config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,15 +19,5 @@ module Thing
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.active_job.queue_adapter = :delayed_job
-
-    # This is required only for the db migration to convert YAML to JSON. We should remove it once we've run that
-    # migration in all environments.
-    config.active_record.yaml_column_permitted_classes = [
-      ActiveSupport::HashWithIndifferentAccess,
-      ActiveSupport::TimeWithZone,
-      ActiveSupport::TimeZone,
-      Date,
-      Time
-    ]
   end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We had temporarily permitted certain data types for YAML unsafe load to support the migration of PaperTrail data in the `versions` table from YAML to JSON. That migration is complete, meaning we no longer use YAML in ETD and this config is no longer needed.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-628

#### How this addresses that need:

This removes the unneeded config.

#### Side effects of this change:

None.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
