### PR TITLE
Allow thesis processors to assign accession numbers to degree periods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage
 
 storage
 .vscode
+
+# Ignore Rails Mermaid ERD gem generated HTML. (We put the markdown in the readme instead.)
+docs/etd_erd.html

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development do
   gem 'dotenv-rails'
   gem 'letter_opener'
   gem 'listen'
+  gem 'rails-mermaid_erd'
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'scout_apm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,7 @@ DEPENDENCIES
   pg
   puma
   rails (~> 7.0)
+  rails-mermaid_erd
   rubocop
   rubocop-rails
   rubyzip

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,8 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-mermaid_erd (0.4.2)
+      rails (>= 5.2)
     railties (7.0.7.2)
       actionpack (= 7.0.7.2)
       activesupport (= 7.0.7.2)

--- a/app/controllers/admin/archivematica_accessions_controller.rb
+++ b/app/controllers/admin/archivematica_accessions_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class ArchivematicaAccessionsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/degree_periods_controller.rb
+++ b/app/controllers/admin/degree_periods_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class DegreePeriodsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/archivematica_accession_dashboard.rb
+++ b/app/dashboards/archivematica_accession_dashboard.rb
@@ -1,0 +1,66 @@
+require 'administrate/base_dashboard'
+
+class ArchivematicaAccessionDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    degree_period: Field::BelongsTo.with_options(collection: DegreePeriod::VALID_GRAD_MONTHS),
+    accession_number: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    degree_period
+    accession_number
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    degree_period
+    accession_number
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    degree_period
+    accession_number
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how accessions are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(archivematica_accession)
+    archivematica_accession.accession_number.to_s
+  end
+end

--- a/app/dashboards/degree_period_dashboard.rb
+++ b/app/dashboards/degree_period_dashboard.rb
@@ -1,0 +1,68 @@
+require 'administrate/base_dashboard'
+
+class DegreePeriodDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    archivematica_accession: Field::HasOne,
+    grad_month: Field::Select.with_options(collection: DegreePeriod::VALID_GRAD_MONTHS),
+    grad_year: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    archivematica_accession
+    grad_month
+    grad_year
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    archivematica_accession
+    grad_month
+    grad_year
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    grad_month
+    grad_year
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how degree periods are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(degree_period)
+    "#{degree_period.grad_month} #{degree_period.grad_year}"
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -92,6 +92,12 @@ class Ability
     can :files, Transfer
 
     can :read, Hold
+
+    can :manage, :archivematica_accession
+    can :manage, ArchivematicaAccession
+
+    can :manage, :degree_period
+    can :manage, DegreePeriod
   end
 
   # Library staff who can use the admin dashboards (which includes operations

--- a/app/models/archivematica_accession.rb
+++ b/app/models/archivematica_accession.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: accessions
+#
+#  id               :integer          not null, primary key
+#  accession_number :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  degree_period_id :integer          not null
+#
+
+# Accession is where we store the Accession Number that is generated in our Archivematica system. It is used in this
+# application to generate an S3 key that automations in Archivematica can detect and associate with Submission
+# Information Packages (SIPs) for a single degree period with a single Accession number in Archivematica.
+class ArchivematicaAccession < ApplicationRecord
+  has_paper_trail
+  belongs_to :degree_period
+
+  validates_uniqueness_of :degree_period_id, message: 'already has an accession number'
+  validates_uniqueness_of :accession_number
+  validates :accession_number, presence: true,
+                               format: {
+                                 with: /\A(19|20)\d{2}_\d{3}\z/i,
+                                 message: 'must match the format `YYYY_ddd`, where `YYYY` is a year between 1900 and ' \
+                                          '2099, and `ddd` is a three-digit sequence number (e.g., 2023_001)'
+                               }
+end

--- a/app/models/archivematica_accession.rb
+++ b/app/models/archivematica_accession.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: accessions
+# Table name: archivematica_accessions
 #
 #  id               :integer          not null, primary key
 #  accession_number :string

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -8,6 +8,7 @@
 #  graduation_confirmed :boolean          default(FALSE), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  proquest_allowed     :boolean
 #
 class Author < ApplicationRecord
   belongs_to :user

