### PR TITLE
Remove ProQuest consent field from receipt email

### DIFF
--- a/app/views/receipt_mailer/receipt_email.html.erb
+++ b/app/views/receipt_mailer/receipt_email.html.erb
@@ -35,9 +35,6 @@ The information we have on record is listed below.</p>
 <strong>Abstract:</strong><br>
 <%= simple_format(@thesis.abstract, {}, wrapper_tag: "p") %>
 <strong>Notes:</strong> <%= @thesis.author_note %><br>
-<% if satisfies_advanced_degree?(@thesis) %>
-  <strong>Consent to send thesis to ProQuest:</strong> <%= render_proquest_status(@thesis) %>
-<% end %>
 </div>
 
 <p>Let us know if you have any questions. And again, congratulations 

--- a/test/mailers/receipt_mailer_test.rb
+++ b/test/mailers/receipt_mailer_test.rb
@@ -18,7 +18,9 @@ class ReceiptMailerTest < ActionMailer::TestCase
     end
   end
 
-  test 'confirmation emails for graduate theses include ProQuest consent' do
+  # This used to be a test that the emails _do_ include ProQuest consent, but we removed that feature in December 2024.
+  # This test is to ensure that grad students do not see a nonexistent metadata field in their receipt email.
+  test 'confirmation emails for graduate theses do not include ProQuest consent' do
     ClimateControl.modify DISABLE_ALL_EMAIL: 'false' do
       thesis = theses(:doctor)
       user = users(:basic)
@@ -29,7 +31,7 @@ class ReceiptMailerTest < ActionMailer::TestCase
         email.deliver_now
       end
 
-      assert_match '<strong>Consent to send thesis to ProQuest:</strong> Opt-in status not reconciled', email.body.to_s
+      refute_match '<strong>Consent to send thesis to ProQuest:</strong>', email.body.to_s
     end
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

We removed the ProQuest consent field from the thesis submission form, but forgot to remove the field from the mailer. Thus, when a grad student submits their thesis, they see this nonexistent field in their confirmation email.

#### Relevant ticket(s):

N/A

#### How this addresses that need:

This removes the field from the mailer.

#### Side effects of this change:

None.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
