### PR TITLE
Ensure theses are not publishable without an accession number

### DIFF
--- a/app/controllers/admin/archivematica_accessions_controller.rb
+++ b/app/controllers/admin/archivematica_accessions_controller.rb
@@ -8,6 +8,13 @@ module Admin
     #   send_foo_updated_email(requested_resource)
     # end
 
+    def new
+      resource = ArchivematicaAccession.new(degree_period_id: params[:degree_period_id])
+      render locals: {
+        page: Administrate::Page::Form.new(dashboard, resource)
+      }
+    end
+
     # Override this method to specify custom lookup behavior.
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -146,6 +146,19 @@ class Thesis < ApplicationRecord
 
   enum proquest_exported: ['Not exported', 'Full harvest', 'Partial harvest']
 
+  # Looks up the thesis' accession number based on its degree period.
+  def accession_number
+    degree_period = look_up_degree_period
+    return if degree_period.nil?
+    return if degree_period.archivematica_accession.nil?
+
+    degree_period.archivematica_accession.accession_number
+  end
+
+  def look_up_degree_period
+    DegreePeriod.find_by(grad_year: graduation_year, grad_month: graduation_month)
+  end
+
   # Returns a true/false value (rendered as "yes" or "no") if there are any
   # holds with a status of either 'active' or 'expired'. A false/"No" is
   # only returned if all holds are 'released'.
@@ -189,7 +202,8 @@ class Thesis < ApplicationRecord
       no_active_holds?,
       authors_graduated?,
       departments_have_dspace_name?,
-      degrees_have_types?
+      degrees_have_types?,
+      accession_number.present?
     ].all?
   end
 

--- a/app/views/thesis/process_theses.html.erb
+++ b/app/views/thesis/process_theses.html.erb
@@ -48,6 +48,14 @@
                                         hint: link_to('See details in admin interface', admin_thesis_path(f.object), target: :_blank) %>
           </li>
           <li>
+            <%= f.input :accession_number?, as: :string,
+                                        readonly: true,
+                                        label_html: { style: 'width: 50%' },
+                                        input_html: { class: 'disabled', style: 'width: 40%', value: f.object.accession_number.present?? 'Yes' : 'No' },
+                                        hint_html: { style: 'display: block' },
+                                        hint: (link_to('Create new accession number', new_admin_archivematica_accession_path(degree_period_id: f.object.look_up_degree_period), target: :_blank) if f.object.accession_number.nil?) %>
+          </li>
+          <li>
             <fieldset>
               <legend>Issues found</legend>
               <%= f.input :issues_found, as: :radio_buttons,

--- a/test/fixtures/archivematica_accessions.yml
+++ b/test/fixtures/archivematica_accessions.yml
@@ -16,3 +16,15 @@
 valid_number_and_degree_period:
   accession_number: '2023_001'
   degree_period: june_2023
+
+september_2017_001:
+  accession_number: '2017_001'
+  degree_period: september_2017
+
+june_2018_001:
+  accession_number: '2018_001'
+  degree_period: june_2018
+
+june_2021_001:
+  accession_number: '2021_001'
+  degree_period: june_2021

--- a/test/fixtures/degree_periods.yml
+++ b/test/fixtures/degree_periods.yml
@@ -16,3 +16,15 @@ june_2023:
 no_archivematica_accessions:
   grad_month: 'May'
   grad_year: '2024'
+
+september_2017:
+  grad_month: 'September'
+  grad_year: '2017'
+
+june_2018:
+  grad_month: 'June'
+  grad_year: '2018'
+
+june_2021:
+  grad_month: 'June'
+  grad_year: '2021'

--- a/test/integration/admin/admin_archivematica_accession_test.rb
+++ b/test/integration/admin/admin_archivematica_accession_test.rb
@@ -115,4 +115,18 @@ class AdminArchivematicaAccessionTest < ActionDispatch::IntegrationTest
     delete admin_archivematica_accession_path(archivematica_accession)
     assert_not ArchivematicaAccession.exists?(archivematica_accession_id)
   end
+
+  test 'new form can be prefilled with degree period' do
+    mock_auth users(:thesis_admin)
+    get new_admin_archivematica_accession_path, params: { degree_period_id: degree_periods(:june_2023).id }
+    assert_select 'select#archivematica_accession_degree_period_id', count: 1
+    assert_select 'option', text: 'June 2023', count: 1
+  end
+
+  test 'new form can be loaded with no prefilled degree period' do
+    mock_auth users(:thesis_admin)
+    get new_admin_archivematica_accession_path
+    assert_select 'select#archivematica_accession_degree_period_id', count: 1
+    assert_select 'option', text: '', count: 1
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Because we want the accession number to be used in the preservation workflow, we do not want a thesis without an accession number to be published.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-596

#### How this addresses that need:

This adds an `accession_number` convenience method to the Thesis model that can look up an accession based on a thesis' degree period. This method is included in the publication checks.

The thesis processing form now shows whether it can find an accession number. If no accession number exists, the form will render a hint that prompts the user to create an accession number for the given degree period.

#### Side effects of this change:

* A future state of this application is for the Thesis model to belong to the Degree Period model. For now, there is no direct assocation, so we are using ActiveRecord lookups based on the thesis' graduation year and graduation month.
* Some fixtures have been added to allow tests related to publication status to pass. (Certain thesis fixtures had no degree periods or accession numbers, they could not be put into publication review.)
* The `new` action on the Archivematica Accessions dashboard has been overwritten to prefill the degree period ID from params.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