--- a/app/models/degree_period.rb
+++ b/app/models/degree_period.rb
@@ -1,0 +1,11 @@
+class DegreePeriod < ApplicationRecord
+  has_paper_trail
+  has_one :archivematica_accession, dependent: :destroy
+
+  validates :grad_year, format: { with: /\A(19|20)\d{2}\z/i,
+                                  message: 'must be between 1900 and 2099' },
+                        uniqueness: { scope: :grad_month, message: 'and month combination already exists' }
+
+  VALID_GRAD_MONTHS = %w[May June September February].freeze
+  validates_inclusion_of :grad_month, in: VALID_GRAD_MONTHS
+end

--- a/app/models/degree_period.rb
+++ b/app/models/degree_period.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: degree_periods
+#
+#  id         :integer          not null, primary key
+#  grad_month :string
+#  grad_year  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class DegreePeriod < ApplicationRecord
   has_paper_trail
   has_one :archivematica_accession, dependent: :destroy

--- a/app/models/proquest_export_batch.rb
+++ b/app/models/proquest_export_batch.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: proquest_export_batches
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class ProquestExportBatch < ApplicationRecord
   require 'csv'
 

--- a/app/models/submission_information_package.rb
+++ b/app/models/submission_information_package.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  preserved_at        :datetime
-#  preservation_status :integer          default(0), not null
+#  preservation_status :integer          default("unpreserved"), not null
 #  bag_declaration     :string
 #  bag_name            :string
 #  manifest            :text
@@ -13,6 +13,7 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #
+
 # Creates the structure for an individual thesis to be preserved in Archivematica according to the BagIt spec:
 # https://datatracker.ietf.org/doc/html/rfc8493.
 #

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -2,22 +2,25 @@
 #
 # Table name: theses
 #
-#  id                 :integer          not null, primary key
-#  title              :string
-#  abstract           :text
-#  grad_date          :date             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  processor_note     :text
-#  author_note        :text
-#  files_complete     :boolean          default(FALSE), not null
-#  metadata_complete  :boolean          default(FALSE), not null
-#  publication_status :string           default("Not ready for publication"), not null
-#  coauthors          :string
-#  copyright_id       :integer
-#  license_id         :integer
-#  dspace_handle      :string
-#  issues_found       :boolean          default(FALSE), not null
+#  id                       :integer          not null, primary key
+#  title                    :string
+#  abstract                 :text
+#  grad_date                :date             not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  processor_note           :text
+#  author_note              :text
+#  files_complete           :boolean          default(FALSE), not null
+#  metadata_complete        :boolean          default(FALSE), not null
+#  publication_status       :string           default("Not ready for publication"), not null
+#  coauthors                :string
+#  copyright_id             :integer
+#  license_id               :integer
+#  dspace_handle            :string
+#  issues_found             :boolean          default(FALSE), not null
+#  authors_count            :integer
+#  proquest_exported        :integer          default("Not exported"), not null
+#  proquest_export_batch_id :integer
 #
 
 class Thesis < ApplicationRecord

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -2,13 +2,15 @@
 #
 # Table name: transfers
 #
-#  id            :integer          not null, primary key
-#  user_id       :integer          not null
-#  department_id :integer          not null
-#  grad_date     :date             not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  note          :text
+#  id                     :integer          not null, primary key
+#  user_id                :integer          not null
+#  department_id          :integer          not null
+#  grad_date              :date             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  note                   :text
+#  files_count            :integer          default(0), not null
+#  unassigned_files_count :integer          default(0), not null
 #
 class Transfer < ApplicationRecord
   belongs_to :user

--- a/config/mermaid_erd.yml
+++ b/config/mermaid_erd.yml
@@ -1,0 +1,3 @@
+# result path
+# default "mermaid_erd/index.html"
+result_path: docs/etd_erd.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,13 @@ Rails.application.routes.draw do
   # For details see http://guides.rubyonrails.org/routing.html
   namespace :admin do
     resources :users
+    resources :archivematica_accessions
     resources :advisors
     resources :authors
     resources :copyrights
     resources :degrees
     resources :degree_types
+    resources :degree_periods
     resources :departments
     resources :department_theses
     resources :holds

