### PR TITLE
Enable fake auth for new staging app

### DIFF
--- a/app/models/concerns/fake_auth_config.rb
+++ b/app/models/concerns/fake_auth_config.rb
@@ -27,6 +27,10 @@ module FakeAuthConfig
   private_class_method def self.app_name_pattern_match?
     return true if Rails.env.development?
 
+    # TODO: remove this line once we have confirmed the S3 and SQS migration to the new AWS org. We created a temporary
+    # second review app to test that migration.
+    return true if ENV.fetch('HEROKU_APP_NAME', nil) == 'thesis-submit-staging-new'
+
     review_app_pattern = /^thesis-(submit|dropbox)-pr-\d+$/
     review_app_pattern.match(ENV.fetch('HEROKU_APP_NAME', nil)).present?
   end

--- a/test/models/fake_auth_test.rb
+++ b/test/models/fake_auth_test.rb
@@ -60,4 +60,11 @@ class FakeAuthTest < ActiveSupport::TestCase
       assert_equal(false, FakeAuthConfig.fake_auth_status)
     end
   end
+
+  test 'fakeauth enabled temp staging app name' do
+    ClimateControl.modify FAKE_AUTH_ENABLED: 'true',
+                          HEROKU_APP_NAME: 'thesis-submit-staging-new' do
+      assert_equal true, FakeAuthConfig.fake_auth_status
+    end
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

We have a temporary staging app, `thesis-submit-staging-new`, that we will use to test the new S3 bucket and SQS queues in the AWS org. It doesn't make sense to set up this second staging app with Touchstone, so it's best to use fake auth for testing purposes.

#### Relevant ticket(s):

N/A.

#### How this addresses that need:

This allows the new staging app to use fake auth.

#### Side effects of this change:

We'll want to remove this feature once we're done testing. An inline comment reiterates this. Longer term, it may make sense to log an exception and crash the application if fake auth is attempted in prod. (This is the situation that the `app_name_pattern_match?` method is trying to prevent.)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
