### PR TITLE
Rollback AWS gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ git_source(:github) do |repo_name|
 end
 
 gem 'administrate', '~> 0.19.0'
-gem 'aws-sdk-rails'
-gem 'aws-sdk-s3'
+gem 'aws-sdk-rails', '~> 3.8.0'
+gem 'aws-sdk-s3', '~> 1.146.1'
 gem 'aws-sdk-sqs', '~> 1.62.0'
 gem 'bootsnap'
 gem 'cancancan'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,19 +105,19 @@ GEM
     aws-sdk-kms (1.87.0)
       aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rails (3.13.0)
+    aws-sdk-rails (3.8.0)
       aws-record (~> 2)
       aws-sdk-ses (~> 1, >= 1.50.0)
       aws-sdk-sesv2 (~> 1, >= 1.34.0)
       aws-sdk-sqs (~> 1, >= 1.56.0)
       aws-sessionstore-dynamodb (~> 2)
-      concurrent-ruby (>= 1.3.1)
+      concurrent-ruby (~> 1)
       railties (>= 5.2.0)
-    aws-sdk-s3 (1.154.0)
-      aws-sdk-core (~> 3, >= 3.199.0)
+    aws-sdk-s3 (1.146.1)
+      aws-sdk-core (~> 3, >= 3.191.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
-    aws-sdk-ses (1.65.0)
+    aws-sdk-ses (1.66.0)
       aws-sdk-core (~> 3, >= 3.199.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-sesv2 (1.53.0)
@@ -438,8 +438,8 @@ PLATFORMS
 DEPENDENCIES
   administrate (~> 0.19.0)
   annotate
-  aws-sdk-rails
-  aws-sdk-s3
+  aws-sdk-rails (~> 3.8.0)
+  aws-sdk-s3 (~> 1.146.1)
   aws-sdk-sqs (~> 1.62.0)
   bootsnap
   bullet


### PR DESCRIPTION
- the gems have changed an internal protocol that is breaking some tests. We need to rollback to a known working version to resolve production issues and then get to a point where we can upgrade all AWS gems to the latest version.

https://mitlibraries.atlassian.net/browse/ENGX-276

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

YES