--- a/db/migrate/20230807173433_create_archivematica_accessions.rb
+++ b/db/migrate/20230807173433_create_archivematica_accessions.rb
@@ -1,0 +1,10 @@
+class CreateArchivematicaAccessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :archivematica_accessions do |t|
+      t.string :accession_number
+      t.index :accession_number, unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230821191942_create_degree_periods.rb
+++ b/db/migrate/20230821191942_create_degree_periods.rb
@@ -1,0 +1,24 @@
+class CreateDegreePeriods < ActiveRecord::Migration[7.0]
+  def up
+    create_table :degree_periods do |t|
+      t.string :grad_month
+      t.string :grad_year
+      t.index [:grad_month, :grad_year], unique: true
+
+      t.timestamps
+    end
+
+    # Seed the table with preexisting degree periods.
+    grad_dates = Thesis.all.map(&:grad_date).uniq.sort.map do |date|
+      { date.strftime('%B') => date.strftime('%Y') }
+    end
+    grad_dates.each do |date|
+      DegreePeriod.create grad_month: date.keys.first,
+                          grad_year: date.values.first
+    end
+  end
+
+  def down
+    drop_table :degree_periods
+  end
+end

--- a/db/migrate/20230821194847_add_degree_period_to_archivematica_accessions.rb
+++ b/db/migrate/20230821194847_add_degree_period_to_archivematica_accessions.rb
@@ -1,0 +1,5 @@
+class AddDegreePeriodToArchivematicaAccessions < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :archivematica_accessions, :degree_period, null: false, index: { unique: true }, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_07_141544) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_194847) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -56,6 +56,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_141544) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "archivematica_accessions", force: :cascade do |t|
+    t.string "accession_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "degree_period_id", null: false
+    t.index ["accession_number"], name: "index_archivematica_accessions_on_accession_number", unique: true
+    t.index ["degree_period_id"], name: "index_archivematica_accessions_on_degree_period_id", unique: true
+  end
+
   create_table "authors", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "thesis_id", null: false
@@ -75,6 +84,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_141544) do
     t.text "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "degree_periods", force: :cascade do |t|
+    t.string "grad_month"
+    t.string "grad_year"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["grad_month", "grad_year"], name: "index_degree_periods_on_grad_month_and_grad_year", unique: true
   end
 
   create_table "degree_theses", id: false, force: :cascade do |t|
@@ -271,6 +288,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_07_141544) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "archivematica_accessions", "degree_periods"
   add_foreign_key "authors", "theses"
   add_foreign_key "authors", "users"
   add_foreign_key "degrees", "degree_types"

--- a/test/fixtures/archivematica_accessions.yml
+++ b/test/fixtures/archivematica_accessions.yml
@@ -1,4 +1,13 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: archivematica_accessions
+#
+#  id               :integer          not null, primary key
+#  accession_number :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  degree_period_id :integer          not null
+#
 
 # This model initially had no columns defined. If you add columns to the
 # model remove the "{}" from the fixture names and add the columns immediately

--- a/test/fixtures/archivematica_accessions.yml
+++ b/test/fixtures/archivematica_accessions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+valid_number_and_degree_period:
+  accession_number: '2023_001'
+  degree_period: june_2023

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -8,6 +8,7 @@
 #  graduation_confirmed :boolean          default(FALSE), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  proquest_allowed     :boolean
 #
 
 one:

--- a/test/fixtures/degree_periods.yml
+++ b/test/fixtures/degree_periods.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+june_2023:
+  grad_month: 'June'
+  grad_year: '2023'
+
+no_archivematica_accessions:
+  grad_month: 'May'
+  grad_year: '2024'

--- a/test/fixtures/degree_periods.yml
+++ b/test/fixtures/degree_periods.yml
@@ -1,4 +1,13 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: degree_periods
+#
+#  id         :integer          not null, primary key
+#  grad_month :string
+#  grad_year  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 
 june_2023:
   grad_month: 'June'

