### PR TITLE
Improve publication logging

### DIFF
--- a/app/jobs/dspace_publication_results_job.rb
+++ b/app/jobs/dspace_publication_results_job.rb
@@ -4,6 +4,8 @@ class DspacePublicationResultsJob < ActiveJob::Base
   MAX_MESSAGES = ENV.fetch('SQS_RESULT_MAX_MESSAGES', 10)
   WAIT_TIME_SECONDS = ENV.fetch('SQS_RESULT_WAIT_TIME_SECONDS', 10)
   IDLE_TIMEOUT = ENV.fetch('SQS_RESULT_IDLE_TIMEOUT', 0)
+  MAX_ERROR_FIELD_LENGTH = 500
+  MAX_TRACEBACK_LENGTH = 1000
 
   queue_as :default
 
@@ -124,7 +126,7 @@ class DspacePublicationResultsJob < ActiveJob::Base
     when 'success'
       update_handle(thesis, body, results)
     when 'error'
-      error = body['DSpaceResponse']
+      error = format_dss_error(body)
       thesis.publication_status = 'Publication error'
       thesis.save
       Rails.logger.info("Thesis #{thesis.id} updated to status #{thesis.publication_status}. Error from DSS: #{error}")
@@ -136,6 +138,42 @@ class DspacePublicationResultsJob < ActiveJob::Base
       Rails.logger.info("Unknown status #{status}; Cannot continue")
       results[:errors] << "Unknown status #{status}; cannot continue (thesis #{thesis.id})"
     end
+  end
+
+  def format_dss_error(body)
+    details = []
+    details << format_error_detail('ErrorInfo', body['ErrorInfo']) if body['ErrorInfo'].present?
+    details << format_error_detail('DSpaceResponse', body['DSpaceResponse']) if body['DSpaceResponse'].present?
+    details << format_error_detail('ExceptionMessage', body['ExceptionMessage']) if body['ExceptionMessage'].present?
+
+    traceback = format_traceback(body['ExceptionTraceback'])
+    details << format_error_detail('ExceptionTraceback', traceback, max_length: MAX_TRACEBACK_LENGTH) if traceback.present?
+
+    return 'No error details provided by DSS' if details.empty?
+
+    details.join(' | ')
+  end
+
+  def format_error_detail(label, value, max_length: MAX_ERROR_FIELD_LENGTH)
+    normalized = value.to_s.gsub(/\s+/, ' ').strip
+    if normalized.length > max_length
+      normalized = "#{normalized[0...max_length]}...(truncated)"
+    end
+
+    "#{label}: #{normalized}"
+  end
+
+  def format_traceback(traceback)
+    lines = if traceback.is_a?(Array)
+              traceback
+            elsif traceback.is_a?(String)
+              traceback.split(/\r?\n/)
+            else
+              []
+            end
+
+    lines = lines.map { |line| line.to_s.strip }
+    lines.reject(&:blank?).first(5).join(' || ')
   end
 
   def poll_messages(queue_url, results)

--- a/test/jobs/dspace_publication_results_job_test.rb
+++ b/test/jobs/dspace_publication_results_job_test.rb
@@ -179,6 +179,34 @@ class DspacePublicationResultsJobTest < ActiveJob::TestCase
                                       'validate checksums as no local files were attached to the record. This ' \
                                       'requires staff to manually check the ETD record and DSpace record and take ' \
                                       'appropriate action.'
+
+  end
+
+  test 'DSS error fields are surfaced in results errors' do
+    Aws.config[:sqs] = {
+      stub_responses: {
+        receive_message: [
+          {
+            messages: [
+              { message_id: 'id1', receipt_handle: 'handle1',
+                body: '{"ResultType": "error", "ErrorInfo": "Stuff broke", "DSpaceResponse": "N/A", "ExceptionMessage": "500 Server Error: Internal Server Error", "ExceptionTraceback": "Traceback (most recent call last):\nFile submission.py, line 84, in submit\nrequests.exceptions.HTTPError: 500 Server Error"}',
+                message_attributes: { 'PackageID' => { string_value: "etd_#{@bad_thesis.id}", data_type: 'String' },
+                                      'SubmissionSource' => { string_value: 'ETD', data_type: 'String' } } }
+            ]
+          },
+          { messages: [] }
+        ]
+      }
+    }
+
+    results = DspacePublicationResultsJob.perform_now
+
+    dss_error = results[:errors].find { |e| e.include?('ErrorInfo:') }
+    assert_not_nil dss_error, 'Expected DSS error details to be surfaced in results[:errors]'
+    assert_includes dss_error, 'ErrorInfo: Stuff broke'
+    assert_includes dss_error, 'DSpaceResponse: N/A'
+    assert_includes dss_error, 'ExceptionMessage: 500 Server Error: Internal Server Error'
+    assert_includes dss_error, 'ExceptionTraceback: Traceback (most recent call last):'
   end
 
   test 'enqueues preservation submission prep job' do


### PR DESCRIPTION
#### Why these changes are being introduced:

Our current logging doesn't capture much
information. (It usually just says 'N/A'.) While
DSpace errors are not useful, we should still
probably try to capture what's there.

#### Relevant ticket(s):

N/A

#### How this addresses that need:

That adds some Copilot-suggested changes to
enhance our logging in the DSpace publication
results job.

#### Side effects of this change:

None.

#### Developer

- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Requires database migrations?

NO

#### Includes new or updated dependencies?

NO
