### PR TITLE
Rails 7.1 framework defaults

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   NewCops: enable
   StyleGuideBaseURL: https://rubystyle.guide
   Exclude:

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -92,10 +92,10 @@ class Transfer < ApplicationRecord
 
   # This ensures that the activestorage objects are actually available before we update the initial files counts.
   # The files are not available until the after_create_commit callback so our before_save callback does not work
-  # for initial Transfer creation. This does mean we calculate the counts twice on creation (once with the count as
-  # always zero, then the initial commit, then during the after_create_commit we re-save which counts them properly).
+  # for initial Transfer creation. We use `update_columns` here to avoid triggering another before_save callback
+  # for updating the files_count and unassigned_files_count.
   def initial_files_count
-    save
+    update_columns(unassigned_files_count: files.count)
   end
 
   # This is triggered on before_save, but we must also remember to call Transfer#save to trigger this

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module Thing
     config.flipflop.raise_strategy_errors = nil
 
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
One way to see this change:

* Locally, create a new transfer with a few files
* In a rails console
  * `t = Transfer.last`
  * `t.files_count`
  * `t.unassigned_files_count`

If everything is working as expected, both file counts should match the number of files you attached in the UI. 

To see that this was fixed, revert line 98 in `app/models/transfer.rb` to `save`, restart your server and console and run the same test. You should get 0 `unassigned_files_count` which is incorrect.

https://mitlibraries.atlassian.net/browse/ETD-66


#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