--- a/test/fixtures/submission_information_packages.yml
+++ b/test/fixtures/submission_information_packages.yml
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: submission_information_packages
+#
+#  id                  :integer          not null, primary key
+#  preserved_at        :datetime
+#  preservation_status :integer          default("unpreserved"), not null
+#  bag_declaration     :string
+#  bag_name            :string
+#  manifest            :text
+#  metadata            :text
+#  thesis_id           :integer          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
 sip_one:
   preserved_at: Master of Fine Arts
   preservation_status: 0

--- a/test/fixtures/theses.yml
+++ b/test/fixtures/theses.yml
@@ -2,22 +2,25 @@
 #
 # Table name: theses
 #
-#  id                 :integer          not null, primary key
-#  title              :string
-#  abstract           :text
-#  grad_date          :date             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  processor_note     :text
-#  author_note        :text
-#  files_complete     :boolean          default(FALSE), not null
-#  metadata_complete  :boolean          default(FALSE), not null
-#  publication_status :string           default("Not ready for publication"), not null
-#  coauthors          :string
-#  copyright_id       :integer
-#  license_id         :integer
-#  dspace_handle      :string
-#  issues_found       :boolean          default(FALSE), not null
+#  id                       :integer          not null, primary key
+#  title                    :string
+#  abstract                 :text
+#  grad_date                :date             not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  processor_note           :text
+#  author_note              :text
+#  files_complete           :boolean          default(FALSE), not null
+#  metadata_complete        :boolean          default(FALSE), not null
+#  publication_status       :string           default("Not ready for publication"), not null
+#  coauthors                :string
+#  copyright_id             :integer
+#  license_id               :integer
+#  dspace_handle            :string
+#  issues_found             :boolean          default(FALSE), not null
+#  authors_count            :integer
+#  proquest_exported        :integer          default("Not exported"), not null
+#  proquest_export_batch_id :integer
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/transfers.yml
+++ b/test/fixtures/transfers.yml
@@ -2,13 +2,15 @@
 #
 # Table name: transfers
 #
-#  id            :integer          not null, primary key
-#  user_id       :integer          not null
-#  department_id :integer          not null
-#  grad_date     :date             not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  note          :text
+#  id                     :integer          not null, primary key
+#  user_id                :integer          not null
+#  department_id          :integer          not null
+#  grad_date              :date             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  note                   :text
+#  files_count            :integer          default(0), not null
+#  unassigned_files_count :integer          default(0), not null
 #
 valid:
   department: one

