### PR TITLE
Update note about confirmation emails in publishing workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,8 +375,9 @@ Publication Review - Publish)
   # run the output queue processing job
   heroku run -s performance-m rails dss:process_output_queue --app TARGET-HEROKU-APP
 
-  # wait for all ETD emails to be received (the preservation email is the final one to look for)
-  # scale the worker back down so we do not pay for more CPU/memory than we need
+  # wait for all ETD emails to be received (there are three emails: one overall results summary, one preservation
+  # results summary, and one MARC batch export).
+  # Then, scale the worker back down so we do not pay for more CPU/memory than we need
   heroku ps:scale worker=1:standard-1x --app TARGET-HEROKU-APP
   ```
 


### PR DESCRIPTION
#### Why these changes are being introduced:

The readme indicates that the last email to look for while running the publication workflow is the preservation email. The past few times I've run the job, it's been the MARC export email.

#### Relevant ticket(s):

N/A

#### How this addresses that need:

This generalizes the aforementioned note to check for the presence of all three emails, before suggesting that the MARC email may be the last one in the series.

#### Side effects of this change:

None.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
