### PR TITLE
Copyright display to author filter

### DIFF
--- a/app/models/copyright.rb
+++ b/app/models/copyright.rb
@@ -15,7 +15,9 @@ class Copyright < ApplicationRecord
   has_many :theses
 
   validates :holder, presence: true
-  validates :display_to_author, presence: true
+  validates :display_to_author, inclusion: [true, false]
   validates :display_description, presence: true
   validates :statement_dspace, presence: true
+
+  scope :display_to_author, -> { where(display_to_author: true) }
 end

--- a/app/views/thesis/edit.html.erb
+++ b/app/views/thesis/edit.html.erb
@@ -127,6 +127,7 @@
 
       <%= f.association :copyright, as: :select,
                                     required: true,
+                                    collection: Copyright.display_to_author,
                                     validate: { present: true },
                                     include_hidden: false,
                                     label: 'Copyright holder *',

--- a/app/views/thesis/new.html.erb
+++ b/app/views/thesis/new.html.erb
@@ -125,6 +125,7 @@
 
     <%= f.association :copyright, as: :select,
                                   required: true,
+                                  collection: Copyright.display_to_author,
                                   validate: { presence: true },
                                   include_hidden: false,
                                   label: 'Copyright holder *',

--- a/test/fixtures/copyrights.yml
+++ b/test/fixtures/copyrights.yml
@@ -51,3 +51,9 @@ sacrificial:
   display_to_author: true
   display_description: "This will be deleted during testing."
   statement_dspace: "This will be deleted during testing."
+
+nodisplay:
+  holder: Author
+  display_to_author: false
+  display_description: "This will not display as selectable to authors."
+  statement_dspace: "This will not display as selectable to authors."

--- a/test/models/copyright_test.rb
+++ b/test/models/copyright_test.rb
@@ -66,4 +66,14 @@ class CopyrightTest < ActiveSupport::TestCase
     assert_equal copyright_count - 1, Copyright.count
     assert_equal thesis_count, Thesis.count
   end
+
+  test 'display_to_author includes display_to_author true' do
+    copyright = copyrights(:author)
+    assert(Copyright.display_to_author.include?(copyright))
+  end
+
+  test 'display_to_author excludes display_to_author false' do
+    copyright = copyrights(:nodisplay)
+    refute(Copyright.display_to_author.include?(copyright))
+  end
 end


### PR DESCRIPTION
Note: suggested validation steps:

- In the review app, use the author interface to create a new thesis but do not hit submit yet. Note the Copyright options.
- In the administrate panel for Copyright, change a Copyright to display or not so it is different than what you noted in the author display for new.
- Reload the author new form, and note the change has taken place.
- If you save the new thesis, you can then go to the edit view as an author and note the same Copyright display patterns of only showing the correct options in the dropdown.

Why are these changes being introduced:

* We have had a field labeled `display_to_author` in our data model for a long time, but it didn't do anything

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-633

How does this address that need:

* This fixes a bug that prevented `false` from being set
* This adds a scope to select only `display_to_author` where the value is true
* This updates the new and edit forms for authors to use the new `display_to_author` scope as their collection

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