--- a/test/integration/admin/admin_archivematica_accession_test.rb
+++ b/test/integration/admin/admin_archivematica_accession_test.rb
@@ -1,0 +1,118 @@
+require 'test_helper'
+
+class AdminArchivematicaAccessionTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'anonymous users cannot access archivematica accession dashboard' do
+    get '/admin/archivematica_accessions'
+    assert_response :redirect
+  end
+
+  test 'basic users cannot access archivematica accession dashboard' do
+    mock_auth(users(:basic))
+    get '/admin/archivematica_accessions'
+    assert_response :redirect
+  end
+
+  test 'transfer submitters cannot access archivematica accession dashboard' do
+    mock_auth(users(:transfer_submitter))
+    get '/admin/archivematica_accessions'
+    assert_response :redirect
+  end
+
+  test 'thesis processors can access archivematica accession dashboard' do
+    mock_auth(users(:processor))
+    get '/admin/archivematica_accessions'
+    assert_response :success
+  end
+
+  test 'thesis admins can access archivematica accession dashboard' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/archivematica_accessions'
+    assert_response :success
+  end
+
+  test 'thesis processors can view archivematica accession details through dashboard' do
+    mock_auth(users(:processor))
+    get "/admin/archivematica_accessions/#{ArchivematicaAccession.first.id}"
+    assert_response :success
+  end
+
+  test 'thesis processors can create an archivematica_accession' do
+    mock_auth(users(:processor))
+    orig_count = ArchivematicaAccession.count
+    new_archivematica_accession = {
+      accession_number: '2010_001',
+      degree_period_id: degree_periods(:no_archivematica_accessions).id
+    }
+    post admin_archivematica_accessions_path, params: { archivematica_accession: new_archivematica_accession }
+    assert_equal orig_count + 1, ArchivematicaAccession.count
+  end
+
+  test 'thesis processors can update an archivematica accession' do
+    mock_auth(users(:processor))
+    archivematica_accession = ArchivematicaAccession.first
+    new_accession_number = '2014_001'
+    assert_not_equal new_accession_number, archivematica_accession.accession_number
+
+    patch admin_archivematica_accession_path(archivematica_accession),
+          params: { archivematica_accession: { accession_number: new_accession_number } }
+    archivematica_accession.reload
+    assert_equal new_accession_number, archivematica_accession.accession_number
+  end
+
+  test 'thesis processors can destroy an archivematica accession' do
+    mock_auth(users(:processor))
+    archivematica_accession = ArchivematicaAccession.first
+    archivematica_accession_id = archivematica_accession.id
+    assert ArchivematicaAccession.exists?(archivematica_accession_id)
+
+    delete admin_archivematica_accession_path(archivematica_accession)
+    assert_not ArchivematicaAccession.exists?(archivematica_accession_id)
+  end
+
+  test 'thesis admins can view archivematica accession details through dashboard' do
+    mock_auth(users(:thesis_admin))
+    get "/admin/archivematica_accessions/#{ArchivematicaAccession.first.id}"
+    assert_response :success
+  end
+
+  test 'thesis admins can create an archivematica accession' do
+    mock_auth(users(:thesis_admin))
+    orig_count = ArchivematicaAccession.count
+    new_archivematica_accession = {
+      accession_number: '2010_001',
+      degree_period_id: degree_periods(:no_archivematica_accessions).id
+    }
+    post admin_archivematica_accessions_path, params: { archivematica_accession: new_archivematica_accession }
+    assert_equal orig_count + 1, ArchivematicaAccession.count
+  end
+
+  test 'thesis admins can update an archivematica accession' do
+    mock_auth(users(:thesis_admin))
+    archivematica_accession = ArchivematicaAccession.first
+    new_accession_number = '2014_001'
+    assert_not_equal new_accession_number, archivematica_accession.accession_number
+
+    patch admin_archivematica_accession_path(archivematica_accession),
+          params: { archivematica_accession: { accession_number: new_accession_number } }
+    archivematica_accession.reload
+    assert_equal new_accession_number, archivematica_accession.accession_number
+  end
+
+  test 'thesis admins can destroy an archivematica accession' do
+    mock_auth(users(:thesis_admin))
+    archivematica_accession = ArchivematicaAccession.first
+    archivematica_accession_id = archivematica_accession.id
+    assert ArchivematicaAccession.exists?(archivematica_accession_id)
+
+    delete admin_archivematica_accession_path(archivematica_accession)
+    assert_not ArchivematicaAccession.exists?(archivematica_accession_id)
+  end
+end

