### PR TITLE
Adds retry logic to PreservationSubmissionJob

### DIFF
--- a/test/jobs/preservation_submission_job_test.rb
+++ b/test/jobs/preservation_submission_job_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 require 'webmock/minitest'
 
 class PreservationSubmissionJobTest < ActiveJob::TestCase
-
   # because we need to actually use the file it's easier to attach it in the test rather
   # than use our fixtures as the fixtures oddly don't account for the file actually being
   # where ActiveStorage expects them to be. We also need this to be a record that looks like
@@ -27,24 +26,24 @@ class PreservationSubmissionJobTest < ActiveJob::TestCase
   end
 
   def stub_apt_lambda_success
-    stub_request(:post, ENV['APT_LAMBDA_URL'])
+    stub_request(:post, ENV.fetch('APT_LAMBDA_URL', nil))
       .to_return(
         status: 200,
         body: {
           success: true,
           bag: {
             entries: {
-              "manifest-md5.txt" => { md5: "fakehash" }
+              'manifest-md5.txt' => { md5: 'fakehash' }
             }
           },
-          output_zip_s3_uri: "s3://my-bucket/apt-testing/test-one-medium.zip"
+          output_zip_s3_uri: 's3://my-bucket/apt-testing/test-one-medium.zip'
         }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
   end
 
   def stub_apt_lambda_failure
-    stub_request(:post, ENV['APT_LAMBDA_URL'])
+    stub_request(:post, ENV.fetch('APT_LAMBDA_URL', nil))
       .to_return(
         status: 500,
         headers: { 'Content-Type' => 'application/json' }
@@ -52,13 +51,13 @@ class PreservationSubmissionJobTest < ActiveJob::TestCase
   end
 
   def stub_apt_lambda_200_failure
-    stub_request(:post, ENV['APT_LAMBDA_URL'])
+    stub_request(:post, ENV.fetch('APT_LAMBDA_URL', nil))
       .to_return(
         status: 200,
         body: {
           success: false,
-          error: "An error occurred (404) when calling the HeadObject operation: Not Found",
-          bag: { entries: {}},
+          error: 'An error occurred (404) when calling the HeadObject operation: Not Found',
+          bag: { entries: {} }
         }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
@@ -177,7 +176,6 @@ class PreservationSubmissionJobTest < ActiveJob::TestCase
     assert_empty another_good_thesis.archivematica_payloads
 
     PreservationSubmissionJob.perform_now([good_thesis, bad_thesis, another_good_thesis])
-
     # first thesis should succeed and have a payload
     assert_equal 1, good_thesis.archivematica_payloads.count
 
@@ -186,5 +184,46 @@ class PreservationSubmissionJobTest < ActiveJob::TestCase
 
     # third thesis should succeed and have a payload, despite prior failure
     assert_equal 1, another_good_thesis.archivematica_payloads.count
+  end
+
+  test 'throws exceptions and probably creates payloads when a bad key is provided' do
+    skip('Test not implemented yet')
+    # Our lambda returns 400 Bad Request with a error body of Invalid input payload
+    # This should never happen as we submit it via ENV, but just in case we should understand what it looks like
+  end
+
+  test 'retries on 502 Bad Gateway errors' do
+    # This syntax will cause the first two calls to return 502, and the third to succeed.
+    stub_request(:post, ENV.fetch('APT_LAMBDA_URL', nil))
+      .to_return(
+        { status: 502 },
+        { status: 502 },
+        { status: 200, body: {
+          success: true,
+          bag: {
+            entries: {
+              'manifest-md5.txt' => { md5: 'fakehash' }
+            }
+          },
+          output_zip_s3_uri: 's3://my-bucket/apt-testing/test-one-medium.zip'
+        }.to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
+
+    thesis = setup_thesis
+    assert_equal 0, thesis.archivematica_payloads.count
+
+    # We need to wrap this in perform_enqueued_jobs so that the retries are actually executed. Our normal syntax only
+    # runs a single job, but because we are testing retries this wrapper executes the jobs this job queues.
+    perform_enqueued_jobs do
+      PreservationSubmissionJob.perform_now([thesis])
+    end
+
+    # 3 payloads were created. 2 for the failures, 1 for the success.
+    # This isn't ideal, but it's the current behavior. A refactor to using a pre-preservation job to create
+    # metadata.csv prior to this job would fix this but is out of scope for now.
+    assert_equal 3, thesis.archivematica_payloads.count
+
+    # The last payload should be marked as preserved.
+    assert_equal 'preserved', thesis.archivematica_payloads.last.preservation_status
   end
 end


### PR DESCRIPTION
Why are these changes being introduced:

* The APT lambda will return 502 errors when it hasn't been called for a few days as AWS makes the lambda `inactive`
* This logic retries the jobs after 5 minutes to hopefully give enough time for the lambda to become active again. It retries up to 10 times.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/ETD-677

How does this address that need:

* Adds a custom error class for APTBadGatewayErrors
* Configures ActiveJob to retry on that error class up to 10 times with a wait of 5 minutes between retries

Document any side effects to this change:

* While this will reduce the number off failed jobs and manual cleanup, it will create additional files in S3 and additional records in the ETD database due to that logic being included in the job that is being retried. This is a tradeoff we are willing to make to at this time as it is much better than a manual cleanup after failure and we are hopeful Infra will be able to add a Cron-like job to keep the lambda from fully deprovisioning into the `inactive` state soon so this should be a temporary workaround but still worth having in our codebase.
* We should ensure the Lambda is not `inactive` manually before running our jobs for a while until we better understand how long passes before it becomes `inactive` and how long it takes to become active again. This code is more of a safety net for when we forget.

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
