### PR TITLE
Adjust language in publication results email

### DIFF
--- a/app/views/report_mailer/publication_results_email.html.erb
+++ b/app/views/report_mailer/publication_results_email.html.erb
@@ -7,7 +7,7 @@
 <ul>
   <li>Total theses in output queue: <%= @results[:total] %></li>
   <li>Total theses updated: <%= @results[:processed] %></li>
-  <li>Total theses sent to preservation: <%= @results[:preservation_ready].count %>
+  <li>Total theses queued for preservation: <%= @results[:preservation_ready].count %>
   <li>Total theses exported as MARC: <%= @results[:marc_exports].count %>
   <li>Errors found: <%= @results[:errors].count %></li>
 </ul>

--- a/test/mailers/report_mailer_test.rb
+++ b/test/mailers/report_mailer_test.rb
@@ -38,7 +38,7 @@ class ReportMailerTest < ActionMailer::TestCase
       assert_match 'Total theses in output queue: 2', email.body.to_s
       assert_match 'Total theses updated: 1', email.body.to_s
       assert_match 'Errors found: 1', email.body.to_s
-      assert_match 'Total theses sent to preservation: 0', email.body.to_s
+      assert_match 'Total theses queued for preservation: 0', email.body.to_s
       assert_match 'Total theses exported as MARC: 1', email.body.to_s
       assert_match 'Couldn&#39;t find Thesis with &#39;id&#39;=9999999999999', email.body.to_s
     end


### PR DESCRIPTION
#### Why these changes are being introduced:

The publication results email lists theses that were "sent to preservation." This language is inaccurate; the theses are queued for preservation at this point, and may not be sent to the Archivematica bucket if the preservation job fails.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/ETD-645

#### How this addresses that need:

This changes the language to "Total theses queued for preservation."

#### Side effects of this change:

This does nothing to confirm or report on which theses were actually sent to preservation. (ETD-646 will evaluate the best way to do this.)

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