--- a/test/integration/admin/admin_degree_period_test.rb
+++ b/test/integration/admin/admin_degree_period_test.rb
@@ -1,0 +1,114 @@
+require 'test_helper'
+
+class AdminDegreePeriodTest < ActionDispatch::IntegrationTest
+  def setup
+    auth_setup
+  end
+
+  def teardown
+    auth_teardown
+  end
+
+  test 'anonymous users cannot access degree period dashboard' do
+    get '/admin/degree_periods'
+    assert_response :redirect
+  end
+
+  test 'basic users cannot access degree period dashboard' do
+    mock_auth(users(:basic))
+    get '/admin/degree_periods'
+    assert_response :redirect
+  end
+
+  test 'transfer submitters cannot access degree period dashboard' do
+    mock_auth(users(:transfer_submitter))
+    get '/admin/degree_periods'
+    assert_response :redirect
+  end
+
+  test 'thesis processors can access degree period dashboard' do
+    mock_auth(users(:processor))
+    get '/admin/degree_periods'
+    assert_response :success
+  end
+
+  test 'thesis admins can access degree period dashboard' do
+    mock_auth(users(:thesis_admin))
+    get '/admin/degree_periods'
+    assert_response :success
+  end
+
+  test 'thesis processors can view degree period details through dashboard' do
+    mock_auth(users(:processor))
+    get "/admin/degree_periods/#{DegreePeriod.first.id}"
+    assert_response :success
+  end
+
+  test 'thesis processors can create a degree period' do
+    mock_auth(users(:processor))
+    orig_count = DegreePeriod.count
+    new_degree_period = {
+      grad_month: 'February',
+      grad_year: '2023'
+    }
+    post admin_degree_periods_path, params: { degree_period: new_degree_period }
+    assert_equal orig_count + 1, DegreePeriod.count
+  end
+
+  test 'thesis processors can update a degree period' do
+    mock_auth(users(:processor))
+    degree_period = DegreePeriod.first
+    assert_not_equal 'February', degree_period.grad_month
+
+    patch admin_degree_period_path(degree_period), params: { degree_period: { grad_month: 'February' } }
+    degree_period.reload
+    assert_equal degree_period.grad_month, 'February'
+  end
+
+  test 'thesis processors can destroy a degree period' do
+    mock_auth(users(:processor))
+    degree_period = DegreePeriod.first
+    degree_period_id = degree_period.id
+    assert DegreePeriod.exists?(degree_period_id)
+
+    delete admin_degree_period_path(degree_period)
+    assert_not DegreePeriod.exists?(degree_period_id)
+  end
+
+  test 'thesis admins can view degree period details through dashboard' do
+    mock_auth(users(:thesis_admin))
+    get "/admin/degree_periods/#{DegreePeriod.first.id}"
+    assert_response :success
+  end
+
+  test 'thesis admins can create a degree period' do
+    mock_auth(users(:thesis_admin))
+    orig_count = DegreePeriod.count
+    new_degree_period = {
+      grad_month: 'February',
+      grad_year: '2023'
+    }
+    post admin_degree_periods_path, params: { degree_period: new_degree_period }
+    assert_equal orig_count + 1, DegreePeriod.count
+  end
+
+  test 'thesis admins can update a degree period' do
+    mock_auth(users(:thesis_admin))
+    degree_period = DegreePeriod.first
+    assert_not_equal 'February', degree_period.grad_month
+
+    patch admin_degree_period_path(degree_period), params: { degree_period: { grad_month: 'February' } }
+    degree_period.reload
+    assert_equal degree_period.grad_month, 'February'
+  end
+
+  test 'thesis admins can destroy a degree period' do
+    mock_auth(users(:thesis_admin))
+    degree_period = degree_periods(:no_archivematica_accessions)
+    degree_period_id = degree_period.id
+    assert DegreePeriod.exists?(degree_period_id)
+
+    delete admin_degree_period_path(degree_period)
+    assert_not DegreePeriod.exists?(degree_period_id)
+  end
+end

