### PR TITLE
Rollback SQS gem to 1.62.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 gem 'administrate', '~> 0.19.0'
 gem 'aws-sdk-rails'
 gem 'aws-sdk-s3'
-gem 'aws-sdk-sqs', '~> 1.63.0'
+gem 'aws-sdk-sqs', '~> 1.62.0'
 gem 'bootsnap'
 gem 'cancancan'
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,8 +123,8 @@ GEM
     aws-sdk-sesv2 (1.53.0)
       aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.63.0)
-      aws-sdk-core (~> 3, >= 3.184.0)
+    aws-sdk-sqs (1.62.0)
+      aws-sdk-core (~> 3, >= 3.177.0)
       aws-sigv4 (~> 1.1)
     aws-sessionstore-dynamodb (2.2.0)
       aws-sdk-dynamodb (~> 1, >= 1.85.0)
@@ -440,7 +440,7 @@ DEPENDENCIES
   annotate
   aws-sdk-rails
   aws-sdk-s3
-  aws-sdk-sqs (~> 1.63.0)
+  aws-sdk-sqs (~> 1.62.0)
   bootsnap
   bullet
   byebug


### PR DESCRIPTION
We ran into an issue in prod where we keep getting no message in queue. This is to confirm if the version change caused that.

I believe this is the last version that was used successfully to read from an SQS queue in prod (but I'm not 100% sure of that)

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
