### PR TITLE
Update publishing workflow instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,24 +377,19 @@ Publication Review - Publish)
 3. DSS runs (as of this writing that is a manual process documented in the
   [DSS repo](https://github.com/MITLibraries/dspace-submission-service#run-stage))
 4. ETD processes output queue to update records and send email to stakeholders with summary data and list
-  of any error records. As of now this is a manual process, but can be triggered via rake task using the following
-  sequence of heroku-cli commands:
+  of any error records. As of now this is a manual process, but can be triggered via rake task using the following heroku-cli command:
 
   ```shell
-  # scale the worker dyno to ensure we have enough memory
-  # as off Aug 2024 `performance-m` has been sufficient
-  heroku ps:scale worker=1:performance-m --app TARGET-HEROKU-APP
-
   # run the output queue processing job
-  heroku run -s performance-m rails dss:process_output_queue --app TARGET-HEROKU-APP
+  heroku run rails dss:process_output_queue --app TARGET-HEROKU-APP
 
   # wait for all ETD emails to be received (there are three emails: one overall results summary, one preservation
   # results summary, and one MARC batch export).
-  # Then, scale the worker back down so we do not pay for more CPU/memory than we need
-  heroku ps:scale worker=1:standard-1x --app TARGET-HEROKU-APP
   ```
 
-Note the `-s` option on the second command, which sets the dyno size for the run command. We are scaling to the larger '2X' dyno because this job is very memory-intensive. We also first scale the worker dyno to 2x and then set it back to 1x when we are done for the same reason (preservation takes a lot of memory).
+Previously, we had to scale up the Heroku worker dynos to accommodate memory spikes. This is no
+longer required as of August 2025, with the integration of the
+[Archival Packaging Tool (APT)](https://github.com/MITLibraries/archival-packaging-tool/).
 
 ### Publishing a single thesis
 


### PR DESCRIPTION
#### Why these changes are being introduced:

We previously had to scale up Heroku dynos prior to running the publishing job. Now that APT handles the bagging of SIPS, this is no longer necessary. We have run two publishing jobs and have not yet seen a memory spike.

#### Relevant ticket(s):

* [ETD-669](https://mitlibraries.atlassian.net/browse/ETD-669)

#### How this addresses that need:

This removes the dyno scaling instructions from the readme.

#### Side effects of this change:

We've only done two publishing runs since integrating APT. It's possible that dyno scaling is still needed, and we just haven't encountered a problem thesis yet. This is highly unlikely, however, since creating bags was the most memory-intensive part of the publication process.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO


[ETD-669]: https://mitlibraries.atlassian.net/browse/ETD-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