--- a/test/models/archivematica_accession_test.rb
+++ b/test/models/archivematica_accession_test.rb
@@ -1,0 +1,164 @@
+# == Schema Information
+#
+# Table name: archivematica_accessions
+#
+#  id               :integer          not null, primary key
+#  accession_number :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  degree_period_id :integer          not null
+#
+require "test_helper"
+
+class ArchivematicaAccessionTest < ActiveSupport::TestCase
+  test 'invalid without a degree period' do
+    a = ArchivematicaAccession.new
+    a.accession_number = '2030_001'
+    assert_not a.valid?
+
+    a.degree_period = degree_periods(:no_archivematica_accessions)
+    assert a.valid?
+  end
+
+  test 'invalid without an accession number' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert a.valid?
+
+    a.accession_number = nil
+    assert_nil a.accession_number
+    assert_not a.valid?
+  end
+
+  test 'accession numbers in the expected format are valid' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert a.valid?
+
+    # basic format
+    a.accession_number = '2016_001'
+    assert a.valid?
+
+    # year can be as early as 1900
+    a.accession_number = '1900_002'
+    assert a.valid?
+
+    # year can be as late as 2099
+    a.accession_number = '2099_003'
+    assert a.valid?
+
+    # years in between are okay, too
+    a.accession_number = '2023_004'
+    assert a.valid?
+
+    a.accession_number = '1997_005'
+    assert a.valid?
+
+    # sequence number can go up to 999
+    a.accession_number = '2016_999'
+    assert a.valid?
+  end
+
+  test 'accession numbers from especially weird years are invalid' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert a.valid?
+    
+    # years before 2000 are invalid
+    a.accession_number = '1897_001'
+    assert_not a.valid?
+
+    a.accession_number = '800_001'
+    assert_not a.valid?
+
+    # years after 2099 are invalid
+    a.accession_number = '2100_001'
+    assert_not a.valid?
+
+    a.accession_number = '3000_001'
+    assert_not a.valid?
+
+    a.accession_number = '10000_001'
+    assert_not a.valid?
+  end
+
+  test 'accession numbers must end in a three-digit sequence number' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert a.accession_number.end_with? '001'
+    assert a.valid?
+
+    a.accession_number = '2019_0001'
+    assert_not a.valid?
+
+    a.accession_number = '2019_01'
+    assert_not a.valid?
+
+    a.accession_number = '2019_1'
+    assert_not a.valid?
+
+    a.accession_number = '2019_00000000000001'
+    assert_not a.valid?
+  end
+
+  test 'the year of an accession number must be followed by an underscore' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert_equal '2023_001', a.accession_number
+    assert a.valid?
+
+    a.accession_number = '2023-001'
+    assert_not a.valid?
+  end
+
+  test 'preceding or trailing characters in an accession number are invalid' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    assert_equal '2023_001', a.accession_number
+    assert a.valid?
+
+    a.accession_number = '2023_001a'
+    assert_not a.valid?
+
+    a.accession_number = 'a2023_001'
+    assert_not a.valid?
+  end
+
+  test 'accession numbers must be unique' do
+    original = archivematica_accessions(:valid_number_and_degree_period)
+    degree_period = degree_periods(:no_archivematica_accessions)
+    duplicate = ArchivematicaAccession.new(accession_number: original.accession_number,
+                              degree_period_id: degree_period.id)
+    assert_raises ActiveRecord::RecordInvalid do
+      duplicate.save!
+    end
+
+    duplicate.accession_number = '2099_001'
+    assert_not_equal duplicate.accession_number, original.accession_number
+    assert_nothing_raised do
+      duplicate.save!
+    end
+  end
+
+  test 'multiple archivematica accessions cannot belong to the same degree period' do
+    d = degree_periods(:june_2023)
+    assert d.archivematica_accession.present?
+    assert_raises ActiveRecord::RecordInvalid do
+      d.create_archivematica_accession!(accession_number: '2024_001')
+    end
+  end
+
+  test 'an archivematica accession cannot belong to multiple degree periods' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    degree_period_one = a.degree_period
+    degree_period_two = degree_periods(:no_archivematica_accessions)
+
+    a.degree_period = degree_period_two
+    a.save
+    assert a.degree_period == degree_period_two
+    assert_not a.degree_period == degree_period_one
+  end
+
+  test 'editing an archivematica accession generates a version' do
+    a = archivematica_accessions(:valid_number_and_degree_period)
+    versions_count = a.versions.count
+    
+    a.accession_number = '2030_001'
+    a.save
+    assert_equal versions_count + 1, a.versions.count
+  end
+end

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -8,6 +8,7 @@
 #  graduation_confirmed :boolean          default(FALSE), not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
+#  proquest_allowed     :boolean
 #
 require 'csv'
 require 'test_helper'

--- a/test/models/degree_period_test.rb
+++ b/test/models/degree_period_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: degree_periods
+#
+#  id         :integer          not null, primary key
+#  grad_month :string
+#  grad_year  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "test_helper"
 
 class DegreePeriodTest < ActiveSupport::TestCase

--- a/test/models/proquest_export_batch_test.rb
+++ b/test/models/proquest_export_batch_test.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: proquest_export_batches
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'test_helper'
 require 'csv'
 

--- a/test/models/submission_information_package_test.rb
+++ b/test/models/submission_information_package_test.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :integer          not null, primary key
 #  preserved_at        :datetime
-#  preservation_status :integer          default(0), not null
+#  preservation_status :integer          default("unpreserved"), not null
 #  bag_declaration     :string
 #  bag_name            :string
 #  manifest            :text

--- a/test/models/thesis_test.rb
+++ b/test/models/thesis_test.rb
@@ -2,22 +2,25 @@
 #
 # Table name: theses
 #
