### PR TITLE
Use Archivematica accession numbers in SIP AWS keys

### DIFF
--- a/app/models/submission_information_package.rb
+++ b/app/models/submission_information_package.rb
@@ -70,11 +70,12 @@ class SubmissionInformationPackage < ApplicationRecord
   end
 
   # Before we try to bag anything, we need to check if it meets a few conditions. All published theses should have
-  # at least one file attached, no duplicate filenames, and a handle pointing to its DSpace record.
+  # at least one file attached, no duplicate filenames, a handle pointing to its DSpace record, and an accession number.
   def baggable_thesis?
-    return unless thesis
+    return false unless thesis
 
-    thesis.files.any? && thesis.dspace_handle.present? && !duplicate_filenames? && thesis.copyright.present?
+    thesis.files.any? && thesis.dspace_handle.present? && !duplicate_filenames? && thesis.copyright.present? \
+    && thesis.accession_number.present?
   end
 
   def duplicate_filenames?

--- a/app/models/submission_information_package_zipper.rb
+++ b/app/models/submission_information_package_zipper.rb
@@ -19,7 +19,7 @@ class SubmissionInformationPackageZipper
   # This key needs to be unique. By default, ActiveStorage generates a UUID, but since we want a file path for our
   # Archivematica needs, we are generating a key. We handle uniqueness on the `bag_name` side.
   def keygen(sip)
-    "etdsip/#{sip.thesis.graduation_year}/#{sip.thesis.graduation_month}/#{sip.bag_name}.zip"
+    "etdsip/#{sip.thesis.accession_number}/#{sip.bag_name}.zip"
   end
 
   # bagamatic takes a sip, creates a temporary zip file, and returns that file

--- a/test/models/submission_information_package_test.rb
+++ b/test/models/submission_information_package_test.rb
@@ -146,6 +146,19 @@ class SubmissionInformationPackageTest < ActiveSupport::TestCase
     assert_not sip.valid?
   end
 
+  test 'a SIP is invalid if its thesis has no accession number' do
+    # unbaggable thesis (no accession number)
+    thesis = theses(:published)
+    degree_period = thesis.look_up_degree_period
+    accession = degree_period.archivematica_accession
+    accession.destroy
+    assert_nil thesis.accession_number
+
+    sip = thesis.submission_information_packages.new
+    thesis.save
+    assert_not sip.valid?
+  end
+
   test 'a SIP is invalid if it has no thesis' do
     sip = SubmissionInformationPackage.create
     assert_not sip.valid?

--- a/test/models/submission_information_package_zipper_test.rb
+++ b/test/models/submission_information_package_zipper_test.rb
@@ -38,4 +38,13 @@ class SubmissionInformationPackageZipperTest < ActiveSupport::TestCase
       assert_equal('manifest-md5.txt', zipfile.find_entry("manifest-md5.txt").to_s)
     end
   end
+
+  test 'sip has the correct key' do
+    thesis = setup_thesis
+    sip = thesis.submission_information_packages.create
+    SubmissionInformationPackageZipper.new(sip)
+
+    blob = thesis.submission_information_packages.last.bag.blob
+    assert blob.key.starts_with? "etdsip/#{thesis.accession_number}"
+  end
 end


### PR DESCRIPTION
#### Why these changes are being introduced:

Artefactual has requested that our AWS keys for SIPs should include an Archivematica accession number. This will allow them to automate processing of thesis SIPs.

#### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-593

#### How this addresses that need:

This builds on previous work to rename the AWS key for a given thesis' SIP using the accession number for that thesis.

#### Side effects of this change:

This will only affect theses preserved _after_ this change is deployed in production. We do not have a plan to retroactively change AWS keys, and stakeholders understand and have agreed to this.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
