### PR TITLE
Update S3 keys for Archivematica payloads

### DIFF
--- a/app/models/archivematica_payload.rb
+++ b/app/models/archivematica_payload.rb
@@ -82,7 +82,7 @@ class ArchivematicaPayload < ApplicationRecord
 
   # The bag_output_uri key is constructed to match the expected format for Archivematica.
   def bag_output_uri
-    key = "etdsip/#{thesis.graduation_year}/#{thesis.graduation_month}-#{thesis.accession_number}/#{bag_name}.zip"
+    key = "etdsip-apt/#{thesis.graduation_year}/#{thesis.graduation_month}-#{thesis.accession_number}/#{bag_name}.zip"
     [ENV.fetch('APT_S3_BUCKET'), key].join('/')
   end
 


### PR DESCRIPTION
#### Why these changes are being introduced:

Preservation stakeholders have requested that new ETD SIPs (generated via APT) remain separate from legacy SIPs. This helps make their Archivematica workflows more efficient.

#### Relevant ticket(s):

* [ETD-669](https://mitlibraries.atlassian.net/browse/ETD-669)

#### How this addresses that need:

This changes the base directory for Archivematica payload S3 keys from `etdsip` to `etdsip-apt`.

#### Side effects of this change:

We will need to re-preserve the batch of theses that were published yesterday.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO


[ETD-669]: https://mitlibraries.atlassian.net/browse/ETD-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