-#  id                 :integer          not null, primary key
-#  title              :string
-#  abstract           :text
-#  grad_date          :date             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  processor_note     :text
-#  author_note        :text
-#  files_complete     :boolean          default(FALSE), not null
-#  metadata_complete  :boolean          default(FALSE), not null
-#  publication_status :string           default("Not ready for publication"), not null
-#  coauthors          :string
-#  copyright_id       :integer
-#  license_id         :integer
-#  dspace_handle      :string
-#  issues_found       :boolean          default(FALSE), not null
+#  id                       :integer          not null, primary key
+#  title                    :string
+#  abstract                 :text
+#  grad_date                :date             not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  processor_note           :text
+#  author_note              :text
+#  files_complete           :boolean          default(FALSE), not null
+#  metadata_complete        :boolean          default(FALSE), not null
+#  publication_status       :string           default("Not ready for publication"), not null
+#  coauthors                :string
+#  copyright_id             :integer
+#  license_id               :integer
+#  dspace_handle            :string
+#  issues_found             :boolean          default(FALSE), not null
+#  authors_count            :integer
+#  proquest_exported        :integer          default("Not exported"), not null
+#  proquest_export_batch_id :integer
 #
 
 require 'csv'

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -2,13 +2,15 @@
 #
 # Table name: transfers
 #
-#  id            :integer          not null, primary key
-#  user_id       :integer          not null
-#  department_id :integer          not null
-#  grad_date     :date             not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  note          :text
+#  id                     :integer          not null, primary key
+#  user_id                :integer          not null
+#  department_id          :integer          not null
+#  grad_date              :date             not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  note                   :text
+#  files_count            :integer          default(0), not null
+#  unassigned_files_count :integer          default(0), not null
 #
 require 'test_helper'
 


### PR DESCRIPTION
#### Why these changes are being introduced:

In order to automate SIP processing in Archivematica, incoming
SIPs must have an accession number in their S3 keys. We can
facilitate this on the ETD side by letting thesis processors
create accession numbers and assign them to degree periods, which
in turn will enable a thesis to look up its accession number.

This PR makes some assumptions:
* Each degree period has one and only one accession number.
* Each accession number is in the format `YYYY_ddd`, where `YYYY`
is a four-digit year and `ddd` is a three-digit sequence number.
* A thesis will always have the same accession number (i.e., a
thesis' grad date will never change, or if it does, the accession
number will remain the same).

These assumptions are based on our current understanding of the
requirements. However, we expect that edge cases will arise and
and can make changes retroactively if this approach does not meet
the need. The exception would be looking up an historical
accession number if a thesis' accession number were to change,
since we are not recording that state on the Thesis model.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-589

#### How this addresses that need:

This adds Accession and Degree Period models and corresponding
administrate dashboards. The degree periods table is autopopulated
on creation based on the grad date data in the thesis table.

Processors can use the dashboards to create accessions and assign
them to degree periods, or create degree periods to prepare for
future thesis submissions.

Note that assigning accession numbers to theses/SIPs is explicitly
out of scope for this ticket. This will likely be a convenience
method on the Thesis model that looks up the accession number as
needed, which will also be added as a publication readiness check.

#### Side effects of this change:

* As noted above, this approach does not allows us to look up a
past accession number for a thesis. If there's any possibility that
a thesis' accession number will change over time, then we should
consider adding state to the Thesis or SIP models to facilitate this.
* It may be slightly confusing to introduce a Degree Period model
that only interacts with the Accession model. This is intended as
a course correction for not having a Degree Period model when we
began developing this application. Degree periods are central to
the ETD data model and should likely be first class citizens.
Longer term, the grad date logic on the Thesis and Transfer models
should be refactored to reference the Degree Period model.
* Optimally, processors would be able to create and edit this data
in a single custom UI rather than in two administrate dashboards.
However, processors already use administrate to do other things. A
potential future refactor would be to ensure that processors can
do everything they need outside of administrate, so the dashboards
are only for developer use.
* The Rails Mermaid ERD gem has been added, but I have not included the generated markdown because GitHub has a problem rendering it that seems to be related to the version of Mermaid it's using. (See that commit message for more details.)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

YES

#### Includes new or updated dependencies?

YES
